### PR TITLE
[CARBONDATA-169]ColDict and All Dictionary should not be used together

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -1016,6 +1016,14 @@ class CarbonSqlParser()
       throw new MalformedCarbonCommandException(errorMessage)
     }
 
+    //  COLUMNDICT and ALL_DICTIONARY_PATH can not be used together.
+    if (options.exists(_._1.equalsIgnoreCase("COLUMNDICT")) &&
+      options.exists(_._1.equalsIgnoreCase("ALL_DICTIONARY_PATH"))) {
+      val errorMessage = "Error: COLUMNDICT and ALL_DICTIONARY_PATH can not be used together" +
+        " in options"
+      throw new MalformedCarbonCommandException(errorMessage)
+    }
+
     // check for duplicate options
     val duplicateOptions = options filter {
       case (_, optionlist) => optionlist.size > 1

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -20,13 +20,13 @@ package org.apache.carbondata.spark.util
 
 import java.io.File
 
+import org.apache.carbondata.core.carbon.CarbonDataLoadSchema
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+import org.apache.carbondata.spark.load.CarbonLoadModel
 import org.apache.spark.sql.{CarbonEnv, CarbonRelation}
 import org.apache.spark.sql.common.util.CarbonHiveContext
 import org.apache.spark.sql.common.util.CarbonHiveContext.sql
 import org.apache.spark.sql.common.util.QueryTest
-
-import org.apache.carbondata.core.carbon.CarbonDataLoadSchema
-import org.apache.carbondata.spark.load.CarbonLoadModel
 
 import org.scalatest.BeforeAndAfterAll
 
@@ -203,6 +203,20 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     }
     DictionaryTestCaseUtil.checkDictionary(
       loadSqlRelation, "deviceInformationId", "10086")
+  }
+
+  test("COLUMNDICT and ALL_DICTIONARY_PATH can not be used together") {
+    try {
+      sql(s"""
+        LOAD DATA LOCAL INPATH "$complexFilePath1" INTO TABLE loadSqlTest
+        OPTIONS('COLUMNDICT'='$extColDictFilePath1',"ALL_DICTIONARY_PATH"='$extColDictFilePath1')
+        """)
+      assert(false)
+    } catch {
+      case ex: MalformedCarbonCommandException =>
+        assertResult(ex.getMessage)("Error: COLUMNDICT and ALL_DICTIONARY_PATH can not be used together " +
+          "in options")
+    }
   }
 
   override def afterAll: Unit = {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CARBONDATA-169

when user use columnDict and All Dictionary together, exception should be thrown.