### PR TITLE
[CARBONDATA-50]Added Spark 1.6.2 support in Carbon. And also supports all versions of Spark 1.5 and 1.6

### DIFF
--- a/examples/src/main/scala/org/carbondata/examples/CarbonExample.scala
+++ b/examples/src/main/scala/org/carbondata/examples/CarbonExample.scala
@@ -44,11 +44,10 @@ object CarbonExample {
            """)
 
     cc.sql("""
-             SELECT country,name,salary,ROW_NUMBER() OVER
-             (PARTITION BY country ORDER BY salary DESC) as rank FROM t3
-           """).show()
-    cc.sql("""
-             SELECT ID, country, salary, SUM(salary) OVER (PARTITION BY country ) AS TopBorcT FROM t3 ORDER BY country
+           SELECT country, count(salary) AS amount
+           FROM t3
+           WHERE country IN ('china','france')
+           GROUP BY country
            """).show()
 
     cc.sql("DROP TABLE IF EXISTS t3")

--- a/examples/src/main/scala/org/carbondata/examples/CarbonExample.scala
+++ b/examples/src/main/scala/org/carbondata/examples/CarbonExample.scala
@@ -44,10 +44,11 @@ object CarbonExample {
            """)
 
     cc.sql("""
-           SELECT country, count(salary) AS amount
-           FROM t3
-           WHERE country IN ('china','france')
-           GROUP BY country
+             SELECT country,name,salary,ROW_NUMBER() OVER
+             (PARTITION BY country ORDER BY salary DESC) as rank FROM t3
+           """).show()
+    cc.sql("""
+             SELECT ID, country, salary, SUM(salary) OVER (PARTITION BY country ) AS TopBorcT FROM t3 ORDER BY country
            """).show()
 
     cc.sql("DROP TABLE IF EXISTS t3")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -93,17 +93,3 @@ abstract class CarbonProfile(attributes: Seq[Attribute]) extends Serializable {
 case class IncludeProfile(attributes: Seq[Attribute]) extends CarbonProfile(attributes)
 
 case class ExcludeProfile(attributes: Seq[Attribute]) extends CarbonProfile(attributes)
-
-case class FakeCarbonCast(child: Literal, dataType: DataType)
-  extends LeafExpression with CodegenFallback {
-
-  override def toString: String = s"FakeCarbonCast($child as ${ dataType.simpleString })"
-
-  override def checkInputDataTypes(): TypeCheckResult = {
-    TypeCheckResult.TypeCheckSuccess
-  }
-
-  override def nullable: Boolean = child.nullable
-
-  override def eval(input: InternalRow): Any = child.value
-}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -74,7 +74,7 @@ class CarbonContext(
   @transient
   override protected[sql] lazy val optimizer: Optimizer =
     CarbonOptimizer.optimizer(
-      CarbonContext.createDefaultOptimizer(conf, sc),
+      CodeGenerateFactory.getInstance(sc.version).createDefaultOptimizer(conf, sc),
       conf.asInstanceOf[CarbonSQLConf],
       sc.version)
 
@@ -197,17 +197,4 @@ object CarbonContext {
     cache(sc) = cc
   }
 
-  def createDefaultOptimizer(conf: CatalystConf, sc: SparkContext): Optimizer = {
-    val name = "org.apache.spark.sql.catalyst.optimizer.DefaultOptimizer"
-    val loader = Utils.getContextOrSparkClassLoader
-    try {
-      val cons = loader.loadClass(name + "$").getDeclaredConstructors
-      cons.head.setAccessible(true)
-      cons.head.newInstance().asInstanceOf[Optimizer]
-    } catch {
-      case e: Exception =>
-        loader.loadClass(name).getConstructor(classOf[CatalystConf])
-          .newInstance(conf).asInstanceOf[Optimizer]
-    }
-  }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -55,6 +55,7 @@ class CarbonContext(
   }
 
   CarbonContext.addInstance(sc, this)
+  CodeGenerateFactory.init(sc.version)
 
   var lastSchemaUpdatedTime = System.currentTimeMillis()
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -74,7 +74,7 @@ class CarbonContext(
   @transient
   override protected[sql] lazy val optimizer: Optimizer =
     CarbonOptimizer.optimizer(
-      CodeGenerateFactory.getInstance(sc.version).createDefaultOptimizer(conf, sc),
+      CodeGenerateFactory.createDefaultOptimizer(conf, sc),
       conf.asInstanceOf[CarbonSQLConf],
       sc.version)
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CodeGenerateFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CodeGenerateFactory.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.optimizer.Optimizer
+import org.apache.spark.sql.catalyst.plans.logical.{Expand, LogicalPlan}
+import org.apache.spark.util.{ScalaCompilerUtil, Utils}
+
+class CodeGenerateFactory(version: String) {
+
+  val optimizerFactory = if (version.equals("1.6.2")) {
+    ScalaCompilerUtil.compiledCode(CodeTemplates.spark1_6_2_OptimizerString)
+      .asInstanceOf[AbstractCarbonOptimizerFactory]
+  } else {
+    ScalaCompilerUtil.compiledCode(CodeTemplates.defaultOptimizerString)
+      .asInstanceOf[AbstractCarbonOptimizerFactory]
+  }
+
+  val expandFactory = if (version.startsWith("1.5")) {
+    ScalaCompilerUtil.compiledCode(CodeTemplates.spark1_5ExpandString)
+      .asInstanceOf[AbstractCarbonExpandFactory]
+  } else {
+    new AbstractCarbonExpandFactory {
+      override def createExpand(expand: Expand, child: LogicalPlan): Expand = {
+        val loader = Utils.getContextOrSparkClassLoader
+        try {
+          val cons = loader.loadClass("org.apache.spark.sql.catalyst.plans.logical.Expand")
+            .getDeclaredConstructors
+          cons.head.setAccessible(true)
+          cons.head.newInstance(expand.projections, expand.output, child).asInstanceOf[Expand]
+        } catch {
+          case e: Exception => null
+        }
+      }
+    }
+  }
+
+}
+
+object CodeGenerateFactory {
+
+  private var codeGenerateFactory: CodeGenerateFactory = _
+
+  def init(version: String): Unit = {
+    if (codeGenerateFactory == null) {
+      codeGenerateFactory = new CodeGenerateFactory(version)
+    }
+  }
+
+  def getInstance(): CodeGenerateFactory = {
+    codeGenerateFactory
+  }
+
+}
+
+object CodeTemplates {
+
+  val spark1_6_2_OptimizerString =
+    s"""
+       import org.apache.spark.sql._;
+       import org.apache.spark.sql.optimizer._;
+       import org.apache.spark.sql.catalyst.plans.logical._;
+       import org.apache.spark.sql.catalyst._;
+       import org.apache.spark.sql.catalyst.optimizer.Optimizer;
+
+       new AbstractCarbonOptimizerFactory {
+
+           override def createOptimizer(optimizer1: Optimizer, conf1: CarbonSQLConf): Optimizer = {
+              class CarbonOptimizer1(optimizer: Optimizer, conf: CarbonSQLConf)
+                extends Optimizer(conf) {
+                override val batches = Nil;
+                override def execute(plan: LogicalPlan): LogicalPlan = {
+                  CarbonOptimizer.execute(plan, optimizer);
+                }
+              }
+              new CarbonOptimizer1(optimizer1, conf1);
+           }
+       }
+    """
+
+  val defaultOptimizerString =
+    s"""
+       import org.apache.spark.sql._;
+       import org.apache.spark.sql.optimizer._;
+       import org.apache.spark.sql.catalyst.plans.logical._;
+       import org.apache.spark.sql.catalyst._;
+       import org.apache.spark.sql.catalyst.optimizer.Optimizer;
+
+       new AbstractCarbonOptimizerFactory {
+
+           override def createOptimizer(optimizer1: Optimizer, conf1: CarbonSQLConf): Optimizer = {
+              class CarbonOptimizer2(optimizer: Optimizer, conf: CarbonSQLConf) extends Optimizer {
+                val batches = Nil;
+                override def execute(plan: LogicalPlan): LogicalPlan = {
+                  CarbonOptimizer.execute(plan, optimizer);
+                }
+              }
+              new CarbonOptimizer2(optimizer1, conf1);
+           }
+       }
+    """
+
+  val spark1_5ExpandString =
+    s"""
+       import org.apache.spark.sql._
+       import org.apache.spark.sql.catalyst.plans.logical.{Expand, LogicalPlan}
+       new AbstractCarbonExpandFactory {
+           override def createExpand(expand: Expand, child: LogicalPlan): Expand = {
+             Expand(expand.bitmasks, expand.groupByExprs, expand.gid, child)
+           }
+       }
+    """
+}
+
+abstract class AbstractCarbonOptimizerFactory {
+  def createOptimizer(optimizer: Optimizer, conf: CarbonSQLConf) : Optimizer
+}
+
+abstract class AbstractCarbonExpandFactory {
+  def createExpand(expand: Expand, child: LogicalPlan) : Expand
+}
+

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -60,7 +60,7 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = {
       plan match {
         case PhysicalOperation(projectList, predicates, l: LogicalRelation)
-          if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
+            if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
           if (isStarQuery(plan)) {
             carbonRawScanForStarQuery(projectList, predicates, l)(sqlContext) :: Nil
           } else {
@@ -210,7 +210,8 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
     private def isStarQuery(plan: LogicalPlan) = {
       plan match {
         case LogicalFilter(condition, l: LogicalRelation)
-          if l.relation.isInstanceOf[CarbonDatasourceRelation] => true
+            if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
+          true
         case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] => true
         case _ => false
       }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -59,15 +59,12 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
 
     def apply(plan: LogicalPlan): Seq[SparkPlan] = {
       plan match {
-        case PhysicalOperation(projectList, predicates,
-        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)) =>
+        case PhysicalOperation(projectList, predicates, l: LogicalRelation)
+          if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
           if (isStarQuery(plan)) {
-            carbonRawScanForStarQuery(projectList, predicates, carbonRelation, l)(sqlContext) :: Nil
+            carbonRawScanForStarQuery(projectList, predicates, l)(sqlContext) :: Nil
           } else {
-            carbonRawScan(projectList,
-              predicates,
-              carbonRelation,
-              l)(sqlContext) :: Nil
+            carbonRawScan(projectList, predicates, l)(sqlContext) :: Nil
           }
         case CarbonDictionaryCatalystDecoder(relations, profile, aliasMap, _, child) =>
           CarbonDictionaryDecoder(relations,
@@ -84,9 +81,9 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
      */
     private def carbonRawScan(projectList: Seq[NamedExpression],
       predicates: Seq[Expression],
-      relation: CarbonDatasourceRelation,
       logicalRelation: LogicalRelation)(sc: SQLContext): SparkPlan = {
 
+      val relation = logicalRelation.relation.asInstanceOf[CarbonDatasourceRelation]
       val tableName: String =
         relation.carbonRelation.metaData.carbonTable.getFactTableName.toLowerCase
       // Check out any expressions are there in project list. if they are present then we need to
@@ -128,9 +125,8 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
      */
     private def carbonRawScanForStarQuery(projectList: Seq[NamedExpression],
       predicates: Seq[Expression],
-      relation: CarbonDatasourceRelation,
       logicalRelation: LogicalRelation)(sc: SQLContext): SparkPlan = {
-
+      val relation = logicalRelation.relation.asInstanceOf[CarbonDatasourceRelation]
       val tableName: String =
         relation.carbonRelation.metaData.carbonTable.getFactTableName.toLowerCase
       // Check out any expressions are there in project list. if they are present then we need to
@@ -213,9 +209,9 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
 
     private def isStarQuery(plan: LogicalPlan) = {
       plan match {
-        case LogicalFilter(condition,
-        LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)) => true
-        case LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) => true
+        case LogicalFilter(condition, l: LogicalRelation)
+          if l.relation.isInstanceOf[CarbonDatasourceRelation] => true
+        case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] => true
         case _ => false
       }
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -449,7 +449,7 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
   private def updateDataType(attr: Attribute,
       relations: Seq[CarbonDecoderRelation],
       allAttrsNotDecode: util.Set[Attribute],
-      aliasMap: CarbonAliasDecoderRelation) = {
+      aliasMap: CarbonAliasDecoderRelation): Attribute = {
     val uAttr = aliasMap.getOrElse(attr, attr)
     val relation = relations.find(p => p.contains(uAttr))
     if (relation.isDefined) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -55,8 +55,8 @@ object CarbonOptimizer {
   // get the carbon relation from plan.
   def collectCarbonRelation(plan: LogicalPlan): Seq[CarbonDecoderRelation] = {
     plan collect {
-      case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
-        CarbonDecoderRelation(l.attributeMap, carbonRelation)
+      case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
+        CarbonDecoderRelation(l.attributeMap, l.relation.asInstanceOf[CarbonDatasourceRelation])
     }
   }
 }
@@ -289,7 +289,7 @@ class ResolveCarbonFunctions(
             Project(p.projectList, child)
           }
 
-        case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
+        case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
           if (!decoder) {
             decoder = true
             CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
@@ -370,7 +370,7 @@ class ResolveCarbonFunctions(
           }
         }.asInstanceOf[Seq[NamedExpression]]
         Project(prExps, p.child)
-      case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
+      case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
         allAttrsNotDecode = marker.revokeJoin()
         l
       case others => others

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -65,8 +65,7 @@ object CarbonOptimizer {
  * It does two jobs. 1. Change the datatype for dictionary encoded column 2. Add the dictionary
  * decoder plan.
  */
-class ResolveCarbonFunctions(
-    relations: Seq[CarbonDecoderRelation])
+class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
   extends Rule[LogicalPlan] with PredicateHelper {
 
   def apply(plan: LogicalPlan): LogicalPlan = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -208,8 +208,8 @@ class ResolveCarbonFunctions(
           }
 
         case j: Join
-          if !(j.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
-               j.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
+            if !(j.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
+                 j.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
           val attrsOnJoin = new util.HashSet[Attribute]
           j.condition match {
             case Some(expression) =>
@@ -261,7 +261,7 @@ class ResolveCarbonFunctions(
           }
 
         case p: Project
-          if relations.nonEmpty && !p.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+            if relations.nonEmpty && !p.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
           val attrsOnProjects = new util.HashSet[Attribute]
           p.projectList.map {
             case attr: AttributeReference =>
@@ -395,7 +395,8 @@ class ResolveCarbonFunctions(
     // Remove unnecessary decoders
     val finalPlan = transFormedPlan transform {
       case CarbonDictionaryCatalystDecoder(_, profile, _, false, child)
-        if profile.isInstanceOf[IncludeProfile] && profile.isEmpty => child
+          if profile.isInstanceOf[IncludeProfile] && profile.isEmpty =>
+        child
     }
     finalPlan
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -23,432 +23,90 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.CatalystConf
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, _}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.apache.spark.util.ScalaCompilerUtil
 
 import org.carbondata.spark.CarbonFilters
+
+
+abstract class AbstractCarbonOptimizerFactory {
+  def createOptimizer(optimizer: Optimizer, conf: CarbonSQLConf) : Optimizer
+}
+
 
 /**
  * Carbon Optimizer to add dictionary decoder.
  */
-class CarbonOptimizer(optimizer: Optimizer, conf: CatalystConf)
-  extends Optimizer with PredicateHelper {
+object CarbonOptimizer {
 
-  val batches = Nil
+  val spark1_6_2_OptimizerString =
+    s"""
+       import org.apache.spark.sql._;
+       import org.apache.spark.sql.optimizer._;
+       import org.apache.spark.sql.catalyst.plans.logical._;
+       import org.apache.spark.sql.catalyst._;
+       import org.apache.spark.sql.catalyst.optimizer.Optimizer;
 
-  override def execute(plan: LogicalPlan): LogicalPlan = {
-    val executedPlan: LogicalPlan = optimizer.execute(plan)
-    val relations = collectCarbonRelation(plan)
-    if (relations.nonEmpty) {
-      new ResolveCarbonFunctions(relations)(executedPlan)
+       new AbstractCarbonOptimizerFactory {
+
+           override def createOptimizer(optimizer1: Optimizer, conf1: CarbonSQLConf): Optimizer = {
+              class CarbonOptimizer1(optimizer: Optimizer, conf: CarbonSQLConf)
+                extends Optimizer(conf) {
+                override val batches = Nil;
+                override def execute(plan: LogicalPlan): LogicalPlan = {
+                  CarbonOptimizer.execute(plan, optimizer);
+                }
+              }
+              new CarbonOptimizer1(optimizer1, conf1);
+           }
+       }
+    """
+
+  val default_OptimizerString =
+    s"""
+       import org.apache.spark.sql._;
+       import org.apache.spark.sql.optimizer._;
+       import org.apache.spark.sql.catalyst.plans.logical._;
+       import org.apache.spark.sql.catalyst._;
+       import org.apache.spark.sql.catalyst.optimizer.Optimizer;
+
+       new AbstractCarbonOptimizerFactory {
+
+           override def createOptimizer(optimizer1: Optimizer, conf1: CarbonSQLConf): Optimizer = {
+              class CarbonOptimizer2(optimizer: Optimizer, conf: CarbonSQLConf) extends Optimizer {
+                val batches = Nil;
+                override def execute(plan: LogicalPlan): LogicalPlan = {
+                  CarbonOptimizer.execute(plan, optimizer);
+                }
+              }
+              new CarbonOptimizer2(optimizer1, conf1);
+           }
+       }
+    """
+
+  def optimizer(optimizer: Optimizer, conf: CarbonSQLConf, version: String): Optimizer = {
+    if (version.equals("1.6.2")) {
+      ScalaCompilerUtil.compiledCode(spark1_6_2_OptimizerString)
+        .asInstanceOf[AbstractCarbonOptimizerFactory].createOptimizer(optimizer, conf)
     } else {
-      executedPlan
+      ScalaCompilerUtil.compiledCode(default_OptimizerString)
+        .asInstanceOf[AbstractCarbonOptimizerFactory].createOptimizer(optimizer, conf)
     }
   }
 
-  /**
-   * It does two jobs. 1. Change the datatype for dictionary encoded column 2. Add the dictionary
-   * decoder plan.
-   */
-  class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation]) extends
-    Rule[LogicalPlan] {
-    def apply(plan: LogicalPlan): LogicalPlan = {
-      transformCarbonPlan(plan, relations)
-    }
-
-    /**
-     * Steps for changing the plan.
-     * 1. It finds out the join condition columns and dimension aggregate columns which are need to
-     * be decoded just before that plan executes.
-     * 2. Plan starts transform by adding the decoder to the plan where it needs the decoded data
-     * like dimension aggregate columns decoder under aggregator and join condition decoder under
-     * join children.
-     */
-    def transformCarbonPlan(plan: LogicalPlan,
-        relations: Seq[CarbonDecoderRelation]): LogicalPlan = {
-      var decoder = false
-      val aliasMap = CarbonAliasDecoderRelation()
-      // collect alias information before hand.
-      collectInformationOnAttributes(plan, aliasMap)
-      val transFormedPlan =
-        plan transformDown {
-          case cd: CarbonDictionaryTempDecoder if cd.isOuter =>
-            decoder = true
-            cd
-          case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-            val attrsOnSort = new util.HashSet[Attribute]()
-            sort.order.map { s =>
-              s.collect {
-                case attr: AttributeReference
-                  if isDictionaryEncoded(attr, relations, aliasMap) =>
-                  attrsOnSort.add(aliasMap.getOrElse(attr, attr))
-              }
-            }
-            var child = sort.child
-            if (attrsOnSort.size() > 0 && !child.isInstanceOf[Sort]) {
-              child = CarbonDictionaryTempDecoder(attrsOnSort,
-                new util.HashSet[Attribute](), sort.child)
-            }
-            if (!decoder) {
-              decoder = true
-              CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
-                new util.HashSet[Attribute](),
-                Sort(sort.order, sort.global, child),
-                isOuter = true)
-            } else {
-              Sort(sort.order, sort.global, child)
-            }
-
-          case agg: Aggregate if !agg.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-            val attrsOndimAggs = new util.HashSet[Attribute]
-            agg.aggregateExpressions.map {
-              case attr: AttributeReference =>
-              case a@Alias(attr: AttributeReference, name) => aliasMap.put(a.toAttribute, attr)
-              case aggExp: AggregateExpression =>
-                aggExp.transform {
-                  case aggExp: AggregateExpression =>
-                    collectDimensionAggregates(aggExp, attrsOndimAggs, aliasMap)
-                    aggExp
-                  case a@Alias(attr: Attribute, name) =>
-                    aliasMap.put(a.toAttribute, attr)
-                    a
-                }
-              case others =>
-                others.collect {
-                  case attr: AttributeReference
-                    if isDictionaryEncoded(attr, relations, aliasMap) =>
-                    attrsOndimAggs.add(aliasMap.getOrElse(attr, attr))
-                }
-            }
-            var child = agg.child
-            // Incase if the child also aggregate then push down decoder to child
-            if (attrsOndimAggs.size() > 0 && !child.equals(agg)) {
-              child = CarbonDictionaryTempDecoder(attrsOndimAggs,
-                new util.HashSet[Attribute](),
-                agg.child)
-            }
-            if (!decoder) {
-              decoder = true
-              CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
-                new util.HashSet[Attribute](),
-                Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child),
-                isOuter = true)
-            } else {
-              Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child)
-            }
-
-          case filter: Filter if !filter.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-            val attrsOnConds = new util.HashSet[Attribute]
-            CarbonFilters
-              .selectFilters(splitConjunctivePredicates(filter.condition), attrsOnConds, aliasMap)
-
-            var child = filter.child
-            if (attrsOnConds.size() > 0 && !child.isInstanceOf[Filter]) {
-              child = CarbonDictionaryTempDecoder(attrsOnConds,
-                new util.HashSet[Attribute](),
-                filter.child)
-            }
-
-            if (!decoder) {
-              decoder = true
-              CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
-                new util.HashSet[Attribute](),
-                Filter(filter.condition, child),
-                isOuter = true)
-            } else {
-              Filter(filter.condition, child)
-            }
-
-          case j: Join
-            if !(j.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
-                 j.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
-            val attrsOnJoin = new util.HashSet[Attribute]
-            j.condition match {
-              case Some(expression) =>
-                expression.collect {
-                  case attr: AttributeReference
-                    if isDictionaryEncoded(attr, relations, aliasMap) =>
-                    attrsOnJoin.add(aliasMap.getOrElse(attr, attr))
-                }
-              case _ =>
-            }
-
-            val leftCondAttrs = new util.HashSet[Attribute]
-            val rightCondAttrs = new util.HashSet[Attribute]
-            if (attrsOnJoin.size() > 0) {
-
-              attrsOnJoin.asScala.map { attr =>
-                if (qualifierPresence(j.left, attr)) {
-                  leftCondAttrs.add(attr)
-                }
-                if (qualifierPresence(j.right, attr)) {
-                  rightCondAttrs.add(attr)
-                }
-              }
-              var leftPlan = j.left
-              var rightPlan = j.right
-              if (leftCondAttrs.size() > 0 &&
-                  !leftPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
-                leftPlan = CarbonDictionaryTempDecoder(leftCondAttrs,
-                  new util.HashSet[Attribute](),
-                  j.left)
-              }
-              if (rightCondAttrs.size() > 0 &&
-                  !rightPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
-                rightPlan = CarbonDictionaryTempDecoder(rightCondAttrs,
-                  new util.HashSet[Attribute](),
-                  j.right)
-              }
-              if (!decoder) {
-                decoder = true
-                CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
-                  new util.HashSet[Attribute](),
-                  Join(leftPlan, rightPlan, j.joinType, j.condition),
-                  isOuter = true)
-              } else {
-                Join(leftPlan, rightPlan, j.joinType, j.condition)
-              }
-            } else {
-              j
-            }
-
-          case p: Project
-            if relations.nonEmpty && !p.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-            val attrsOnProjects = new util.HashSet[Attribute]
-            p.projectList.map {
-              case attr: AttributeReference =>
-              case a@Alias(attr: AttributeReference, name) => aliasMap.put(a.toAttribute, attr)
-              case others =>
-                others.collect {
-                  case attr: AttributeReference
-                    if isDictionaryEncoded(attr, relations, aliasMap) =>
-                    attrsOnProjects.add(aliasMap.getOrElse(attr, attr))
-                }
-            }
-            var child = p.child
-            if (attrsOnProjects.size() > 0 && !child.isInstanceOf[Project]) {
-              child = CarbonDictionaryTempDecoder(attrsOnProjects,
-                new util.HashSet[Attribute](),
-                p.child)
-            }
-            if (!decoder) {
-              decoder = true
-              CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
-                new util.HashSet[Attribute](),
-                Project(p.projectList, child),
-                isOuter = true)
-            } else {
-              Project(p.projectList, child)
-            }
-
-          case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
-            if (!decoder) {
-              decoder = true
-              CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
-                new util.HashSet[Attribute](), l, isOuter = true)
-            } else {
-              l
-            }
-
-          case others => others
-        }
-
-      val processor = new CarbonDecoderProcessor
-      processor.updateDecoders(processor.getDecoderList(transFormedPlan))
-      updateProjection(updateTempDecoder(transFormedPlan, aliasMap))
-    }
-
-    private def updateTempDecoder(plan: LogicalPlan,
-        aliasMap: CarbonAliasDecoderRelation): LogicalPlan = {
-      var allAttrsNotDecode: util.Set[Attribute] = new util.HashSet[Attribute]()
-      val marker = new CarbonPlanMarker
-      plan transformDown {
-        case cd: CarbonDictionaryTempDecoder if !cd.processed =>
-          cd.processed = true
-          allAttrsNotDecode = cd.attrsNotDecode
-          marker.pushMarker(cd.attrsNotDecode)
-          if (cd.isOuter) {
-            CarbonDictionaryCatalystDecoder(relations,
-              ExcludeProfile(cd.attrsNotDecode.asScala.toSeq),
-              aliasMap,
-              isOuter = true,
-              cd.child)
-          } else {
-            CarbonDictionaryCatalystDecoder(relations,
-              IncludeProfile(cd.attrList.asScala.toSeq),
-              aliasMap,
-              isOuter = false,
-              cd.child)
-          }
-        case cd: CarbonDictionaryCatalystDecoder =>
-          cd
-        case sort: Sort =>
-          val sortExprs = sort.order.map { s =>
-            s.transform {
-              case attr: AttributeReference =>
-                updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
-            }.asInstanceOf[SortOrder]
-          }
-          Sort(sortExprs, sort.global, sort.child)
-        case agg: Aggregate if !agg.child.isInstanceOf[CarbonDictionaryCatalystDecoder] =>
-          val aggExps = agg.aggregateExpressions.map { aggExp =>
-            aggExp.transform {
-              case attr: AttributeReference =>
-                updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
-            }
-          }.asInstanceOf[Seq[NamedExpression]]
-
-          val grpExps = agg.groupingExpressions.map { gexp =>
-            gexp.transform {
-              case attr: AttributeReference =>
-                updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
-            }
-          }
-          Aggregate(grpExps, aggExps, agg.child)
-        case filter: Filter =>
-          val filterExps = filter.condition transform {
-            case attr: AttributeReference =>
-              updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
-            case l: Literal => FakeCarbonCast(l, l.dataType)
-          }
-          Filter(filterExps, filter.child)
-        case j: Join =>
-          marker.pushJoinMarker(allAttrsNotDecode)
-          j
-        case p: Project if relations.nonEmpty =>
-          val prExps = p.projectList.map { prExp =>
-            prExp.transform {
-              case attr: AttributeReference =>
-                updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
-            }
-          }.asInstanceOf[Seq[NamedExpression]]
-          Project(prExps, p.child)
-        case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
-          allAttrsNotDecode = marker.revokeJoin()
-          l
-        case others => others
-      }
-    }
-
-    private def updateProjection(plan: LogicalPlan): LogicalPlan = {
-      val transFormedPlan = plan transform {
-        case p@Project(projectList: Seq[NamedExpression], cd: CarbonDictionaryCatalystDecoder) =>
-          if (cd.child.isInstanceOf[Filter] || cd.child.isInstanceOf[LogicalRelation]) {
-            Project(projectList: Seq[NamedExpression], cd.child)
-          } else {
-            p
-          }
-        case f@Filter(condition: Expression, cd: CarbonDictionaryCatalystDecoder) =>
-          if (cd.child.isInstanceOf[Project] || cd.child.isInstanceOf[LogicalRelation]) {
-            Filter(condition, cd.child)
-          } else {
-            f
-          }
-      }
-      // Remove unnecessary decoders
-      val finalPlan = transFormedPlan transform {
-        case CarbonDictionaryCatalystDecoder(_, profile, _, false, child)
-          if profile.isInstanceOf[IncludeProfile] && profile.isEmpty => child
-      }
-      finalPlan
-    }
-
-    private def collectInformationOnAttributes(plan: LogicalPlan,
-        aliasMap: CarbonAliasDecoderRelation) {
-      plan transformUp {
-        case project: Project =>
-          project.projectList.map { p =>
-            p transform {
-              case a@Alias(attr: Attribute, name) =>
-                aliasMap.put(a.toAttribute, attr)
-                a
-              case a@Alias(_, name) =>
-                aliasMap.put(a.toAttribute, new AttributeReference("", StringType)())
-                a
-            }
-          }
-          project
-        case agg: Aggregate =>
-          agg.aggregateExpressions.map { aggExp =>
-            aggExp.transform {
-              case a@Alias(attr: Attribute, name) =>
-                aliasMap.put(a.toAttribute, attr)
-                a
-              case a@Alias(_, name) =>
-                aliasMap.put(a.toAttribute, new AttributeReference("", StringType)())
-                a
-            }
-          }
-          agg
-      }
-    }
-
-    // Collect aggregates on dimensions so that we can add decoder to it.
-    private def collectDimensionAggregates(aggExp: AggregateExpression,
-        attrsOndimAggs: util.HashSet[Attribute],
-        aliasMap: CarbonAliasDecoderRelation) {
-      aggExp collect {
-        case attr: AttributeReference if isDictionaryEncoded(attr, relations, aliasMap) =>
-          attrsOndimAggs.add(aliasMap.getOrElse(attr, attr))
-        case a@Alias(attr: Attribute, name) => aliasMap.put(a.toAttribute, attr)
-      }
-    }
-
-    /**
-     * Update the attribute datatype with [IntegerType] if the carbon column is encoded with
-     * dictionary.
-     *
-     */
-    private def updateDataType(attr: Attribute,
-        relations: Seq[CarbonDecoderRelation],
-        allAttrsNotDecode: util.Set[Attribute],
-        aliasMap: CarbonAliasDecoderRelation) = {
-      val uAttr = aliasMap.getOrElse(attr, attr)
-      val relation = relations.find(p => p.contains(uAttr))
-      if (relation.isDefined) {
-        relation.get.carbonRelation.carbonRelation.metaData.dictionaryMap.get(uAttr.name) match {
-          case Some(true) if !allAttrsNotDecode.asScala.exists(p => p.name.equals(uAttr.name)) =>
-            val newAttr = AttributeReference(attr.name,
-              IntegerType,
-              attr.nullable,
-              attr.metadata)(attr.exprId, attr.qualifiers)
-            relation.get.addAttribute(newAttr)
-            newAttr
-          case _ => attr
-        }
-      } else {
-        attr
-      }
-    }
-
-    private def isDictionaryEncoded(attr: Attribute,
-        relations: Seq[CarbonDecoderRelation],
-        aliasMap: CarbonAliasDecoderRelation): Boolean = {
-      val uAttr = aliasMap.getOrElse(attr, attr)
-      val relation = relations.find(p => p.contains(uAttr))
-      if (relation.isDefined) {
-        relation.get.carbonRelation.carbonRelation.metaData.dictionaryMap.get(uAttr.name) match {
-          case Some(true) => true
-          case _ => false
-        }
-      } else {
-        false
-      }
-    }
-
-    def qualifierPresence(plan: LogicalPlan, attr: Attribute): Boolean = {
-      var present = false
-      plan collect {
-        case l: LogicalRelation if l.attributeMap.contains(attr) =>
-          present = true
-      }
-      present
+  def execute(plan: LogicalPlan, optimizer: Optimizer): LogicalPlan = {
+    val executedPlan: LogicalPlan = optimizer.execute(plan)
+    val relations = CarbonOptimizer.collectCarbonRelation(plan)
+    if (relations.nonEmpty) {
+      new ResolveCarbonFunctions(relations).apply(executedPlan)
+    } else {
+      executedPlan
     }
   }
 
@@ -458,6 +116,408 @@ class CarbonOptimizer(optimizer: Optimizer, conf: CatalystConf)
       case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
         CarbonDecoderRelation(l.attributeMap, carbonRelation)
     }
+  }
+}
+
+/**
+ * It does two jobs. 1. Change the datatype for dictionary encoded column 2. Add the dictionary
+ * decoder plan.
+ */
+class ResolveCarbonFunctions(
+    relations: Seq[CarbonDecoderRelation])
+  extends Rule[LogicalPlan] with PredicateHelper {
+
+  def apply(plan: LogicalPlan): LogicalPlan = {
+    transformCarbonPlan(plan, relations)
+  }
+
+  /**
+   * Steps for changing the plan.
+   * 1. It finds out the join condition columns and dimension aggregate columns which are need to
+   * be decoded just before that plan executes.
+   * 2. Plan starts transform by adding the decoder to the plan where it needs the decoded data
+   * like dimension aggregate columns decoder under aggregator and join condition decoder under
+   * join children.
+   */
+  def transformCarbonPlan(plan: LogicalPlan,
+      relations: Seq[CarbonDecoderRelation]): LogicalPlan = {
+    var decoder = false
+    val aliasMap = CarbonAliasDecoderRelation()
+    // collect alias information before hand.
+    collectInformationOnAttributes(plan, aliasMap)
+    val transFormedPlan =
+      plan transformDown {
+        case cd: CarbonDictionaryTempDecoder if cd.isOuter =>
+          decoder = true
+          cd
+        case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+          val attrsOnSort = new util.HashSet[Attribute]()
+          sort.order.map { s =>
+            s.collect {
+              case attr: AttributeReference
+                if isDictionaryEncoded(attr, relations, aliasMap) =>
+                attrsOnSort.add(aliasMap.getOrElse(attr, attr))
+            }
+          }
+          var child = sort.child
+          if (attrsOnSort.size() > 0 && !child.isInstanceOf[Sort]) {
+            child = CarbonDictionaryTempDecoder(attrsOnSort,
+              new util.HashSet[Attribute](), sort.child)
+          }
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
+              new util.HashSet[Attribute](),
+              Sort(sort.order, sort.global, child),
+              isOuter = true)
+          } else {
+            Sort(sort.order, sort.global, child)
+          }
+
+        case agg: Aggregate if !agg.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+          val attrsOndimAggs = new util.HashSet[Attribute]
+          agg.aggregateExpressions.map {
+            case attr: AttributeReference =>
+            case a@Alias(attr: AttributeReference, name) => aliasMap.put(a.toAttribute, attr)
+            case aggExp: AggregateExpression =>
+              aggExp.transform {
+                case aggExp: AggregateExpression =>
+                  collectDimensionAggregates(aggExp, attrsOndimAggs, aliasMap)
+                  aggExp
+                case a@Alias(attr: Attribute, name) =>
+                  aliasMap.put(a.toAttribute, attr)
+                  a
+              }
+            case others =>
+              others.collect {
+                case attr: AttributeReference
+                  if isDictionaryEncoded(attr, relations, aliasMap) =>
+                  attrsOndimAggs.add(aliasMap.getOrElse(attr, attr))
+              }
+          }
+          var child = agg.child
+          // Incase if the child also aggregate then push down decoder to child
+          if (attrsOndimAggs.size() > 0 && !child.equals(agg)) {
+            child = CarbonDictionaryTempDecoder(attrsOndimAggs,
+              new util.HashSet[Attribute](),
+              agg.child)
+          }
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
+              new util.HashSet[Attribute](),
+              Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child),
+              isOuter = true)
+          } else {
+            Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child)
+          }
+
+        case filter: Filter if !filter.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+          val attrsOnConds = new util.HashSet[Attribute]
+          CarbonFilters
+            .selectFilters(splitConjunctivePredicates(filter.condition), attrsOnConds, aliasMap)
+
+          var child = filter.child
+          if (attrsOnConds.size() > 0 && !child.isInstanceOf[Filter]) {
+            child = CarbonDictionaryTempDecoder(attrsOnConds,
+              new util.HashSet[Attribute](),
+              filter.child)
+          }
+
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
+              new util.HashSet[Attribute](),
+              Filter(filter.condition, child),
+              isOuter = true)
+          } else {
+            Filter(filter.condition, child)
+          }
+
+        case j: Join
+          if !(j.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
+               j.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
+          val attrsOnJoin = new util.HashSet[Attribute]
+          j.condition match {
+            case Some(expression) =>
+              expression.collect {
+                case attr: AttributeReference
+                  if isDictionaryEncoded(attr, relations, aliasMap) =>
+                  attrsOnJoin.add(aliasMap.getOrElse(attr, attr))
+              }
+            case _ =>
+          }
+
+          val leftCondAttrs = new util.HashSet[Attribute]
+          val rightCondAttrs = new util.HashSet[Attribute]
+          if (attrsOnJoin.size() > 0) {
+
+            attrsOnJoin.asScala.map { attr =>
+              if (qualifierPresence(j.left, attr)) {
+                leftCondAttrs.add(attr)
+              }
+              if (qualifierPresence(j.right, attr)) {
+                rightCondAttrs.add(attr)
+              }
+            }
+            var leftPlan = j.left
+            var rightPlan = j.right
+            if (leftCondAttrs.size() > 0 &&
+                !leftPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
+              leftPlan = CarbonDictionaryTempDecoder(leftCondAttrs,
+                new util.HashSet[Attribute](),
+                j.left)
+            }
+            if (rightCondAttrs.size() > 0 &&
+                !rightPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
+              rightPlan = CarbonDictionaryTempDecoder(rightCondAttrs,
+                new util.HashSet[Attribute](),
+                j.right)
+            }
+            if (!decoder) {
+              decoder = true
+              CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
+                new util.HashSet[Attribute](),
+                Join(leftPlan, rightPlan, j.joinType, j.condition),
+                isOuter = true)
+            } else {
+              Join(leftPlan, rightPlan, j.joinType, j.condition)
+            }
+          } else {
+            j
+          }
+
+        case p: Project
+          if relations.nonEmpty && !p.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+          val attrsOnProjects = new util.HashSet[Attribute]
+          p.projectList.map {
+            case attr: AttributeReference =>
+            case a@Alias(attr: AttributeReference, name) => aliasMap.put(a.toAttribute, attr)
+            case others =>
+              others.collect {
+                case attr: AttributeReference
+                  if isDictionaryEncoded(attr, relations, aliasMap) =>
+                  attrsOnProjects.add(aliasMap.getOrElse(attr, attr))
+              }
+          }
+          var child = p.child
+          if (attrsOnProjects.size() > 0 && !child.isInstanceOf[Project]) {
+            child = CarbonDictionaryTempDecoder(attrsOnProjects,
+              new util.HashSet[Attribute](),
+              p.child)
+          }
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
+              new util.HashSet[Attribute](),
+              Project(p.projectList, child),
+              isOuter = true)
+          } else {
+            Project(p.projectList, child)
+          }
+
+        case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[Attribute](),
+              new util.HashSet[Attribute](), l, isOuter = true)
+          } else {
+            l
+          }
+
+        case others => others
+      }
+
+    val processor = new CarbonDecoderProcessor
+    processor.updateDecoders(processor.getDecoderList(transFormedPlan))
+    updateProjection(updateTempDecoder(transFormedPlan, aliasMap))
+  }
+
+  private def updateTempDecoder(plan: LogicalPlan,
+      aliasMap: CarbonAliasDecoderRelation): LogicalPlan = {
+    var allAttrsNotDecode: util.Set[Attribute] = new util.HashSet[Attribute]()
+    val marker = new CarbonPlanMarker
+    plan transformDown {
+      case cd: CarbonDictionaryTempDecoder if !cd.processed =>
+        cd.processed = true
+        allAttrsNotDecode = cd.attrsNotDecode
+        marker.pushMarker(cd.attrsNotDecode)
+        if (cd.isOuter) {
+          CarbonDictionaryCatalystDecoder(relations,
+            ExcludeProfile(cd.attrsNotDecode.asScala.toSeq),
+            aliasMap,
+            isOuter = true,
+            cd.child)
+        } else {
+          CarbonDictionaryCatalystDecoder(relations,
+            IncludeProfile(cd.attrList.asScala.toSeq),
+            aliasMap,
+            isOuter = false,
+            cd.child)
+        }
+      case cd: CarbonDictionaryCatalystDecoder =>
+        cd
+      case sort: Sort =>
+        val sortExprs = sort.order.map { s =>
+          s.transform {
+            case attr: AttributeReference =>
+              updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
+          }.asInstanceOf[SortOrder]
+        }
+        Sort(sortExprs, sort.global, sort.child)
+      case agg: Aggregate if !agg.child.isInstanceOf[CarbonDictionaryCatalystDecoder] =>
+        val aggExps = agg.aggregateExpressions.map { aggExp =>
+          aggExp.transform {
+            case attr: AttributeReference =>
+              updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
+          }
+        }.asInstanceOf[Seq[NamedExpression]]
+
+        val grpExps = agg.groupingExpressions.map { gexp =>
+          gexp.transform {
+            case attr: AttributeReference =>
+              updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
+          }
+        }
+        Aggregate(grpExps, aggExps, agg.child)
+      case filter: Filter =>
+        val filterExps = filter.condition transform {
+          case attr: AttributeReference =>
+            updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
+          case l: Literal => FakeCarbonCast(l, l.dataType)
+        }
+        Filter(filterExps, filter.child)
+      case j: Join =>
+        marker.pushJoinMarker(allAttrsNotDecode)
+        j
+      case p: Project if relations.nonEmpty =>
+        val prExps = p.projectList.map { prExp =>
+          prExp.transform {
+            case attr: AttributeReference =>
+              updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
+          }
+        }.asInstanceOf[Seq[NamedExpression]]
+        Project(prExps, p.child)
+      case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
+        allAttrsNotDecode = marker.revokeJoin()
+        l
+      case others => others
+    }
+  }
+
+  private def updateProjection(plan: LogicalPlan): LogicalPlan = {
+    val transFormedPlan = plan transform {
+      case p@Project(projectList: Seq[NamedExpression], cd: CarbonDictionaryCatalystDecoder) =>
+        if (cd.child.isInstanceOf[Filter] || cd.child.isInstanceOf[LogicalRelation]) {
+          Project(projectList: Seq[NamedExpression], cd.child)
+        } else {
+          p
+        }
+      case f@Filter(condition: Expression, cd: CarbonDictionaryCatalystDecoder) =>
+        if (cd.child.isInstanceOf[Project] || cd.child.isInstanceOf[LogicalRelation]) {
+          Filter(condition, cd.child)
+        } else {
+          f
+        }
+    }
+    // Remove unnecessary decoders
+    val finalPlan = transFormedPlan transform {
+      case CarbonDictionaryCatalystDecoder(_, profile, _, false, child)
+        if profile.isInstanceOf[IncludeProfile] && profile.isEmpty => child
+    }
+    finalPlan
+  }
+
+  private def collectInformationOnAttributes(plan: LogicalPlan,
+      aliasMap: CarbonAliasDecoderRelation) {
+    plan transformUp {
+      case project: Project =>
+        project.projectList.map { p =>
+          p transform {
+            case a@Alias(attr: Attribute, name) =>
+              aliasMap.put(a.toAttribute, attr)
+              a
+            case a@Alias(_, name) =>
+              aliasMap.put(a.toAttribute, new AttributeReference("", StringType)())
+              a
+          }
+        }
+        project
+      case agg: Aggregate =>
+        agg.aggregateExpressions.map { aggExp =>
+          aggExp.transform {
+            case a@Alias(attr: Attribute, name) =>
+              aliasMap.put(a.toAttribute, attr)
+              a
+            case a@Alias(_, name) =>
+              aliasMap.put(a.toAttribute, new AttributeReference("", StringType)())
+              a
+          }
+        }
+        agg
+    }
+  }
+
+  // Collect aggregates on dimensions so that we can add decoder to it.
+  private def collectDimensionAggregates(aggExp: AggregateExpression,
+      attrsOndimAggs: util.HashSet[Attribute],
+      aliasMap: CarbonAliasDecoderRelation) {
+    aggExp collect {
+      case attr: AttributeReference if isDictionaryEncoded(attr, relations, aliasMap) =>
+        attrsOndimAggs.add(aliasMap.getOrElse(attr, attr))
+      case a@Alias(attr: Attribute, name) => aliasMap.put(a.toAttribute, attr)
+    }
+  }
+
+  /**
+   * Update the attribute datatype with [IntegerType] if the carbon column is encoded with
+   * dictionary.
+   *
+   */
+  private def updateDataType(attr: Attribute,
+      relations: Seq[CarbonDecoderRelation],
+      allAttrsNotDecode: util.Set[Attribute],
+      aliasMap: CarbonAliasDecoderRelation) = {
+    val uAttr = aliasMap.getOrElse(attr, attr)
+    val relation = relations.find(p => p.contains(uAttr))
+    if (relation.isDefined) {
+      relation.get.carbonRelation.carbonRelation.metaData.dictionaryMap.get(uAttr.name) match {
+        case Some(true) if !allAttrsNotDecode.asScala.exists(p => p.name.equals(uAttr.name)) =>
+          val newAttr = AttributeReference(attr.name,
+            IntegerType,
+            attr.nullable,
+            attr.metadata)(attr.exprId, attr.qualifiers)
+          relation.get.addAttribute(newAttr)
+          newAttr
+        case _ => attr
+      }
+    } else {
+      attr
+    }
+  }
+
+  private def isDictionaryEncoded(attr: Attribute,
+      relations: Seq[CarbonDecoderRelation],
+      aliasMap: CarbonAliasDecoderRelation): Boolean = {
+    val uAttr = aliasMap.getOrElse(attr, attr)
+    val relation = relations.find(p => p.contains(uAttr))
+    if (relation.isDefined) {
+      relation.get.carbonRelation.carbonRelation.metaData.dictionaryMap.get(uAttr.name) match {
+        case Some(true) => true
+        case _ => false
+      }
+    } else {
+      false
+    }
+  }
+
+  def qualifierPresence(plan: LogicalPlan, attr: Attribute): Boolean = {
+    var present = false
+    plan collect {
+      case l: LogicalRelation if l.attributeMap.contains(attr) =>
+        present = true
+    }
+    present
   }
 }
 

