### PR TITLE
[CARBONDATA-31] To unify definition for SparkContext,CarbonContext,HiveContext,SQLContext

### DIFF
--- a/examples/src/main/scala/org/carbondata/examples/GenerateDictionaryExample.scala
+++ b/examples/src/main/scala/org/carbondata/examples/GenerateDictionaryExample.scala
@@ -57,13 +57,13 @@ object GenerateDictionaryExample {
     printDictionary(cc, tableIdentifier, dictFolderPath)
   }
 
-  def printDictionary(carbonContext: CarbonContext, carbonTableIdentifier: CarbonTableIdentifier,
+  def printDictionary(cc: CarbonContext, carbonTableIdentifier: CarbonTableIdentifier,
                       dictFolderPath: String) {
     val dataBaseName = carbonTableIdentifier.getDatabaseName
     val tableName = carbonTableIdentifier.getTableName
-    val carbonRelation = CarbonEnv.getInstance(carbonContext).carbonCatalog.
+    val carbonRelation = CarbonEnv.getInstance(cc).carbonCatalog.
       lookupRelation1(Option(dataBaseName),
-        tableName) (carbonContext).asInstanceOf[CarbonRelation]
+        tableName) (cc).asInstanceOf[CarbonRelation]
     val carbonTable = carbonRelation.cubeMeta.carbonTable
     val dimensions = carbonTable.getDimensionByTableName(tableName.toLowerCase())
       .toArray.map(_.asInstanceOf[CarbonDimension])
@@ -77,7 +77,7 @@ object GenerateDictionaryExample {
       println(s"Key\t\t\tValue")
       val columnIdentifier = new DictionaryColumnUniqueIdentifier(carbonTableIdentifier,
         dimension.getColumnIdentifier, dimension.getDataType)
-      val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, carbonContext.storePath)
+      val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, cc.storePath)
       var index: Int = 1
       var distinctValue = dict.getDictionaryValueForKey(index)
       while (distinctValue != null) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.hive.{CarbonMetastoreCatalog, HiveContext}
 /**
  * Carbon Environment for unified context
  */
-case class CarbonEnv(carbonContext: HiveContext, carbonCatalog: CarbonMetastoreCatalog)
+case class CarbonEnv(hiveContext: HiveContext, carbonCatalog: CarbonMetastoreCatalog)
 
 object CarbonEnv {
   val className = classOf[CarbonEnv].getCanonicalName

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -101,7 +101,8 @@ case class DictionaryMap(dictionaryMap: Map[String, Boolean]) {
   }
 }
 
-class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String, client: ClientInterface)
+class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
+    client: ClientInterface)
   extends HiveMetastoreCatalog(client, hiveContext)
     with spark.Logging {
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -101,8 +101,8 @@ case class DictionaryMap(dictionaryMap: Map[String, Boolean]) {
   }
 }
 
