### PR TITLE
[CARBONDATA-170] Delete the lock file once the unlocking is done.

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/HdfsFileLock.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/HdfsFileLock.java
@@ -68,7 +68,6 @@ public class HdfsFileLock extends AbstractCarbonLock {
   public HdfsFileLock(CarbonTableIdentifier tableIdentifier, String lockFile) {
     this(tableIdentifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + tableIdentifier
         .getTableName(), lockFile);
-    initRetry();
   }
 
   /* (non-Javadoc)
@@ -98,6 +97,12 @@ public class HdfsFileLock extends AbstractCarbonLock {
         dataOutputStream.close();
       } catch (IOException e) {
         return false;
+      } finally {
+        if (FileFactory.getCarbonFile(location, FileFactory.getFileType(location)).delete()) {
+          LOGGER.info("Deleted the lock file " + location);
+        } else {
+          LOGGER.error("Not able to delete the lock file " + location);
+        }
       }
     }
     return true;

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/LocalFileLock.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/LocalFileLock.java
@@ -62,9 +62,7 @@ public class LocalFileLock extends AbstractCarbonLock {
 
   public static final String tmpPath;
 
-  private String tableName;
-
-  private String databaseName;
+  private  String lockFilePath;
 
   /**
    * LOGGER for  logging the messages.
@@ -106,7 +104,7 @@ public class LocalFileLock extends AbstractCarbonLock {
       if (!FileFactory.isFileExist(location, FileFactory.getFileType(tmpPath))) {
         FileFactory.mkdirs(location, FileFactory.getFileType(tmpPath));
       }
-      String lockFilePath = location + CarbonCommonConstants.FILE_SEPARATOR +
+      lockFilePath = location + CarbonCommonConstants.FILE_SEPARATOR +
           lockFile;
       if (!FileFactory.isFileExist(lockFilePath, FileFactory.getFileType(location))) {
         FileFactory.createNewLockFile(lockFilePath, FileFactory.getFileType(location));
@@ -148,6 +146,13 @@ public class LocalFileLock extends AbstractCarbonLock {
       if (null != fileOutputStream) {
         try {
           fileOutputStream.close();
+          // deleting the lock file after releasing the lock.
+          if (FileFactory.getCarbonFile(lockFilePath, FileFactory.getFileType(lockFilePath))
+              .delete()) {
+            LOGGER.info("Successfully deleted the lock file " + lockFilePath);
+          } else {
+            LOGGER.error("Not able to delete the lock file " + lockFilePath);
+          }
         } catch (IOException e) {
           LOGGER.error(e.getMessage());
         }


### PR DESCRIPTION
Issue : The lock files which are used for locking purpose need to get deleted once lock is unlocked.

Solution : deleting the lock files after the unlock. 