### PR TITLE
[CARBONDATA-43][BUG]Handle for decimal filter query "where dicimalFiled=123456.12"

### DIFF
--- a/core/src/main/java/org/carbondata/scan/expression/ExpressionResult.java
+++ b/core/src/main/java/org/carbondata/scan/expression/ExpressionResult.java
@@ -259,7 +259,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
         case LONG:
           return new BigDecimal((long) value);
         case DOUBLE:
-          return new BigDecimal((double) value);
+          return new BigDecimal(value.toString());
         case DECIMAL:
           return new BigDecimal(value.toString());
         case TIMESTAMP:

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
@@ -92,6 +92,24 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
       sql("select count(distinct salary) from hiveTable"))
   }
 
+  test("test filter query on big decimal column") {
+    // equal to
+    checkAnswer(sql("select salary from carbonTable where salary=45234525465882.24"),
+      sql("select salary from hiveTable where salary=45234525465882.24"))
+    // greater than
+    checkAnswer(sql("select salary from carbonTable where salary>15000"),
+      sql("select salary from hiveTable where salary>15000"))
+    // greater than equal to
+    checkAnswer(sql("select salary from carbonTable where salary>=15000.43525"),
+      sql("select salary from hiveTable where salary>=15000.43525"))
+    // less than
+    checkAnswer(sql("select salary from carbonTable where salary<45234525465882"),
+      sql("select salary from hiveTable where salary<45234525465882"))
+    // less than equal to
+    checkAnswer(sql("select salary from carbonTable where salary<=45234525465882.24"),
+      sql("select salary from hiveTable where salary<=45234525465882.24"))
+  }
+
   override def afterAll {
     sql("drop table if exists carbonTable")
     sql("drop table if exists hiveTable")


### PR DESCRIPTION
when query with "select ... from table where decimalFiled=123456.12", the query result is empty, while 123456.12 is in the csv data. and in hive, we can get the correct result.

this is because the code handles double value as new Bigdecimal(double), this is not accurate.