-class CarbonMetastoreCatalog(hive: HiveContext, val storePath: String, client: ClientInterface)
-  extends HiveMetastoreCatalog(client, hive)
+class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String, client: ClientInterface)
+  extends HiveMetastoreCatalog(client, hiveContext)
     with spark.Logging {
 
   @transient val LOGGER = LogServiceFactory
@@ -159,7 +159,7 @@ class CarbonMetastoreCatalog(hive: HiveContext, val storePath: String, client: C
     if (CarbonProperties.getInstance()
       .getProperty(CarbonCommonConstants.LOCK_TYPE, CarbonCommonConstants.LOCK_TYPE_DEFAULT)
       .equalsIgnoreCase(CarbonCommonConstants.CARBON_LOCK_TYPE_ZOOKEEPER)) {
-      val zookeeperUrl = hive.getConf("spark.deploy.zookeeper.url", "127.0.0.1:2181")
+      val zookeeperUrl = hiveContext.getConf("spark.deploy.zookeeper.url", "127.0.0.1:2181")
       ZookeeperInit.getInstance(zookeeperUrl)
     }
 
@@ -344,7 +344,7 @@ class CarbonMetastoreCatalog(hive: HiveContext, val storePath: String, client: C
   def getNodeList: Array[String] = {
 
     val arr =
-      hive.sparkContext.getExecutorMemoryStatus.map {
+      hiveContext.sparkContext.getExecutorMemoryStatus.map {
         kv =>
           kv._1.split(":")(0)
       }.toSeq
@@ -352,7 +352,7 @@ class CarbonMetastoreCatalog(hive: HiveContext, val storePath: String, client: C
     val selectedLocalIPList = localhostIPs.filter(arr.contains(_))
 
     val nodelist: List[String] = withoutDriverIP(arr.toList)(selectedLocalIPList.contains(_))
-    val masterMode = hive.sparkContext.getConf.get("spark.master")
+    val masterMode = hiveContext.sparkContext.getConf.get("spark.master")
     if (nodelist.nonEmpty) {
       // Specific for Yarn Mode
       if ("yarn-cluster".equals(masterMode) || "yarn-client".equals(masterMode)) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSQLDialect.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSQLDialect.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 import org.carbondata.spark.exception.MalformedCarbonCommandException
 
-private[spark] class CarbonSQLDialect(context: HiveContext) extends ParserDialect {
+private[spark] class CarbonSQLDialect(hiveContext: HiveContext) extends ParserDialect {
 
   @transient
   protected val sqlParser = new CarbonSqlParser

--- a/integration/spark/src/main/scala/org/carbondata/spark/csv/CarbonTextFile.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/csv/CarbonTextFile.scala
@@ -50,13 +50,13 @@ private[csv] object CarbonTextFile {
       hadoopConfiguration).setName("newHadoopRDD-spark-csv")
   }
 
-  def withCharset(cc: SparkContext, location: String, charset: String): RDD[String] = {
+  def withCharset(sc: SparkContext, location: String, charset: String): RDD[String] = {
     if (Charset.forName(charset) == TextFile.DEFAULT_CHARSET) {
-      newHadoopRDD(cc, location).map(pair => pair._2.toString)
+      newHadoopRDD(sc, location).map(pair => pair._2.toString)
     } else {
       // can't pass a Charset object here cause its not serializable
       // TODO: maybe use mapPartitions instead?
-      newHadoopRDD(cc, location).map(
+      newHadoopRDD(sc, location).map(
         pair => new String(pair._2.getBytes, 0, pair._2.getLength, charset))
     }
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/csv/CarbonTextFile.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/csv/CarbonTextFile.scala
@@ -37,26 +37,26 @@ import org.carbondata.spark.rdd.CarbonDataRDDFactory
  */
 private[csv] object CarbonTextFile {
 
-  private def newHadoopRDD(context: SparkContext, location: String) = {
-    val hadoopConfiguration = new Configuration(context.hadoopConfiguration)
+  private def newHadoopRDD(sc: SparkContext, location: String) = {
+    val hadoopConfiguration = new Configuration(sc.hadoopConfiguration)
     hadoopConfiguration.setStrings(FileInputFormat.INPUT_DIR, location)
     hadoopConfiguration.setBoolean(FileInputFormat.INPUT_DIR_RECURSIVE, true)
-    CarbonDataRDDFactory.configSplitMaxSize(context, location, hadoopConfiguration)
+    CarbonDataRDDFactory.configSplitMaxSize(sc, location, hadoopConfiguration)
     new NewHadoopRDD[LongWritable, Text](
-      context,
+      sc,
       classOf[TextInputFormat],
       classOf[LongWritable],
       classOf[Text],
       hadoopConfiguration).setName("newHadoopRDD-spark-csv")
   }
 
-  def withCharset(context: SparkContext, location: String, charset: String): RDD[String] = {
+  def withCharset(cc: SparkContext, location: String, charset: String): RDD[String] = {
     if (Charset.forName(charset) == TextFile.DEFAULT_CHARSET) {
-      newHadoopRDD(context, location).map(pair => pair._2.toString)
+      newHadoopRDD(cc, location).map(pair => pair._2.toString)
     } else {
       // can't pass a Charset object here cause its not serializable
       // TODO: maybe use mapPartitions instead?
-      newHadoopRDD(context, location).map(
+      newHadoopRDD(cc, location).map(
         pair => new String(pair._2.getBytes, 0, pair._2.getLength, charset))
     }
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataFrameRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataFrameRDD.scala
@@ -20,8 +20,8 @@ package org.carbondata.spark.rdd
 import org.apache.spark.sql.{CarbonContext, DataFrame, Row}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
-class CarbonDataFrameRDD(val sc: CarbonContext, logicalPlan: LogicalPlan)
-  extends DataFrame(sc, logicalPlan) {
+class CarbonDataFrameRDD(val cc: CarbonContext, logicalPlan: LogicalPlan)
+  extends DataFrame(cc, logicalPlan) {
 
   override def collect(): Array[Row] = {
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/Compactor.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/Compactor.scala
@@ -48,7 +48,7 @@ object Compactor {
     kettleHomePath: String,
     cubeCreationTime: Long,
     loadsToMerge: java.util.List[LoadMetadataDetails],
-    sc: SQLContext): Unit = {
+    sqlContext: SQLContext): Unit = {
 
     val startTime = System.nanoTime();
     val mergedLoadName = CarbonDataMergerUtil.getMergedLoadName(loadsToMerge)
@@ -85,7 +85,7 @@ object Compactor {
     )
 
     val mergeStatus = new CarbonMergerRDD(
-      sc.sparkContext,
+      sqlContext.sparkContext,
       new MergeResultImpl(),
       carbonLoadModel,
       carbonMergerMapping

--- a/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -47,9 +47,9 @@ object CarbonThriftServer {
         Thread.sleep(30000)
     }
 
-    val carbonContext = new CarbonContext(sc, args.head)
+    val cc = new CarbonContext(sc, args.head)
 
-    HiveThriftServer2.startWithContext(carbonContext)
+    HiveThriftServer2.startWithContext(cc)
   }
 
 }

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeDirectDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeDirectDictionaryTestCase.scala
@@ -40,7 +40,7 @@ import org.scalatest.BeforeAndAfterAll
   *
   */
 class TimestampDataTypeDirectDictionaryTest extends QueryTest with BeforeAndAfterAll {
-  var oc: HiveContext = _
+  var hiveContext: HiveContext = _
 
   override def beforeAll {
     try {

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeDirectDictionaryWithNoDictTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeDirectDictionaryWithNoDictTestCase.scala
@@ -39,7 +39,7 @@ import org.carbondata.core.util.CarbonProperties
   *
   */
 class TimestampDataTypeDirectDictionaryWithNoDictTestCase extends QueryTest with BeforeAndAfterAll {
-  var oc: HiveContext = _
+  var hiveContext: HiveContext = _
 
   override def beforeAll {
     try {

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeNullDataTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeNullDataTest.scala
@@ -38,7 +38,7 @@ import org.scalatest.BeforeAndAfterAll
   *
   */
 class TimestampDataTypeNullDataTest extends QueryTest with BeforeAndAfterAll {
-  var oc: HiveContext = _
+  var hiveContext: HiveContext = _
 
   override def beforeAll {
     try {


### PR DESCRIPTION
For SparkContext,CarbonContext,HiveContext,SQLContext definition, different places having different definition, for example:
1)val sc = new CaronContext, val carboncontext = new CaronContext
2)var oc: HiveContext , var context: HiveContext
....
To unify definition for SparkContext,CarbonContext,HiveContext,SQLContext as below:
CarbonContext : cc
SQLContext : sqlContext
SparkContext : sc
HiveContext : hiveContext