### PR TITLE
[CARBONDATA-157]query exception when decimal(n,n) column has int filter

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/filter/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/FilterExpressionProcessor.java
@@ -215,6 +215,20 @@ public class FilterExpressionProcessor implements FilterProcessor {
       AbsoluteTableIdentifier tableIdentifier, Expression intermediateExpression) {
     ExpressionType filterExpressionType = expressionTree.getFilterExpressionType();
     BinaryExpression currentExpression = null;
+    if (filterExpressionType == ExpressionType.OR || filterExpressionType == ExpressionType.AND) {
+      Expression leftExpression = ((BinaryExpression) expressionTree).getLeft();
+      Expression rightExpression = ((BinaryExpression) expressionTree).getRight();
+      if (!(leftExpression instanceof BinaryExpression ||
+          leftExpression instanceof ConditionalExpression)) {
+        expressionTree = rightExpression;
+        filterExpressionType = rightExpression.getFilterExpressionType();
+      }
+      else if (!(rightExpression instanceof BinaryExpression ||
+          rightExpression instanceof ConditionalExpression)) {
+        expressionTree = leftExpression;
+        filterExpressionType = leftExpression.getFilterExpressionType();
+      }
+    }
     switch (filterExpressionType) {
       case OR:
         currentExpression = (BinaryExpression) expressionTree;

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
@@ -36,6 +36,8 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists hiveTable")
     sql("drop table if exists hiveBigDecimal")
     sql("drop table if exists carbonBigDecimal_2")
+    sql("drop table if exists testHiveDecimal")
+    sql("drop table if exists testCarbonDecimal")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.SORT_SIZE, "1")
@@ -48,6 +50,10 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
     sql("LOAD DATA local inpath './src/test/resources/decimalBoundaryDataHive.csv' INTO table hiveBigDecimal")
     sql("create table if not exists carbonBigDecimal_2 (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(30, 10)) STORED BY 'org.apache.carbondata.format'")
     sql("LOAD DATA LOCAL INPATH './src/test/resources/decimalBoundaryDataCarbon.csv' into table carbonBigDecimal_2")
+    sql("create table if not exists testHiveDecimal(ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(38, 38))row format delimited fields terminated by ','")
+    sql("LOAD DATA local inpath './src/test/resources/decimalBoundaryDataHive.csv' INTO table testHiveDecimal")
+    sql("create table if not exists testCarbonDecimal (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(38, 38)) STORED BY 'org.apache.carbondata.format'")
+    sql("LOAD DATA LOCAL INPATH './src/test/resources/decimalBoundaryDataCarbon.csv' into table testCarbonDecimal")
   }
 
   test("test detail query on big decimal column") {
@@ -187,11 +193,18 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
       sql("select avg(salary)/10 from hiveBigDecimal"))
   }
 
+  test("test decimal(n,n) when filter value is int") {
+    checkAnswer(sql("select salary from testHiveDecimal where salary=0.123 or salary=123 or salary<0.5"),
+      sql("select salary from testCarbonDecimal where salary=0.123 or salary=123 or salary<0.5"))
+  }
+
   override def afterAll {
     sql("drop table if exists carbonTable")
     sql("drop table if exists hiveTable")
     sql("drop table if exists hiveBigDecimal")
     sql("drop table if exists carbonBigDecimal_2")
+    sql("drop table if exists testHiveDecimal")
+    sql("drop table if exists testCarbonDecimal")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.SORT_SIZE,
@@ -200,5 +213,3 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
       CarbonCommonConstants.SORT_INTERMEDIATE_FILES_LIMIT_DEFAULT_VALUE)
   }
 }
-
-


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CARBONDATA-157


Because decimal(n,n) means only fractional part,no integer. so in spark optimizer, the filter expression decimalColumn=intValue is optimized to literal Expression(Null), and in carbon side,we do not judge on this literal Expression, so there is this exception. 
To resolve this, we should add judge on this.