### PR TITLE
[CARBONDATA-88] Fixed relative path issue from carbon-spark-shell

### DIFF
--- a/bin/carbon-spark-shell
+++ b/bin/carbon-spark-shell
@@ -52,6 +52,7 @@ fi
 ASSEMBLY_JAR="${ASSEMBLY_DIR}/${ASSEMBLY_JARS}"
 export JAR="$ASSEMBLY_JAR"
 export SPARK_CLASSPATH=$SPARK_CLASSPATH:$JAR
+export CARBON_HOME=$CARBON_SOURCE
 
 
 # SPARK-4161: scala does not assume use of the java classpath,

--- a/bin/carbon-spark-sql
+++ b/bin/carbon-spark-sql
@@ -51,6 +51,7 @@ fi
 
 ASSEMBLY_JAR="${ASSEMBLY_DIR}/${ASSEMBLY_JARS}"
 export JAR="$ASSEMBLY_JAR"
+export CARBON_HOME=$CARBON_SOURCE
 
 function usage {
   if [ -n "$1" ]; then

--- a/integration/spark/src/main/scala/org/apache/spark/repl/CarbonSparkILoop.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/repl/CarbonSparkILoop.scala
@@ -41,7 +41,8 @@ class CarbonSparkILoop extends SparkILoop {
          @transient val cc = {
            val _cc = {
              import java.io.File
-             val store = new File("./carbonshellstore")
+             val path = System.getenv("CARBON_HOME") + "/bin/carbonshellstore"
+             val store = new File(path)
              store.mkdirs()
              val storePath = sc.getConf.getOption("spark.carbon.storepath")
                   .getOrElse(store.getCanonicalPath)
@@ -51,7 +52,18 @@ class CarbonSparkILoop extends SparkILoop {
            _cc
          }
               """)
-      command("""cc.setConf("carbon.kettle.home", "../processing/carbonplugins")""")
+
+      command("import org.apache.spark.sql.SQLContext")
+      command("""
+         @transient val sqlContext = {
+           val _sqlContext = new SQLContext(sc)
+           println("SQL context available as sqlContext.")
+           _sqlContext
+         }
+              """)
+      command("import sqlContext.implicits._")
+      command("import sqlContext.sql")
+
       command("import cc.implicits._")
       command("import cc.sql")
       command("import org.apache.spark.sql.functions._")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -797,10 +797,7 @@ private[sql] case class AlterTableCompaction(alterTableModel: AlterTableModel) e
 
     val partitioner = relation.tableMeta.partitioner
 
-    var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
-    if (null == kettleHomePath) {
-      kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
-    }
+    var kettleHomePath = CarbonScalaUtil.getKettleHomePath(sqlContext)
     if (kettleHomePath == null) {
       sys.error(s"carbon.kettle.home is not set")
     }
@@ -1083,10 +1080,7 @@ private[sql] case class LoadTable(
       storeLocation = storeLocation + "/carbonstore/" + System.nanoTime()
 
       val columinar = sqlContext.getConf("carbon.is.columnar.storage", "true").toBoolean
-      var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
-      if (null == kettleHomePath) {
-        kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
-      }
+      var kettleHomePath = CarbonScalaUtil.getKettleHomePath(sqlContext)
       if (kettleHomePath == null) {
         sys.error(s"carbon.kettle.home is not set")
       }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/cli/CarbonSQLCLIDriver.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/cli/CarbonSQLCLIDriver.scala
@@ -63,12 +63,12 @@ object CarbonSQLCLIDriver extends Logging {
 
       sparkContext = new SparkContext(sparkConf)
       sparkContext.addSparkListener(new StatsReportListener())
-      val store = new File("./carbonsqlclistore")
+      val path = System.getenv("CARBON_HOME") + "/bin/carbonsqlclistore"
+      val store = new File(path)
       store.mkdirs()
       hiveContext = new CarbonContext(sparkContext,
         maybeStorePath.getOrElse(store.getCanonicalPath),
         store.getCanonicalPath)
-      hiveContext.setConf("carbon.kettle.home", "../processing/carbonplugins")
 
       hiveContext.setConf("spark.sql.hive.version", HiveContext.hiveExecutionVersion)
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
@@ -27,7 +27,7 @@ import org.carbondata.core.carbon.metadata.datatype.{DataType => CarbonDataType}
 import org.carbondata.core.carbon.metadata.encoder.Encoding
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable
 import org.carbondata.core.constants.CarbonCommonConstants
-import org.carbondata.core.util.CarbonUtil
+import org.carbondata.core.util.{CarbonProperties, CarbonUtil}
 
 object CarbonScalaUtil {
   def convertSparkToCarbonDataType(
@@ -77,6 +77,21 @@ object CarbonScalaUtil {
       case CarbonDataType.DECIMAL => DecimalType.SYSTEM_DEFAULT
       case CarbonDataType.TIMESTAMP => TimestampType
     }
+  }
+
+  def getKettleHomePath(sqlContext: SQLContext): String = {
+    val carbonHome = System.getenv("CARBON_HOME")
+    var kettleHomePath: String = null
+    if (carbonHome != null) {
+      kettleHomePath = System.getenv("CARBON_HOME") + "/processing/carbonplugins"
+    }
+    if (kettleHomePath == null) {
+      kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
+    }
+    if (null == kettleHomePath) {
+      kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
+    }
+    kettleHomePath
   }
 
   object CarbonSparkUtil {


### PR DESCRIPTION
This issue happens when `carbon-spark-shell` or `carbon-spark-sql` runs from any other folder other than   carbondata/bin folder. 