### PR TITLE
CARBONDATA-80 Dictionary values should be equally distributed in buckets while loading in memory

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractColumnDictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractColumnDictionaryInfo.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.carbondata.core.util.CarbonUtil;
 
 /**
  * class that implements cacheable interface and methods specific to column dictionary
@@ -62,6 +63,11 @@ public abstract class AbstractColumnDictionaryInfo implements DictionaryInfo {
   private long dictionaryMetaFileLength;
 
   /**
+   * size of one dictionary bucket
+   */
+  private final int dictionaryOneChunkSize = CarbonUtil.getDictionaryChunkSize();
+
+  /**
    * This method will return the timestamp of file based on which decision
    * the decision will be taken whether to read that file or not
    *
@@ -96,6 +102,16 @@ public abstract class AbstractColumnDictionaryInfo implements DictionaryInfo {
    */
   @Override public void incrementAccessCount() {
     accessCount.incrementAndGet();
+  }
+
+  /**
+   * This method will return the size of of last dictionary chunk so that only that many
+   * values are read from the dictionary reader
+   *
+   * @return size of last dictionary chunk
+   */
+  @Override public int getSizeOfLastDictionaryChunk() {
+    return 0;
   }
 
   /**
@@ -241,22 +257,19 @@ public abstract class AbstractColumnDictionaryInfo implements DictionaryInfo {
    */
   protected byte[] getDictionaryBytesFromSurrogate(int surrogateKey) {
     byte[] dictionaryValueInBytes = null;
-    int totalSizeOfDictionaryChunksTraversed = 0;
-    for (List<byte[]> oneDictionaryChunk : dictionaryChunks) {
-      totalSizeOfDictionaryChunksTraversed =
-          totalSizeOfDictionaryChunksTraversed + oneDictionaryChunk.size();
-      // skip the dictionary chunk till surrogate key is lesser than size of
-      // dictionary chunks traversed
-      if (totalSizeOfDictionaryChunksTraversed < surrogateKey) {
-        continue;
+    // surrogate key starts from 1 and list index will start from 0, so lets say if surrogate
+    // key is 10 then value will present at index 9 of the dictionary chunk list
+    int actualSurrogateIndex = surrogateKey - 1;
+    // lets say dictionaryOneChunkSize = 10, surrogateKey = 10, so bucket index will
+    // be 0 and dictionary chunk index will be 9 to get the value
+    int dictionaryBucketIndex = actualSurrogateIndex / dictionaryOneChunkSize;
+    if (dictionaryChunks.size() > dictionaryBucketIndex) {
+      int indexInsideBucket = actualSurrogateIndex % dictionaryOneChunkSize;
+      List<byte[]> dictionaryBucketContainingSurrogateValue =
+          dictionaryChunks.get(dictionaryBucketIndex);
+      if (dictionaryBucketContainingSurrogateValue.size() > indexInsideBucket) {
+        dictionaryValueInBytes = dictionaryBucketContainingSurrogateValue.get(indexInsideBucket);
       }
-      // lets say surrogateKey = 26, total size traversed is 28, dictionary chunk size = 12
-      // then surrogate position in dictionary chunk list is = 26 - (28-12) - 1 = 9
-      // -1 because list index starts from 0
-      int surrogatePositionInDictionaryChunk =
-          surrogateKey - (totalSizeOfDictionaryChunksTraversed - oneDictionaryChunk.size()) - 1;
-      dictionaryValueInBytes = oneDictionaryChunk.get(surrogatePositionInDictionaryChunk);
-      break;
     }
     return dictionaryValueInBytes;
   }

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractColumnDictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractColumnDictionaryInfo.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.CarbonUtil;
 
 /**
  * class that implements cacheable interface and methods specific to column dictionary

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryChunkIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryChunkIterator.java
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-package org.carbondata.core.cache.dictionary;
+package org.apache.carbondata.core.cache.dictionary;
 
 import java.nio.ByteBuffer;
 import java.util.List;
 
-import org.carbondata.common.CarbonIterator;
-import org.carbondata.format.ColumnDictionaryChunk;
+import org.apache.carbondata.common.CarbonIterator;
+import org.apache.carbondata.format.ColumnDictionaryChunk;
 
 /**
  * This class is a wrapper over column dictionary chunk thrift object.

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
@@ -133,8 +133,9 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
           List<byte[]> subListOfNewDictionaryChunk =
               newDictionaryChunk.subList(0, differenceInLastDictionaryAndOneChunkSize);
           lastDictionaryChunk.addAll(subListOfNewDictionaryChunk);
-          subListOfNewDictionaryChunk.clear();
-          dictionaryChunks.add(newDictionaryChunk);
+          List<byte[]> remainingNewDictionaryChunk = newDictionaryChunk
+              .subList(differenceInLastDictionaryAndOneChunkSize, newDictionaryChunk.size());
+          dictionaryChunks.add(remainingNewDictionaryChunk);
         }
       } else {
         dictionaryChunks.add(newDictionaryChunk);
@@ -142,6 +143,20 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
     } else {
       dictionaryChunks.add(newDictionaryChunk);
     }
+  }
+
+  /**
+   * This method will return the size of of last dictionary chunk so that only that many
+   * values are read from the dictionary reader
+   *
+   * @return size of last dictionary chunk
+   */
+  @Override public int getSizeOfLastDictionaryChunk() {
+    int lastDictionaryChunkSize = 0;
+    if (dictionaryChunks.size() > 0) {
+      lastDictionaryChunkSize = dictionaryChunks.get(dictionaryChunks.size() - 1).size();
+    }
+    return lastDictionaryChunkSize;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
@@ -30,7 +30,7 @@ import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonProperties;
-import org.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.CarbonUtil;
 
 /**
  * class that implements methods specific for dictionary data look up

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.carbondata.core.util.CarbonUtil;
 
 /**
  * class that implements methods specific for dictionary data look up
@@ -112,10 +113,35 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
   /**
    * This method will add a new dictionary chunk to existing list of dictionary chunks
    *
-   * @param dictionaryChunk
+   * @param newDictionaryChunk
    */
-  @Override public void addDictionaryChunk(List<byte[]> dictionaryChunk) {
-    dictionaryChunks.add(dictionaryChunk);
+  @Override public void addDictionaryChunk(List<byte[]> newDictionaryChunk) {
+    if (dictionaryChunks.size() > 0) {
+      // Ensure that each time a new dictionary chunk is getting added to the
+      // dictionary chunks list, equal distribution of dictionary values should
+      // be there in the sublists of dictionary chunk list
+      List<byte[]> lastDictionaryChunk = dictionaryChunks.get(dictionaryChunks.size() - 1);
+      int dictionaryOneChunkSize = CarbonUtil.getDictionaryChunkSize();
+      int differenceInLastDictionaryAndOneChunkSize =
+          dictionaryOneChunkSize - lastDictionaryChunk.size();
+      if (differenceInLastDictionaryAndOneChunkSize > 0) {
+        // if difference is greater than new dictionary size then copy a part of list
+        // else copy the complete new dictionary chunk list in the last dictionary chunk list
+        if (differenceInLastDictionaryAndOneChunkSize >= newDictionaryChunk.size()) {
+          lastDictionaryChunk.addAll(newDictionaryChunk);
+        } else {
+          List<byte[]> subListOfNewDictionaryChunk =
+              newDictionaryChunk.subList(0, differenceInLastDictionaryAndOneChunkSize);
+          lastDictionaryChunk.addAll(subListOfNewDictionaryChunk);
+          subListOfNewDictionaryChunk.clear();
+          dictionaryChunks.add(newDictionaryChunk);
+        }
+      } else {
+        dictionaryChunks.add(newDictionaryChunk);
+      }
+    } else {
+      dictionaryChunks.add(newDictionaryChunk);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
@@ -27,10 +27,11 @@ import java.util.List;
 import org.apache.carbondata.common.factory.CarbonCommonFactory;
 import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 import org.apache.carbondata.core.carbon.ColumnIdentifier;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.reader.CarbonDictionaryReader;
 import org.apache.carbondata.core.reader.sortindex.CarbonDictionarySortIndexReader;
 import org.apache.carbondata.core.service.DictionaryService;
-import org.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.CarbonUtil;
 
 /**
  * This class is responsible for loading the dictionary data for given columns

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryInfo.java
@@ -58,6 +58,14 @@ public interface DictionaryInfo extends Cacheable, Dictionary {
   void addDictionaryChunk(List<byte[]> dictionaryChunk);
 
   /**
+   * This method will return the size of of last dictionary chunk so that only that many
+   * values are read from the dictionary reader
+   *
+   * @return size of last dictionary chunk
+   */
+  int getSizeOfLastDictionaryChunk();
+
+  /**
    * This method will set the sort order index of a dictionary column.
    * Sort order index if the index of dictionary values after they are sorted.
    *

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReader.java
@@ -21,6 +21,7 @@ package org.apache.carbondata.core.reader;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -63,8 +64,8 @@ public interface CarbonDictionaryReader extends Closeable {
    *
    * @param startOffset start offset of dictionary file
    * @param endOffset   end offset of dictionary file
-   * @return list of byte array. Each byte array is unique dictionary value
+   * @return iterator over byte array. Each byte array is unique dictionary value
    * @throws IOException if an I/O error occurs
    */
-  List<byte[]> read(long startOffset, long endOffset) throws IOException;
+  Iterator<byte[]> read(long startOffset, long endOffset) throws IOException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImpl.java
@@ -26,10 +26,10 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.carbondata.common.factory.CarbonCommonFactory;
+import org.apache.carbondata.core.cache.dictionary.ColumnDictionaryChunkIterator;
 import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 import org.apache.carbondata.core.carbon.ColumnIdentifier;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
-import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.service.PathService;
 import org.apache.carbondata.format.ColumnDictionaryChunk;
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1443,6 +1443,5 @@ public final class CarbonUtil {
     }
     return dictionaryOneChunkSize;
   }
-
 }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1424,5 +1424,25 @@ public final class CarbonUtil {
     }
   }
 
+  /**
+   * initialize the value of dictionary chunk that can be kept in memory at a time
+   *
+   * @return
+   */
+  public static int getDictionaryChunkSize() {
+    int dictionaryOneChunkSize = 0;
+    try {
+      dictionaryOneChunkSize = Integer.parseInt(CarbonProperties.getInstance()
+          .getProperty(CarbonCommonConstants.DICTIONARY_ONE_CHUNK_SIZE,
+              CarbonCommonConstants.DICTIONARY_ONE_CHUNK_SIZE_DEFAULT));
+    } catch (NumberFormatException e) {
+      dictionaryOneChunkSize =
+          Integer.parseInt(CarbonCommonConstants.DICTIONARY_ONE_CHUNK_SIZE_DEFAULT);
+      LOGGER.error("Dictionary chunk size not configured properly. Taking default size "
+          + dictionaryOneChunkSize);
+    }
+    return dictionaryOneChunkSize;
+  }
+
 }
 

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
@@ -38,7 +38,6 @@ import org.apache.carbondata.core.reader.CarbonDictionaryColumnMetaChunk;
 import org.apache.carbondata.core.reader.CarbonDictionaryMetadataReader;
 import org.apache.carbondata.core.reader.CarbonDictionaryMetadataReaderImpl;
 import org.apache.carbondata.core.service.PathService;
-import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.format.ColumnDictionaryChunk;
 import org.apache.carbondata.format.ColumnDictionaryChunkMeta;

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
@@ -263,16 +263,7 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
    * initialize the value of dictionary chunk that can be kept in memory at a time
    */
   private void initDictionaryChunkSize() {
-    try {
-      dictionary_one_chunk_size = Integer.parseInt(CarbonProperties.getInstance()
-          .getProperty(CarbonCommonConstants.DICTIONARY_ONE_CHUNK_SIZE,
-              CarbonCommonConstants.DICTIONARY_ONE_CHUNK_SIZE_DEFAULT));
-    } catch (NumberFormatException e) {
-      dictionary_one_chunk_size =
-          Integer.parseInt(CarbonCommonConstants.DICTIONARY_ONE_CHUNK_SIZE_DEFAULT);
-      LOGGER.error("Dictionary chunk size not configured properly. Taking default size "
-              + dictionary_one_chunk_size);
-    }
+    dictionary_one_chunk_size = CarbonUtil.getDictionaryChunkSize();
   }
 
   /**

--- a/core/src/main/java/org/carbondata/core/cache/dictionary/ColumnDictionaryChunkIterator.java
+++ b/core/src/main/java/org/carbondata/core/cache/dictionary/ColumnDictionaryChunkIterator.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.carbondata.core.cache.dictionary;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.carbondata.common.CarbonIterator;
+import org.carbondata.format.ColumnDictionaryChunk;
+
+/**
+ * This class is a wrapper over column dictionary chunk thrift object.
+ * The wrapper class wraps the list<ColumnDictionaryChunk> and provides an API
+ * to fill the byte array into list
+ */
+public class ColumnDictionaryChunkIterator extends CarbonIterator {
+
+  /**
+   * list of dictionaryChunks
+   */
+  private List<ColumnDictionaryChunk> columnDictionaryChunks;
+
+  /**
+   * size of the list
+   */
+  private int size;
+
+  /**
+   * Current index of the list
+   */
+  private int currentSize;
+
+  /**
+   * variable holds the count of elements already iterated
+   */
+  private int iteratorIndex;
+
+  /**
+   * variable holds the current index of List<List<byte[]>> being traversed
+   */
+  private int outerIndex;
+
+  /**
+   * Constructor of ColumnDictionaryChunkIterator
+   *
+   * @param columnDictionaryChunks
+   */
+  public ColumnDictionaryChunkIterator(List<ColumnDictionaryChunk> columnDictionaryChunks) {
+    this.columnDictionaryChunks = columnDictionaryChunks;
+    for (ColumnDictionaryChunk dictionaryChunk : columnDictionaryChunks) {
+      this.size += dictionaryChunk.getValues().size();
+    }
+  }
+
+  /**
+   * Returns {@code true} if the iteration has more elements.
+   * (In other words, returns {@code true} if {@link #next} would
+   * return an element rather than throwing an exception.)
+   *
+   * @return {@code true} if the iteration has more elements
+   */
+  @Override public boolean hasNext() {
+    return (currentSize < size);
+  }
+
+  /**
+   * Returns the next element in the iteration.
+   * The method pics the next elements from the first inner list till first is not finished, pics
+   * the second inner list ...
+   *
+   * @return the next element in the iteration
+   */
+  @Override public byte[] next() {
+    if (iteratorIndex >= columnDictionaryChunks.get(outerIndex).getValues().size()) {
+      iteratorIndex = 0;
+      outerIndex++;
+    }
+    ByteBuffer buffer = columnDictionaryChunks.get(outerIndex).getValues().get(iteratorIndex);
+    byte[] value = buffer.array();
+    currentSize++;
+    iteratorIndex++;
+    return value;
+  }
+}

--- a/core/src/test/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
@@ -28,6 +28,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
@@ -457,7 +458,10 @@ public class CarbonDictionaryWriterImplTest {
       if (0 == dictionaryEndOffset) {
         dictionaryValues = dictionaryReader.read(dictionaryStartOffset);
       } else {
-        dictionaryValues = dictionaryReader.read(dictionaryStartOffset, dictionaryEndOffset);
+        Iterator<byte[]> itr = dictionaryReader.read(dictionaryStartOffset, dictionaryEndOffset);
+        while (itr.hasNext()) {
+          dictionaryValues.add(itr.next());
+        }
       }
     } finally {
       dictionaryReader.close();


### PR DESCRIPTION
jira link: 
https://issues.apache.org/jira/browse/CARBONDATA-80