### PR TITLE
[CARBONDATA-36]fix dictionary exception when data column count less then schema

### DIFF
--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -67,7 +67,9 @@ case class PrimitiveParser(dimension: CarbonDimension,
 
   def parseString(input: String): Unit = {
     if (hasDictEncoding) {
-      set.add(input)
+      if (StringUtils.isNotEmpty(input)) {
+        set.add(input)
+      }
     }
   }
 }

--- a/integration/spark/src/test/resources/lessthandatacolumndata.csv
+++ b/integration/spark/src/test/resources/lessthandatacolumndata.csv
@@ -1,0 +1,11 @@
+ID,date,country,name,phonetype,serialname,salary
+1,2015/7/23,china,aaa1,phone197,ASD69643,15000
+2,2015/7/24,china,aaa2,phone756,ASD42892,15001
+3,2015/7/25,china
+4,2015/7/26,china,aaa4,phone2435,ASD66902,15003
+5,2015/7/27,china,aaa5,phone2441,ASD90633,15004
+6,2015/7/28,china,aaa6,phone294,ASD59961,15005
+7,2015/7/29,china,aaa7,phone610,
+8,2015/7/30,china,aaa8,phone1848,ASD57308,15007
+9,2015/7/18,china,aaa9,phone706,ASD86717,15008
+10,2015/7/19,usa,aaa10,phone685,ASD30505,15009

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestDataWithDicExcludeAndInclude.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestDataWithDicExcludeAndInclude.scala
@@ -39,6 +39,10 @@ class TestLoadDataWithDictionaryExcludeAndInclude extends QueryTest with BeforeA
     filePath = pwd + "/src/test/resources/emptyDimensionData.csv"
   }
 
+  def dropTable() = {
+    sql("DROP TABLE IF EXISTS t3")
+  }
+
   def buildTable() = {
     try {
       sql(
@@ -69,12 +73,14 @@ class TestLoadDataWithDictionaryExcludeAndInclude extends QueryTest with BeforeA
   }
 
   override def beforeAll {
+    dropTable
     buildTestData
     buildTable
     loadTable
   }
 
   test("test load data with dictionary exclude & include and with empty dimension") {
+    sql("select ID from t3").show()
     checkAnswer(
       sql("select ID from t3"), Seq(Row(1), Row(2), Row(3), Row(4), Row(5), Row(6), Row(7),
         Row(8), Row(9), Row(10), Row(11), Row(12), Row(13), Row(14), Row(15), Row(16), Row
@@ -83,7 +89,7 @@ class TestLoadDataWithDictionaryExcludeAndInclude extends QueryTest with BeforeA
   }
 
   override def afterAll {
-    sql("drop table t3")
+    dropTable
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
   }

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithHiveSyntax.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithHiveSyntax.scala
@@ -293,6 +293,27 @@ class TestLoadDataWithHiveSyntax extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS t3")
   }
 
+  test("test data which contain column less than schema"){
+    sql("DROP TABLE IF EXISTS t3")
+
+    sql(
+      """
+           CREATE TABLE IF NOT EXISTS t3
+           (ID Int, date Timestamp, country String,
+           name String, phonetype String, serialname String, salary Int)
+           STORED BY 'org.apache.carbondata.format'
+
+      """)
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+    sql(s"""
+         LOAD DATA LOCAL INPATH './src/test/resources/lessthandatacolumndata.csv' into table t3
+        """)
+    sql("select * from t3").show()
+    checkAnswer(sql("select count(*) from t3"),Seq(Row(10)))
+  }
+
   override def afterAll {
     sql("drop table carbontable")
     sql("drop table hivetable")

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithHiveSyntax.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithHiveSyntax.scala
@@ -310,7 +310,6 @@ class TestLoadDataWithHiveSyntax extends QueryTest with BeforeAndAfterAll {
     sql(s"""
          LOAD DATA LOCAL INPATH './src/test/resources/lessthandatacolumndata.csv' into table t3
         """)
-    sql("select * from t3").show()
     checkAnswer(sql("select count(*) from t3"),Seq(Row(10)))
   }
 


### PR DESCRIPTION
when csv head is id,name,age,city
if the data record like as the following:
1,a,10,china
2,b
3,c,11,usa
then,when read this row:2,b,generating dicionary will failure,and the remain record (3,c,11,usa)will no generate dictionary.

this pr to prevent put null value to Set,and let it continue.
@ravipesala can u please help to check this pr?
thank u.