### PR TITLE
[CARBONDATA-174]Fix the problem of hdfs lock and move the lock file inside the table folder.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -142,6 +142,14 @@ public final class CarbonCommonConstants {
    */
   public static final String LOAD_FOLDER = "Segment_";
   /**
+   * HDFSURL_PREFIX
+   */
+  public static final String HDFSURL_PREFIX = "hdfs://";
+  /**
+   * FS_DEFAULT_FS
+   */
+  public static final String FS_DEFAULT_FS = "fs.defaultFS";
+  /**
    * RESTructure Folder
    */
   public static final String RESTRUCTRE_FOLDER = "RS_";

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/HdfsFileLock.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/HdfsFileLock.java
@@ -55,7 +55,7 @@ public class HdfsFileLock extends AbstractCarbonLock {
     tmpPath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION,
                System.getProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION));
     if (!tmpPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX)) {
-      tmpPath += hdfsPath;
+      tmpPath = hdfsPath + tmpPath;
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/HdfsFileLock.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/HdfsFileLock.java
@@ -28,6 +28,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class is used to handle the HDFS File locking.
  * This is acheived using the concept of acquiring the data out stream using Append option.
@@ -46,8 +48,15 @@ public class HdfsFileLock extends AbstractCarbonLock {
   public static String tmpPath;
 
   static {
-    tmpPath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION,
+    Configuration conf = new Configuration(true);
+    String hdfsPath = conf.get(CarbonCommonConstants.FS_DEFAULT_FS);
+    // By default, we put the hdfs lock meta file for one table inside this table's store folder.
+    // If can not get the STORE_LOCATION, then use hadoop.tmp.dir .
+    tmpPath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION,
                System.getProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION));
+    if (!tmpPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX)) {
+      tmpPath += hdfsPath;
+    }
   }
 
   /**


### PR DESCRIPTION
## Why raise this pr
1. The hdfs lock file for one table should be put inside this table's store path, this is more reasonable, and if the store path is not set, then we put it into hadoop.tmp.dir.
For example: if the store path of carbon on hdfs is /user/hive/warehouse/carbon.store, then the lock file for this table woud be: /user/hive/warehouse/carbon.store/default/table_name/meta.lock
2. This bug is found by : Some times, hadoop configured wrong hadoop.tmp.dir, hadoop can still work normally, but carbon's hdfs lock can not work normally, it will throws exception: "Table is locked for updation. Please try after some time".


So, we should use the table store path as the first choice and reduce the coupling between hadoop conf and carbon.
