### PR TITLE
[CARBONDATA-154] Fix the bug of block prune that query result is wrong.

### DIFF
--- a/core/src/main/java/org/carbondata/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/scan/filter/FilterUtil.java
@@ -669,27 +669,14 @@ public final class FilterUtil {
    * @param segmentProperties
    * @return long[] start key
    */
-  public static long[] getStartKey(DimColumnResolvedFilterInfo dimColResolvedFilterInfo,
-      SegmentProperties segmentProperties, long[] startKey) {
-    Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter =
-        dimColResolvedFilterInfo.getDimensionResolvedFilterInstance();
-    for (Map.Entry<CarbonDimension, List<DimColumnFilterInfo>> entry : dimensionFilter.entrySet()) {
-      List<DimColumnFilterInfo> values = entry.getValue();
-      if (null == values || !entry.getKey().hasEncoding(Encoding.DICTIONARY)) {
-        continue;
-      }
-      boolean isExcludePresent = false;
-      for (DimColumnFilterInfo info : values) {
-        if (!info.isIncludeFilter()) {
-          isExcludePresent = true;
-        }
-      }
-      if (isExcludePresent) {
-        continue;
-      }
-      getStartKeyBasedOnFilterResoverInfo(dimensionFilter, startKey);
+  public static void getStartKey(Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter,
+      AbsoluteTableIdentifier tableIdentifier, long[] startKey, SegmentProperties segmentProperties,
+      List<long[]> startKeyList) throws QueryExecutionException {
+    for(int i = 0; i < startKey.length; i++) {
+      // The min surrogate key is 1, set it as the init value for starkey of each column level
+      startKey[i] = 1;
     }
-    return startKey;
+    getStartKeyWithFilter(dimensionFilter, startKey, startKeyList);
   }
 
   /**
@@ -711,7 +698,7 @@ public final class FilterUtil {
    */
   public static void getStartKeyForNoDictionaryDimension(
       DimColumnResolvedFilterInfo dimColResolvedFilterInfo, SegmentProperties segmentProperties,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray) {
+      SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList) {
     Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter =
         dimColResolvedFilterInfo.getDimensionResolvedFilterInstance();
     // step 1
@@ -766,7 +753,7 @@ public final class FilterUtil {
    */
   public static void getEndKeyForNoDictionaryDimension(
       DimColumnResolvedFilterInfo dimColResolvedFilterInfo, SegmentProperties segmentProperties,
-      SortedMap<Integer, byte[]> setOfEndKeyByteArray) {
+      SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList) {
 
     Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter =
         dimColResolvedFilterInfo.getDimensionResolvedFilterInstance();
@@ -832,11 +819,12 @@ public final class FilterUtil {
    * @param dimensionFilter
    * @param startKey
    */
-  private static void getStartKeyBasedOnFilterResoverInfo(
-      Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter, long[] startKey) {
+  private static void getStartKeyWithFilter(
+      Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter, long[] startKey,
+      List<long[]> startKeyList) {
     for (Map.Entry<CarbonDimension, List<DimColumnFilterInfo>> entry : dimensionFilter.entrySet()) {
       List<DimColumnFilterInfo> values = entry.getValue();
-      if (null == values) {
+      if (null == values || !entry.getKey().hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
       boolean isExcludePresent = false;
@@ -853,12 +841,15 @@ public final class FilterUtil {
           startKey[entry.getKey().getKeyOrdinal()] = info.getFilterList().get(0);
         }
       }
+      long[] newStartKey = new long[startKey.length];
+      System.arraycopy(startKey, 0, newStartKey, 0, startKey.length);
+      startKeyList.add(newStartKey);
     }
   }
 
   public static void getEndKey(Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter,
-      AbsoluteTableIdentifier tableIdentifier, long[] endKey, SegmentProperties segmentProperties)
-      throws QueryExecutionException {
+      AbsoluteTableIdentifier tableIdentifier, long[] endKey, SegmentProperties segmentProperties,
+      List<long[]> endKeyList) throws QueryExecutionException {
 
     List<CarbonDimension> updatedDimListBasedOnKeyGenerator =
         getCarbonDimsMappedToKeyGenerator(segmentProperties.getDimensions());
@@ -866,7 +857,7 @@ public final class FilterUtil {
       endKey[i] = getMaxValue(tableIdentifier, updatedDimListBasedOnKeyGenerator.get(i),
           segmentProperties.getDimColumnsCardinality());
     }
-    getEndKeyWithFilter(dimensionFilter, endKey);
+    getEndKeyWithFilter(dimensionFilter, endKey, endKeyList);
 
   }
 
@@ -885,7 +876,8 @@ public final class FilterUtil {
   }
 
   private static void getEndKeyWithFilter(
-      Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter, long[] endKey) {
+      Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter, long[] endKey,
+      List<long[]> endKeyList) {
     for (Map.Entry<CarbonDimension, List<DimColumnFilterInfo>> entry : dimensionFilter.entrySet()) {
       List<DimColumnFilterInfo> values = entry.getValue();
       if (null == values || !entry.getKey().hasEncoding(Encoding.DICTIONARY)) {
@@ -908,6 +900,9 @@ public final class FilterUtil {
               info.getFilterList().get(info.getFilterList().size() - 1);
         }
       }
+      long[] newEndKey = new long[endKey.length];
+      System.arraycopy(endKey, 0, newEndKey, 0, endKey.length);
+      endKeyList.add(newEndKey);
     }
 
   }
@@ -1157,8 +1152,42 @@ public final class FilterUtil {
     SortedMap<Integer, byte[]> setOfEndKeyByteArray = new TreeMap<Integer, byte[]>();
     SortedMap<Integer, byte[]> defaultStartValues = new TreeMap<Integer, byte[]>();
     SortedMap<Integer, byte[]> defaultEndValues = new TreeMap<Integer, byte[]>();
+    List<long[]> startKeyList = new ArrayList<long[]>();
+    List<long[]> endKeyList = new ArrayList<long[]>();
     traverseResolverTreeAndPopulateStartAndEndKeys(filterResolver, tableIdentifier,
-        segmentProperties, startKey, setOfStartKeyByteArray, endKey, setOfEndKeyByteArray);
+        segmentProperties, startKey, setOfStartKeyByteArray, endKey, setOfEndKeyByteArray,
+        startKeyList, endKeyList);
+    if (endKeyList.size() > 0) {
+      //get the new end key from list
+      for (int i = 0; i < endKey.length; i++) {
+        long[] endkeyColumnLevel = new long[endKeyList.size()];
+        int j = 0;
+        for (long[] oneEndKey : endKeyList) {
+          //get each column level end key
+          endkeyColumnLevel[j++] = oneEndKey[i];
+        }
+        Arrays.sort(endkeyColumnLevel);
+        // get the max one as end of this column level
+        endKey[i] = endkeyColumnLevel[endkeyColumnLevel.length - 1];
+      }
+    }
+
+    if (startKeyList.size() > 0) {
+      //get the new start key from list
+      for (int i = 0; i < startKey.length; i++) {
+        long[] startkeyColumnLevel = new long[startKeyList.size()];
+        int j = 0;
+        for (long[] oneStartKey : startKeyList) {
+          //get each column level start key
+          startkeyColumnLevel[j++] = oneStartKey[i];
+        }
+        Arrays.sort(startkeyColumnLevel);
+        // get the min - 1 as start of this column level, for example if a block contains 5,6
+        // the filter is 6, but that block's start key is 5, if not -1, this block will missing.
+        startKey[i] = startkeyColumnLevel[0] - 1;
+      }
+    }
+
     fillDefaultStartValue(defaultStartValues, segmentProperties);
     fillDefaultEndValue(defaultEndValues, segmentProperties);
     fillNullValuesStartIndexWithDefaultKeys(setOfStartKeyByteArray, segmentProperties);
@@ -1283,18 +1312,22 @@ public final class FilterUtil {
       FilterResolverIntf filterResolverTree, AbsoluteTableIdentifier tableIdentifier,
       SegmentProperties segmentProperties, long[] startKeys,
       SortedMap<Integer, byte[]> setOfStartKeyByteArray, long[] endKeys,
-      SortedMap<Integer, byte[]> setOfEndKeyByteArray) throws QueryExecutionException {
+      SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> startKeyList,
+      List<long[]> endKeyList) throws QueryExecutionException {
     if (null == filterResolverTree) {
       return;
     }
     traverseResolverTreeAndPopulateStartAndEndKeys(filterResolverTree.getLeft(), tableIdentifier,
-        segmentProperties, startKeys, setOfStartKeyByteArray, endKeys, setOfEndKeyByteArray);
-
-    filterResolverTree.getStartKey(segmentProperties, startKeys, setOfStartKeyByteArray);
-    filterResolverTree.getEndKey(segmentProperties, tableIdentifier, endKeys, setOfEndKeyByteArray);
+        segmentProperties, startKeys, setOfStartKeyByteArray, endKeys, setOfEndKeyByteArray,
+        startKeyList, endKeyList);
+    filterResolverTree.getStartKey(segmentProperties, tableIdentifier, startKeys,
+        setOfStartKeyByteArray, startKeyList);
+    filterResolverTree.getEndKey(segmentProperties, tableIdentifier, endKeys, setOfEndKeyByteArray,
+        endKeyList);
 
     traverseResolverTreeAndPopulateStartAndEndKeys(filterResolverTree.getRight(), tableIdentifier,
-        segmentProperties, startKeys, setOfStartKeyByteArray, endKeys, setOfEndKeyByteArray);
+        segmentProperties, startKeys, setOfStartKeyByteArray, endKeys, setOfEndKeyByteArray,
+        startKeyList, endKeyList);
   }
 
   /**

--- a/core/src/main/java/org/carbondata/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/scan/filter/FilterUtil.java
@@ -670,8 +670,7 @@ public final class FilterUtil {
    * @return long[] start key
    */
   public static void getStartKey(Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter,
-      AbsoluteTableIdentifier tableIdentifier, long[] startKey, SegmentProperties segmentProperties,
-      List<long[]> startKeyList) throws QueryExecutionException {
+      long[] startKey, List<long[]> startKeyList) throws QueryExecutionException {
     for(int i = 0; i < startKey.length; i++) {
       // The min surrogate key is 1, set it as the init value for starkey of each column level
       startKey[i] = 1;
@@ -697,8 +696,8 @@ public final class FilterUtil {
    * @return
    */
   public static void getStartKeyForNoDictionaryDimension(
-      DimColumnResolvedFilterInfo dimColResolvedFilterInfo, SegmentProperties segmentProperties,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList) {
+      DimColumnResolvedFilterInfo dimColResolvedFilterInfo,
+      SortedMap<Integer, byte[]> setOfStartKeyByteArray) {
     Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter =
         dimColResolvedFilterInfo.getDimensionResolvedFilterInstance();
     // step 1
@@ -752,8 +751,8 @@ public final class FilterUtil {
    * @return end key array
    */
   public static void getEndKeyForNoDictionaryDimension(
-      DimColumnResolvedFilterInfo dimColResolvedFilterInfo, SegmentProperties segmentProperties,
-      SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList) {
+      DimColumnResolvedFilterInfo dimColResolvedFilterInfo,
+      SortedMap<Integer, byte[]> setOfEndKeyByteArray) {
 
     Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionFilter =
         dimColResolvedFilterInfo.getDimensionResolvedFilterInstance();

--- a/core/src/main/java/org/carbondata/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/scan/filter/FilterUtil.java
@@ -1319,8 +1319,7 @@ public final class FilterUtil {
     traverseResolverTreeAndPopulateStartAndEndKeys(filterResolverTree.getLeft(), tableIdentifier,
         segmentProperties, startKeys, setOfStartKeyByteArray, endKeys, setOfEndKeyByteArray,
         startKeyList, endKeyList);
-    filterResolverTree.getStartKey(segmentProperties, tableIdentifier, startKeys,
-        setOfStartKeyByteArray, startKeyList);
+    filterResolverTree.getStartKey(startKeys, setOfStartKeyByteArray, startKeyList);
     filterResolverTree.getEndKey(segmentProperties, tableIdentifier, endKeys, setOfEndKeyByteArray,
         endKeyList);
 

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/AndFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/AndFilterResolverImpl.java
@@ -39,14 +39,11 @@ public class AndFilterResolverImpl extends LogicalFilterResolverImpl {
     super(leftEvalutor, rightEvalutor, expression);
   }
 
-  @Override public void getStartKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier tableIdentifier, long[] startKeys,
+  @Override public void getStartKey(long[] startKeys,
       SortedMap<Integer, byte[]> noDicStartKeys, List<long[]> startKeyList)
       throws QueryExecutionException {
-    leftEvalutor.getStartKey(segmentProperties, tableIdentifier, startKeys, noDicStartKeys,
-        startKeyList);
-    rightEvalutor.getStartKey(segmentProperties, tableIdentifier, startKeys, noDicStartKeys,
-        startKeyList);
+    leftEvalutor.getStartKey(startKeys, noDicStartKeys, startKeyList);
+    rightEvalutor.getStartKey(startKeys, noDicStartKeys, startKeyList);
   }
 
   @Override public void getEndKey(SegmentProperties segmentProperties,

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/AndFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/AndFilterResolverImpl.java
@@ -18,6 +18,7 @@
  */
 package org.carbondata.scan.filter.resolver;
 
+import java.util.List;
 import java.util.SortedMap;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
@@ -38,16 +39,21 @@ public class AndFilterResolverImpl extends LogicalFilterResolverImpl {
     super(leftEvalutor, rightEvalutor, expression);
   }
 
-  @Override public void getStartKey(SegmentProperties segmentProperties, long[] startKeys,
-      SortedMap<Integer, byte[]> noDicStartKeys) {
-    leftEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys);
-    rightEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys);
+  @Override public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier tableIdentifier, long[] startKeys,
+      SortedMap<Integer, byte[]> noDicStartKeys, List<long[]> startKeyList)
+      throws QueryExecutionException {
+    leftEvalutor.getStartKey(segmentProperties, tableIdentifier, startKeys, noDicStartKeys,
+        startKeyList);
+    rightEvalutor.getStartKey(segmentProperties, tableIdentifier, startKeys, noDicStartKeys,
+        startKeyList);
   }
 
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier tableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> noDicEndKeys) throws QueryExecutionException {
-    leftEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys);
-    rightEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys);
+      SortedMap<Integer, byte[]> noDicEndKeys, List<long[]> endKeyList)
+      throws QueryExecutionException {
+    leftEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys, endKeyList);
+    rightEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys, endKeyList);
   }
 }

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
@@ -186,11 +186,15 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
   /**
    * method will calculates the start key based on the filter surrogates
    */
-  public void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray) {
+  public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier absoluteTableIdentifier, long[] startKey,
+      SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
+      throws QueryExecutionException {
     if (null == dimColResolvedFilterInfo.getStarIndexKey()) {
+      FilterUtil.getStartKey(dimColResolvedFilterInfo.getDimensionResolvedFilterInstance(),
+          absoluteTableIdentifier, startKey, segmentProperties, startKeyList);
       FilterUtil.getStartKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties,
-          setOfStartKeyByteArray);
+          setOfStartKeyByteArray, startKeyList);
     }
   }
 
@@ -202,12 +206,13 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
    */
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier absoluteTableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> setOfEndKeyByteArray) throws QueryExecutionException {
+      SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList)
+      throws QueryExecutionException {
     if (null == dimColResolvedFilterInfo.getEndIndexKey()) {
       FilterUtil.getEndKey(dimColResolvedFilterInfo.getDimensionResolvedFilterInstance(),
-          absoluteTableIdentifier, endKeys, segmentProperties);
+          absoluteTableIdentifier, endKeys, segmentProperties, endKeyList);
       FilterUtil.getEndKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties,
-          setOfEndKeyByteArray);
+          setOfEndKeyByteArray, endKeyList);
     }
   }
 

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
@@ -186,8 +186,7 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
   /**
    * method will calculates the start key based on the filter surrogates
    */
-  public void getStartKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier absoluteTableIdentifier, long[] startKey,
+  public void getStartKey(long[] startKey,
       SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
       throws QueryExecutionException {
     if (null == dimColResolvedFilterInfo.getStarIndexKey()) {

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
@@ -192,9 +192,9 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
       throws QueryExecutionException {
     if (null == dimColResolvedFilterInfo.getStarIndexKey()) {
       FilterUtil.getStartKey(dimColResolvedFilterInfo.getDimensionResolvedFilterInstance(),
-          absoluteTableIdentifier, startKey, segmentProperties, startKeyList);
-      FilterUtil.getStartKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties,
-          setOfStartKeyByteArray, startKeyList);
+          startKey, startKeyList);
+      FilterUtil.getStartKeyForNoDictionaryDimension(dimColResolvedFilterInfo,
+          setOfStartKeyByteArray);
     }
   }
 
@@ -211,8 +211,8 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
     if (null == dimColResolvedFilterInfo.getEndIndexKey()) {
       FilterUtil.getEndKey(dimColResolvedFilterInfo.getDimensionResolvedFilterInstance(),
           absoluteTableIdentifier, endKeys, segmentProperties, endKeyList);
-      FilterUtil.getEndKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties,
-          setOfEndKeyByteArray, endKeyList);
+      FilterUtil.getEndKeyForNoDictionaryDimension(dimColResolvedFilterInfo,
+          setOfEndKeyByteArray);
     }
   }
 

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/FilterResolverIntf.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/FilterResolverIntf.java
@@ -73,9 +73,8 @@ public interface FilterResolverIntf extends Serializable {
    * @param startKey
    * @param setOfStartKeyByteArray
    */
-  void getStartKey(SegmentProperties segmentProperties, AbsoluteTableIdentifier tableIdentifier,
-      long[] startKey, SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
-      throws QueryExecutionException;
+  void getStartKey(long[] startKey, SortedMap<Integer, byte[]> setOfStartKeyByteArray,
+      List<long[]> startKeyList) throws QueryExecutionException;
 
   /**
    * API will read the end key based on the max surrogate of

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/FilterResolverIntf.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/FilterResolverIntf.java
@@ -19,6 +19,7 @@
 package org.carbondata.scan.filter.resolver;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.SortedMap;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
@@ -72,8 +73,9 @@ public interface FilterResolverIntf extends Serializable {
    * @param startKey
    * @param setOfStartKeyByteArray
    */
-  void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray);
+  void getStartKey(SegmentProperties segmentProperties, AbsoluteTableIdentifier tableIdentifier,
+      long[] startKey, SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
+      throws QueryExecutionException;
 
   /**
    * API will read the end key based on the max surrogate of
@@ -85,7 +87,7 @@ public interface FilterResolverIntf extends Serializable {
    * @throws QueryExecutionException
    */
   void getEndKey(SegmentProperties segmentProperties, AbsoluteTableIdentifier tableIdentifier,
-      long[] endKeys, SortedMap<Integer, byte[]> setOfEndKeyByteArray)
+      long[] endKeys, SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList)
       throws QueryExecutionException;
 
   /**

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/LogicalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/LogicalFilterResolverImpl.java
@@ -87,8 +87,7 @@ public class LogicalFilterResolverImpl implements FilterResolverIntf {
     return null;
   }
 
-  @Override public void getStartKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier tableIdentifier, long[] startKey,
+  @Override public void getStartKey(long[] startKey,
       SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
       throws QueryExecutionException {
 

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/LogicalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/LogicalFilterResolverImpl.java
@@ -19,6 +19,7 @@
 
 package org.carbondata.scan.filter.resolver;
 
+import java.util.List;
 import java.util.SortedMap;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
@@ -86,17 +87,21 @@ public class LogicalFilterResolverImpl implements FilterResolverIntf {
     return null;
   }
 
-  @Override public void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray) {
+  @Override public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier tableIdentifier, long[] startKey,
+      SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
+      throws QueryExecutionException {
 
   }
 
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier tableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> setOfEndKeyByteArray) throws QueryExecutionException {
-  }
+      SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList)
+      throws QueryExecutionException {
 
-  @Override public FilterExecuterType getFilterExecuterType() {
+    }
+
+    @Override public FilterExecuterType getFilterExecuterType() {
     switch (filterExpressionType) {
       case OR:
         return FilterExecuterType.OR;

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/RestructureFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/RestructureFilterResolverImpl.java
@@ -174,8 +174,9 @@ public class RestructureFilterResolverImpl implements FilterResolverIntf {
    * For restructure resolver no implementation is required for getting
    * the start key since it already has default values
    */
-  @Override public void getStartKey(SegmentProperties segmentProperties, long[] startKeys,
-      SortedMap<Integer, byte[]> noDicStartKeys) {
+  @Override public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier tableIdentifier, long[] startKeys,
+      SortedMap<Integer, byte[]> noDicStartKeys, List<long[]> startKeyList) {
 
   }
 
@@ -187,7 +188,7 @@ public class RestructureFilterResolverImpl implements FilterResolverIntf {
    */
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier tableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> noDicEndKeys) {
+      SortedMap<Integer, byte[]> noDicEndKeys, List<long[]> endKeyList) {
   }
 
   /**

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/RestructureFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/RestructureFilterResolverImpl.java
@@ -174,8 +174,7 @@ public class RestructureFilterResolverImpl implements FilterResolverIntf {
    * For restructure resolver no implementation is required for getting
    * the start key since it already has default values
    */
-  @Override public void getStartKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier tableIdentifier, long[] startKeys,
+  @Override public void getStartKey(long[] startKeys,
       SortedMap<Integer, byte[]> noDicStartKeys, List<long[]> startKeyList) {
 
   }

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -99,8 +99,7 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
    *
    * @return start IndexKey
    */
-  public void getStartKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier absoluteTableIdentifier, long[] startKey,
+  public void getStartKey(long[] startKey,
       SortedMap<Integer, byte[]> noDictStartKeys, List<long[]> startKeyList) {
     if (null == dimColEvaluatorInfoList.get(0).getStarIndexKey()) {
       try {

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -99,13 +99,19 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
    *
    * @return start IndexKey
    */
-  public void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> noDictStartKeys) {
+  public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier absoluteTableIdentifier, long[] startKey,
+      SortedMap<Integer, byte[]> noDictStartKeys, List<long[]> startKeyList) {
     if (null == dimColEvaluatorInfoList.get(0).getStarIndexKey()) {
-      FilterUtil.getStartKey(dimColEvaluatorInfoList.get(0), segmentProperties, startKey);
-      FilterUtil
-          .getStartKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
-              noDictStartKeys);
+      try {
+        FilterUtil.getStartKey(dimColEvaluatorInfoList.get(0).getDimensionResolvedFilterInstance(),
+            absoluteTableIdentifier, startKey, segmentProperties, startKeyList);
+        FilterUtil
+            .getStartKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
+                noDictStartKeys, startKeyList);
+      } catch (QueryExecutionException e) {
+        LOGGER.error("Can not get the start key during block prune");
+      }
     }
   }
 
@@ -116,17 +122,17 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
    */
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier absoluteTableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> noDicEndKeys) {
+      SortedMap<Integer, byte[]> noDicEndKeys, List<long[]> endKeyList) {
     if (null == dimColEvaluatorInfoList.get(0).getEndIndexKey()) {
       try {
         FilterUtil.getEndKey(dimColEvaluatorInfoList.get(0).getDimensionResolvedFilterInstance(),
-            absoluteTableIdentifier, endKeys, segmentProperties);
+            absoluteTableIdentifier, endKeys, segmentProperties, endKeyList);
         FilterUtil
             .getEndKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
-                noDicEndKeys);
+                noDicEndKeys, endKeyList);
       } catch (QueryExecutionException e) {
         // TODO Auto-generated catch block
-        e.printStackTrace();
+        LOGGER.error("Can not get the end key during block prune");
       }
     }
   }