--- a/integration/spark/src/main/scala/org/apache/spark/util/ScalaCompilerUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/ScalaCompilerUtil.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import scala.tools.reflect.ToolBox
+
+/**
+ * It compiles the code dynamically at runtime and returns the object
+ */
+object ScalaCompilerUtil {
+
+  def compiledCode(code: String): Any = {
+    import scala.reflect.runtime.universe._
+    val cm = runtimeMirror(Utils.getContextOrSparkClassLoader)
+    val toolbox = cm.mkToolBox()
+
+    val tree = toolbox.parse(code)
+    toolbox.compile(tree)()
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -114,20 +114,14 @@
       </properties>
     </profile>
     <profile>
-      <id>spark-1.5.2</id>
+      <id>spark-1.5</id>
       <!-- default -->
       <properties>
         <spark.version>1.5.2</spark.version>
       </properties>
     </profile>
     <profile>
-      <id>spark-1.6.1</id>
-      <properties>
-        <spark.version>1.6.1</spark.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>spark-1.6.2</id>
+      <id>spark-1.6</id>
       <properties>
         <spark.version>1.6.2</spark.version>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
       </properties>
     </profile>
     <profile>
+      <id>spark-1.6.2</id>
+      <properties>
+        <spark.version>1.6.2</spark.version>
+      </properties>
+    </profile>
+    <profile>
       <id>integration-test</id>
       <modules>
         <module>integration-testcases</module>


### PR DESCRIPTION
Carbon can support Spark 1.6.2 version with this PR. And also supports all versions of Spark 1.5 and Spark 1.6

User can provide maven profile and spark version while building Carbon like following
*Spark 1.5.0*
`mvn clean -DskipTests -Pspark-1.5 -Dspark-version=1.5.0 package`
*Spark 1.5.1*
`mvn clean -DskipTests -Pspark-1.5 -Dspark-version=1.5.1 package`
*Spark 1.5.2*
`mvn clean -DskipTests -Pspark-1.5 -Dspark-version=1.5.2 package`

*Spark 1.6.0*
`mvn clean -DskipTests -Pspark-1.6 -Dspark-version=1.6.0 package`
*Spark 1.6.1*
`mvn clean -DskipTests -Pspark-1.6 -Dspark-version=1.6.1 package`
*Spark 1.6.2*
`mvn clean -DskipTests -Pspark-1.6 -Dspark-version=1.6.2 package`

By default Carbon builds with Spark version 1.5.2
