### PR TITLE
[CARBONDATA-34] Fixed failing of drop table with db name

### DIFF
--- a/core/src/main/java/org/carbondata/core/carbon/path/CarbonTablePath.java
+++ b/core/src/main/java/org/carbondata/core/carbon/path/CarbonTablePath.java
@@ -306,7 +306,7 @@ public class CarbonTablePath extends Path {
      */
     public static String getUpdateTimeStamp(String carbonDataFileName) {
       // Get the file name from path
-      String fileName = new File(carbonDataFileName).getName();
+      String fileName = getFileName(carbonDataFileName);
       // + 1 for size of "-"
       int firstDashPos = fileName.indexOf("-");
       int secondDashPos = fileName.indexOf("-", firstDashPos + 1);
@@ -320,7 +320,7 @@ public class CarbonTablePath extends Path {
      */
     public static String getPartNo(String carbonDataFileName) {
       // Get the file name from path
-      String fileName = new File(carbonDataFileName).getName();
+      String fileName = getFileName(carbonDataFileName);
       // + 1 for size of "-"
       int startIndex = fileName.indexOf("-") + 1;
       int endIndex = fileName.indexOf("-", startIndex);
@@ -332,12 +332,24 @@ public class CarbonTablePath extends Path {
      */
     public static String getTaskNo(String carbonDataFileName) {
       // Get the file name from path
-      String fileName = new File(carbonDataFileName).getName();
+      String fileName = getFileName(carbonDataFileName);
       // + 1 for size of "-"
       int firstDashPos = fileName.indexOf("-");
       int startIndex = fileName.indexOf("-", firstDashPos + 1) + 1;
       int endIndex = fileName.indexOf("-", startIndex);
       return fileName.substring(startIndex, endIndex);
+    }
+
+    /**
+     * Gets the file name from file path
+     */
+    private static String getFileName(String carbonDataFileName) {
+      int endIndex = carbonDataFileName.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR);
+      if (endIndex > -1) {
+        return carbonDataFileName.substring(endIndex + 1, carbonDataFileName.length());
+      } else {
+        return carbonDataFileName;
+      }
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -498,6 +498,12 @@ class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
       }
     }
 
+    metadata.cubesMeta -= metadata.cubesMeta.filter(
+      c => c.carbonTableIdentifier.getDatabaseName.equalsIgnoreCase(dbName) &&
+           c.carbonTableIdentifier.getTableName.equalsIgnoreCase(tableName))(0)
+    org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
+      .removeTable(dbName + "_" + tableName)
+
     try {
       sqlContext.sql(s"DROP TABLE $dbName.$tableName").collect()
     } catch {
@@ -505,12 +511,6 @@ class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
         LOGGER.audit(
           s"Error While deleting the table $dbName.$tableName during drop Table" + e.getMessage)
     }
-
-    metadata.cubesMeta -= metadata.cubesMeta.filter(
-      c => c.carbonTableIdentifier.getDatabaseName.equalsIgnoreCase(dbName) &&
-           c.carbonTableIdentifier.getTableName.equalsIgnoreCase(tableName))(0)
-    org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
-      .removeTable(dbName + "_" + tableName)
     logInfo(s"Table $tableName of $dbName Database dropped syccessfully.")
     LOGGER.info("Table " + tableName + " of " + dbName + " Database dropped syccessfully.")
 

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -22,36 +22,36 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
 
   }
 
-  // normal deletion case
-  test("drop table Test with new DDL") {
-    sql("drop table table1")
-
-  }
-
-  // deletion case with if exists
-  test("drop table if exists Test with new DDL") {
-    sql("drop table if exists table2")
-
-  }
-
-  // try to delete after deletion with if exists
-  test("drop table after deletion with if exists with new DDL") {
-    sql("drop table if exists table2")
-
-  }
-
-  // try to delete after deletion with out if exists. this should fail
-  test("drop table after deletion with new DDL") {
-    try {
-      sql("drop table table2")
-      fail("failed") // this should not be executed as exception is expected
-    }
-    catch {
-      case e: Exception => // pass the test case as this is expected
-    }
-
-
-  }
+//  // normal deletion case
+//  test("drop table Test with new DDL") {
+//    sql("drop table table1")
+//
+//  }
+//
+//  // deletion case with if exists
+//  test("drop table if exists Test with new DDL") {
+//    sql("drop table if exists table2")
+//
+//  }
+//
+//  // try to delete after deletion with if exists
+//  test("drop table after deletion with if exists with new DDL") {
+//    sql("drop table if exists table2")
+//
+//  }
+//
+//  // try to delete after deletion with out if exists. this should fail
+//  test("drop table after deletion with new DDL") {
+//    try {
+//      sql("drop table table2")
+//      fail("failed") // this should not be executed as exception is expected
+//    }
+//    catch {
+//      case e: Exception => // pass the test case as this is expected
+//    }
+//
+//
+//  }
 
   test("drop table using case insensitive table name") {
     // create table

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -22,36 +22,36 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
 
   }
 
-//  // normal deletion case
-//  test("drop table Test with new DDL") {
-//    sql("drop table table1")
-//
-//  }
-//
-//  // deletion case with if exists
-//  test("drop table if exists Test with new DDL") {
-//    sql("drop table if exists table2")
-//
-//  }
-//
-//  // try to delete after deletion with if exists
-//  test("drop table after deletion with if exists with new DDL") {
-//    sql("drop table if exists table2")
-//
-//  }
-//
-//  // try to delete after deletion with out if exists. this should fail
-//  test("drop table after deletion with new DDL") {
-//    try {
-//      sql("drop table table2")
-//      fail("failed") // this should not be executed as exception is expected
-//    }
-//    catch {
-//      case e: Exception => // pass the test case as this is expected
-//    }
-//
-//
-//  }
+  // normal deletion case
+  test("drop table Test with new DDL") {
+    sql("drop table table1")
+
+  }
+
+  // deletion case with if exists
+  test("drop table if exists Test with new DDL") {
+    sql("drop table if exists table2")
+
+  }
+
+  // try to delete after deletion with if exists
+  test("drop table after deletion with if exists with new DDL") {
+    sql("drop table if exists table2")
+
+  }
+
+  // try to delete after deletion with out if exists. this should fail
+  test("drop table after deletion with new DDL") {
+    try {
+      sql("drop table table2")
+      fail("failed") // this should not be executed as exception is expected
+    }
+    catch {
+      case e: Exception => // pass the test case as this is expected
+    }
+
+
+  }
 
   test("drop table using case insensitive table name") {
     // create table

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -74,6 +74,19 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
 
   }
 
+  test("drop table using dbName and table name") {
+    // create table
+    sql(
+      "CREATE table default.table3 (ID int, date String, country String, name " +
+      "String," +
+      "phonetype String, serialname String, salary int) stored by 'org.apache.carbondata.format'" +
+      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID', 'DICTIONARY_INCLUDE'='salary')"
+    )
+    // table should drop wihout any error
+    sql("drop table default.table3")
+
+  }
+
 
   override def afterAll: Unit = {
 


### PR DESCRIPTION
Table drop fails when drop table with dbname like
`DROP TABLE default.tablename` 
This PR fixes it.
And also it fixes the CARBONDATA-33 issue when store path is hdfs.