### PR TITLE
Fixed distinct count query issue in 1.6.2

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -439,6 +439,11 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
           }
         }
         Aggregate(grpExps, aggExps, agg.child)
+      case expand: Expand =>
+        expand.transformExpressions {
+          case attr: AttributeReference =>
+            updateDataType(attr, relations, allAttrsNotDecode, aliasMap)
+        }
       case filter: Filter =>
         val filterExps = filter.condition transform {
           case attr: AttributeReference =>
@@ -526,6 +531,21 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
           case _ => aliasMap.put(a.toAttribute, new AttributeReference("", StringType)())
         }
         a
+    }
+    // collect the output of expand and add projections attributes as alias to it.
+    plan.collect {
+      case expand: Expand =>
+        expand.projections.foreach {s =>
+          s.zipWithIndex.foreach { f =>
+            f._1 match {
+              case attr: AttributeReference =>
+                aliasMap.put(expand.output(f._2).toAttribute, attr)
+              case a@Alias(attr: AttributeReference, name) =>
+                aliasMap.put(expand.output(f._2).toAttribute, attr)
+              case others =>
+            }
+          }
+        }
     }
   }
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -35,6 +35,9 @@ object CarbonThriftServer {
       System.setProperty("carbon.properties.filepath",
         sparkHome + '/' + "conf" + '/' + "carbon.properties")
     }
+    if (org.apache.spark.SPARK_VERSION.startsWith("1.6")) {
+      conf.set("spark.sql.hive.thriftServer.singleSession", "true")
+    }
     val sc = new SparkContext(conf)
     val warmUpTime = CarbonProperties.getInstance().getProperty("carbon.spark.warmUpTime", "5000")
     try {

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
@@ -98,6 +98,13 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
         "(designation) order by empname"))
   }
 
+  test("select count(empno), count(distinct(empno)) from alldatatypestableAGG")
+  {
+    checkAnswer(
+      sql("select count(empno), count(distinct(empno)) from alldatatypestableAGG"),
+      sql("select count(empno), count(distinct(empno)) from alldatatypescubeAGG_hive"))
+  }
+
   override def afterAll {
     sql("drop table alldatatypestableAGG")
   }


### PR DESCRIPTION
Distinct count queries like below are fixed in spark version 1.6.2
`select count(imei), count(distinct(imei)) from table1`

This PR fixes it.