### PR TITLE
[CARBONDATA-132] Fix the bug that the CSV file header exception can not be shown to user using beeline. 

### DIFF
--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.dataload
+
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterAll{
+  override def beforeAll {
+    sql("DROP TABLE IF EXISTS t3")
+    sql("""
+           CREATE TABLE IF NOT EXISTS t3
+           (ID Int, date Timestamp, country String,
+           name String, phonetype String, serialname String, salary Int)
+           STORED BY 'carbondata'
+           """)
+  }
+
+  test("test load data both file and ddl without fileheader exception") {
+    try {
+      sql(s"""
+           LOAD DATA LOCAL INPATH './src/test/resources/windows.csv' into table t3
+           """)
+      assert(false)
+    } catch {
+      case e: Exception =>
+        assert(e.getMessage.equals("DataLoad failure: CSV File provided is not proper. " +
+          "Column names in schema and csv header are not same. CSVFile Name : windows.csv"))
+    }
+  }
+
+  test("test load data ddl provided  wrong fileheader exception") {
+    try {
+      sql(s"""
+           LOAD DATA LOCAL INPATH './src/test/resources/windows.csv' into table t3
+           options('fileheader'='no_column')
+           """)
+      assert(false)
+    } catch {
+      case e: Exception =>
+        assert(e.getMessage.equals("DataLoad failure: CSV header provided in DDL is not proper. " +
+          "Column names in schema and CSV header are not the same."))
+    }
+  }
+
+  override def afterAll {
+    sql("DROP TABLE IF EXISTS t3")
+  }
+}

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
@@ -34,7 +34,7 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
            """)
   }
 
-  test("test load data both file and ddl without fileheader exception") {
+  test("test load data both file and ddl without file header exception") {
     try {
       sql(s"""
            LOAD DATA LOCAL INPATH './src/test/resources/windows.csv' into table t3
@@ -47,7 +47,7 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
     }
   }
 
-  test("test load data ddl provided  wrong fileheader exception") {
+  test("test load data ddl provided  wrong file header exception") {
     try {
       sql(s"""
            LOAD DATA LOCAL INPATH './src/test/resources/windows.csv' into table t3


### PR DESCRIPTION
## Why raise this pr:
**For bug fix: The exception that 'CSV File provided is not proper. Column names in schema and csv header are not same' can not be shown to beeline.**

For example, when data load is failed because of wrong csv file header in load DDL, the exception message only shows in executor side like "CSV header provided in DDL is not proper. Column names in schema and CSV header are not the same" but the **user using beeline can not get it from driver side because dirver only shows "Dataload Failure"** , it is very inconvenient for user to get the reason unless he check the executor log info.

## How to solve:
Get the Exception on driver side and parse the cause, get the casue message to driver. Show DataLoadingException is because that it is mainly about CSV file and wrapped in understandable message which can be shown to the user.

## How to test
Add new test cases:
1. If both ddl and file not have fileheader:
Beeline will show like : "DataLoad failure: CSV File provided is not proper. Column names in schema and csv header are not same. CSVFile Name : windows.csv"
2. If ddl did not provide the proper file header:
Beeline will show like :"DataLoad failure: CSV header provided in DDL is not proper. Column names in schema and CSV header are not the same."