### PR TITLE
[CARBONDATA-180]give proper error message when dataloading with wrong delimiter or fileheader

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -689,6 +689,12 @@ object GlobalDictionaryUtil extends Logging {
           generatePredefinedColDictionary(colDictFilePath, table,
             dimensions, carbonLoadModel, sqlContext, hdfsLocation, dictfolderPath)
         }
+        if (headers.length > df.columns.length) {
+          val msg = "The number of columns in the file header do not match the number of " +
+            "columns in the data file; Either delimiter or fileheader provided is not correct"
+          logError(msg)
+          throw new DataLoadingException(msg)
+        }
         // use fact file to generate global dict
         val (requireDimension, requireColumnNames) = pruneDimensions(dimensions,
           headers, df.columns)
@@ -705,7 +711,7 @@ object GlobalDictionaryUtil extends Logging {
           // check result status
           checkStatus(carbonLoadModel, sqlContext, model, statusList)
         } else {
-          logInfo("have no column need to generate global dictionary in Fact file")
+          logInfo("No column found for generating global dictionary in source data files")
         }
         // generate global dict from dimension file
         if (carbonLoadModel.getDimFolderPath != null) {
@@ -771,7 +777,7 @@ object GlobalDictionaryUtil extends Logging {
       }
     } catch {
       case ex: Exception =>
-        logError("generate global dictionary failed")
+        logError("generate global dictionary failed", ex)
         throw ex
     }
   }


### PR DESCRIPTION
**1 Issue Description**
JIRA link [CARBONDATA-180](https://issues.apache.org/jira/browse/CARBONDATA-180)

**2 Cause Analysis**
When dataloading with wrong delimiter or fileheader,  We get less columns  from input file than columns in fileheader property.

**3 Solution**
We can check the columns in fileheader property and the columns in input files. If these two columns list are different, we can stop dataloading flow and give a proper error message.  

**4 Impact**
DataLoading