### PR TITLE
[CARBONDATA-167]Fix that 'UndeclaredThrowableException' thrown instead of 'data loading failed' when load failed.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import java.io.File
+import java.lang.reflect.UndeclaredThrowableException
 import java.text.SimpleDateFormat
 import java.util
 import java.util.UUID
@@ -26,7 +27,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 import scala.util.Random
-
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -36,7 +36,6 @@ import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.util.FileUtils
 import org.codehaus.jackson.map.ObjectMapper
-
 import org.apache.carbondata.common.factory.CarbonCommonFactory
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.carbon.CarbonDataLoadSchema
@@ -1193,6 +1192,10 @@ private[sql] case class LoadTable(
       case mce: MalformedCarbonCommandException =>
         LOGGER.audit(s"Dataload failed for $dbName.$tableName. " + mce.getMessage)
         throw mce
+      case ude: UndeclaredThrowableException =>
+        LOGGER.audit(s"Dataload failed for $dbName.$tableName. " +
+          ude.getUndeclaredThrowable.getMessage)
+        throw ude.getUndeclaredThrowable
     } finally {
       if (carbonLock != null) {
         if (carbonLock.unlock()) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -27,6 +27,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 import scala.util.Random
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -36,6 +37,7 @@ import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.util.FileUtils
 import org.codehaus.jackson.map.ObjectMapper
+
 import org.apache.carbondata.common.factory.CarbonCommonFactory
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.carbon.CarbonDataLoadSchema


### PR DESCRIPTION
## Why raise this pr:
For bug fix:
The user using` beeline` when create a table named test and execute
` LOAD DATA INPATH  'hdfs://hacluster/test/chetan/vardhan.csv' INTO table test OPTIONS('DELIMITER'= ',' ,'QUOTECHAR'= '"', 'FILEHEADER '='~');` the fileheader is not proper and
 It will throws exception like:
`Error: java.lang.reflect.UndeclaredThrowableException (state=,code=0)`
**Actually it should tell "DataLoad failed" to user instead of throws such an exception.**

## How to solve:

Catch the  UndeclaredThrowableException and throw the cause wrapped in it which is carbon's real exception message to user.