### PR TITLE
Fixed casesensitive column issue in self join queries

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonDecoderOptimizerHelper.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonDecoderOptimizerHelper.scala
@@ -107,7 +107,7 @@ case class AttributeReferenceWrapper(attr: Attribute) {
 
   override def equals(other: Any): Boolean = other match {
     case ar: AttributeReferenceWrapper =>
-      attr.name == ar.attr.name && attr.exprId == ar.attr.exprId
+      attr.name.equalsIgnoreCase(ar.attr.name) && attr.exprId == ar.attr.exprId
     case _ => false
   }
   override def hashCode: Int = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -574,7 +574,8 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
     val relation = relations.find(p => p.contains(uAttr))
     if (relation.isDefined) {
       relation.get.carbonRelation.carbonRelation.metaData.dictionaryMap.get(uAttr.name) match {
-        case Some(true) if !allAttrsNotDecode.asScala.exists(p => p.name.equals(uAttr.name)) =>
+        case Some(true)
+          if !allAttrsNotDecode.asScala.exists(p => p.name.equalsIgnoreCase(uAttr.name)) =>
           val newAttr = AttributeReference(attr.name,
             IntegerType,
             attr.nullable,

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
@@ -1108,4 +1108,10 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
       sql("select Min(imei) from (select imei from Carbon_automation_hive order by imei) t"))
   })
 
+  test("select b.IMEI from Carbon_automation_test a join Carbon_automation_test b on a.imei=b.imei")({
+    checkAnswer(
+      sql("select b.IMEI from Carbon_automation_test a join Carbon_automation_test b on a.imei=b.imei"),
+      sql("select b.IMEI from Carbon_automation_hive a join Carbon_automation_hive b on a.imei=b.imei"))
+  })
+
 }


### PR DESCRIPTION
Queries are failing when the case sensitive columns are used in self join queries like below
`select b.IMEI from table1 a join table1 b on a.imei=b.imei`