### PR TITLE
Fixed aggregate queries with using subqueries in Spark 1.6.2

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -121,14 +121,13 @@ case class CarbonDictionaryDecoder(
     val dictIds: Array[(String, ColumnIdentifier, DataType)] = attributes.map { a =>
       val attr = aliasMap.getOrElse(a, a)
       val relation = relations.find(p => p.contains(attr))
-      if(relation.isDefined) {
+      if(relation.isDefined && canBeDecoded(attr)) {
         val carbonTable = relation.get.carbonRelation.carbonRelation.metaData.carbonTable
         val carbonDimension =
           carbonTable.getDimensionByName(carbonTable.getFactTableName, attr.name)
         if (carbonDimension != null &&
             carbonDimension.hasEncoding(Encoding.DICTIONARY) &&
-            !carbonDimension.hasEncoding(Encoding.DIRECT_DICTIONARY) &&
-            canBeDecoded(attr)) {
+            !carbonDimension.hasEncoding(Encoding.DIRECT_DICTIONARY)) {
           (carbonTable.getFactTableName, carbonDimension.getColumnIdentifier,
               carbonDimension.getDataType)
         } else {

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
@@ -1102,4 +1102,10 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbonunion")
   })
 
+  test("select Min(imei) from (select imei from Carbon_automation_test order by imei) t")({
+    checkAnswer(
+      sql("select Min(imei) from (select imei from Carbon_automation_test order by imei) t"),
+      sql("select Min(imei) from (select imei from Carbon_automation_hive order by imei) t"))
+  })
+
 }


### PR DESCRIPTION
Queries using aggregates and sub queries like below are not working with Spark 1.6.2
`select Min(imei) from (select imei from table1 order by imei) t`.

This PR fixes this issue