### PR TITLE
[CARBONDATA-123] Stored by 'carbondata' or 'org.apache.carbondata.format' shoulb be not case senstive

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -119,7 +119,7 @@ class CarbonContext(
   @transient
   val LOGGER = LogServiceFactory.getLogService(CarbonContext.getClass.getName)
 
-  override def sql(sql: String): SchemaRDD = {
+  override def sql(sql: String): DataFrame = {
     // queryId will be unique for each query, creting query detail holder
     val queryId: String = System.nanoTime() + ""
     this.setConf("queryId", queryId)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -423,7 +423,7 @@ class CarbonSqlParser()
               likeTableName = child.getChild(0).getText()
 
             case Token("TOK_STORAGEHANDLER", child :: Nil) =>
-              storedBy = BaseSemanticAnalyzer.unescapeSQLString(child.getText)
+              storedBy = BaseSemanticAnalyzer.unescapeSQLString(child.getText).trim.toLowerCase
 
             case _ => // Unsupport features
           }


### PR DESCRIPTION
For example, support STORED BY  'CARBONDATA' or '  carbondata' or 'org.apache.carbondata.format' or 'ORG.APACHE.CARBONDATA.FORMAT'.