### PR TITLE
[CARBONDATA-107] Remove unnecessary ConvertToSafe

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -138,8 +138,11 @@ case class CarbonDictionaryDecoder(
     dictIds
   }
 
-
   override def outputsUnsafeRows: Boolean = true
+
+  override def canProcessUnsafeRows: Boolean = true
+
+  override def canProcessSafeRows: Boolean = true
 
   override def doExecute(): RDD[InternalRow] = {
     attachTree(this, "execute") {
@@ -154,8 +157,7 @@ case class CarbonDictionaryDecoder(
         child.execute().mapPartitions { iter =>
           val cacheProvider: CacheProvider = CacheProvider.getInstance
           val forwardDictionaryCache: Cache[DictionaryColumnUniqueIdentifier, Dictionary] =
-            cacheProvider
-              .createCache(CacheType.FORWARD_DICTIONARY, storePath)
+            cacheProvider.createCache(CacheType.FORWARD_DICTIONARY, storePath)
           val dicts: Seq[Dictionary] = getDictionary(absoluteTableIdentifiers,
             forwardDictionaryCache)
           val dictIndex = dicts.zipWithIndex.filter(x => x._1 != null).map(x => x._2)

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
@@ -37,6 +37,10 @@ class NO_DICTIONARY_COL_TestCase extends QueryTest with BeforeAndAfterAll {
   override def beforeAll {
     //For the Hive table creation and data loading
     sql("drop table if exists filtertestTables")
+    sql("drop table if exists NO_DICTIONARY_HIVE_6")
+    sql("drop table if exists NO_DICTIONARY_CARBON_6")
+    sql("drop table if exists NO_DICTIONARY_CARBON_7")
+    
     sql(
       "create table NO_DICTIONARY_HIVE_6(empno int,empname string,designation string,doj " +
         "Timestamp,workgroupcategory int, " +


### PR DESCRIPTION
CarbonDictionaryDecoder is using InternalRow only, so it should be able to process UnsafeRow.
By changing `canProcessUnsafeRows` and `canProcessSafeRows` to `true`, the planner will remove unnecessary ConvertToSafe operator