--- a/core/src/main/java/org/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -105,10 +105,9 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
     if (null == dimColEvaluatorInfoList.get(0).getStarIndexKey()) {
       try {
         FilterUtil.getStartKey(dimColEvaluatorInfoList.get(0).getDimensionResolvedFilterInstance(),
-            absoluteTableIdentifier, startKey, segmentProperties, startKeyList);
+            startKey, startKeyList);
         FilterUtil
-            .getStartKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
-                noDictStartKeys, startKeyList);
+            .getStartKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), noDictStartKeys);
       } catch (QueryExecutionException e) {
         LOGGER.error("Can not get the start key during block prune");
       }
@@ -128,8 +127,7 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
         FilterUtil.getEndKey(dimColEvaluatorInfoList.get(0).getDimensionResolvedFilterInstance(),
             absoluteTableIdentifier, endKeys, segmentProperties, endKeyList);
         FilterUtil
-            .getEndKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
-                noDicEndKeys, endKeyList);
+            .getEndKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), noDicEndKeys);
       } catch (QueryExecutionException e) {
         // TODO Auto-generated catch block
         LOGGER.error("Can not get the end key during block prune");

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.carbondata.spark.testsuite.blockprune
+
+import java.io.{DataOutputStream, File}
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.carbondata.core.datastorage.store.impl.FileFactory
+import org.scalatest.BeforeAndAfterAll
+
+/**
+  * This class contains test cases for block prune query
+  */
+class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
+  def currentPath: String = new File(this.getClass.getResource("/").getPath + "/../../")
+    .getCanonicalPath
+  val outputPath = currentPath + "/src/test/resources/block_prune_test.csv"
+  override def beforeAll {
+    // Since the data needed for plock prune is big, need to create a temp data file
+    val testData: Array[String]= new Array[String](3);
+    testData(0) = "a"
+    testData(1) = "b"
+    testData(2) = "c"
+    var writer: DataOutputStream = null
+    try {
+      val fileType = FileFactory.getFileType(outputPath)
+      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      if (!file.exists()) {
+        file.createNewFile()
+      }
+      writer = FileFactory.getDataOutputStream(outputPath, fileType)
+      for (i <- 0 to 2) {
+        for (j <- 0 to 240000) {
+          writer.writeBytes(testData(i) + "," + j + "\n")
+        }
+      }
+    } catch {
+      case ex: Exception =>
+        logError("Build test file for block prune failed" + ex)
+    } finally {
+      if (writer != null) {
+        try {
+          writer.close()
+        } catch {
+          case ex: Exception =>
+            logError("Close output stream catching exception:" + ex)
+        }
+      }
+    }
+
+    sql("DROP TABLE IF EXISTS blockprune")
+  }
+
+  test("test block prune query") {
+    sql(
+      """
+        CREATE TABLE IF NOT EXISTS blockprune (name string, id int)
+        STORED BY 'org.apache.carbondata.format'
+      """)
+    sql(
+        s"LOAD DATA LOCAL INPATH '$outputPath' INTO table blockprune options('FILEHEADER'='name,id')"
+      )
+    // data is in all 7 blocks
+    checkAnswer(
+      sql(
+        """
+          select name,count(name) as amount from blockprune
+          where name='c' or name='b' or name='a' group by name
+        """),
+      Seq(Row("a", 240001), Row("b", 240001), Row("c", 240001)))
+
+    // data only in middle 3/4/5 blocks
+    checkAnswer(
+      sql(
+        """
+          select name,count(name) as amount from blockprune
+          where name='b' group by name
+        """),
+      Seq(Row("b", 240001)))
+  }
+
+  override def afterAll {
+    // delete the temp data file
+    try {
+      val fileType = FileFactory.getFileType(outputPath)
+      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      if (file.exists()) {
+        file.delete()
+      }
+    } catch {
+      case ex: Exception =>
+        logError("Delete temp test data file for block prune catching exception:" + ex)
+    }
+    sql("DROP TABLE IF EXISTS blockprune")
+  }
+
+}


### PR DESCRIPTION
## Why raise this pr:

During block prune, endkey is always only decided by the last filter expression, this is a bug
and can lead wrong result,
For example, when load data whose dimension column is 120000 lines of 'a', 120000 lines of 'b', 120000 lines of 'c', if query like "select * from tablename where colname='c' or colname='b' or colname='a'" only 120000lines 'a' will be selected because of wrong endkey.

## How to solve this:

Fix the end key consider all the filter expression end key get max and start key get (min - 1) for each column level, using this to produce a new start key an a new endkey.

For more details please look at the test case.