### PR TITLE
Handle all dictionary exception more properly

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -199,9 +199,9 @@ public final class CarbonCommonConstants {
    */
   public static final String MEMBER_DEFAULT_VAL = "@NU#LL$!";
   /**
-   * BLANK_LINE_FLAG
+   * DEFAULT_COLUMN_NAME
    */
-  public static final String BLANK_LINE_FLAG = "@NU#LL$!BLANKLINE";
+  public static final String DEFAULT_COLUMN_NAME = "@NU#LL$!COLUMN";
   /**
    * FILE STATUS IN-PROGRESS
    */

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/filesystem/LocalCarbonFile.java
@@ -86,7 +86,10 @@ public class LocalCarbonFile implements CarbonFile {
   }
 
   @Override public boolean exists() {
-    return file.exists();
+    if (file != null) {
+      return file.exists();
+    }
+    return false;
   }
 
   @Override public String getCanonicalPath() {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -592,7 +592,7 @@ object GlobalDictionaryUtil extends Logging {
         .map(x => {
         val tokens = x.split("" + CSVWriter.DEFAULT_SEPARATOR)
         if (tokens.size != 2) {
-          logError("[ALL_DICTIONARY] Read a bad dictionary record: " + x)
+          logError("Read a bad dictionary record: " + x)
         }
         var columnName: String = CarbonCommonConstants.DEFAULT_COLUMN_NAME
         var value: String = ""
@@ -601,7 +601,7 @@ object GlobalDictionaryUtil extends Logging {
           value = tokens(1)
         } catch {
           case ex: Exception =>
-            logError("[ALL_DICTIONARY] Reset bad dictionary record as default value")
+            logError("Reset bad dictionary record as default value")
         }
         (columnName, value)
       })
@@ -613,7 +613,7 @@ object GlobalDictionaryUtil extends Logging {
         .filter(x => requireColumnsList.contains(x._1))
     } catch {
       case ex: Exception =>
-        logError("[ALL_DICTIONARY] Read dictionary files failed. Caused by" + ex.getMessage)
+        logError("Read dictionary files failed. Caused by: " + ex.getMessage)
         throw ex
     }
     allDictionaryRdd
@@ -637,26 +637,26 @@ object GlobalDictionaryUtil extends Logging {
           file.getName.endsWith(dictExt) && file.getSize > 0)) {
           true
         } else {
-          logWarning("[ALL_DICTIONARY] No dictionary files found or empty dictionary files! " +
+          logWarning("No dictionary files found or empty dictionary files! " +
             "Won't generate new dictionary.")
           false
         }
       } else {
         throw new FileNotFoundException(
-          "[ALL_DICTIONARY] The given dictionary file path not found!")
+          "The given dictionary file path is not found!")
       }
     } else {
       if (filePath.exists()) {
         if (filePath.getSize > 0) {
           true
         } else {
-          logWarning("[ALL_DICTIONARY] No dictionary files found or empty dictionary files! " +
+          logWarning("No dictionary files found or empty dictionary files! " +
             "Won't generate new dictionary.")
           false
         }
       } else {
         throw new FileNotFoundException(
-          "[ALL_DICTIONARY] The given dictionary file path not found!")
+          "The given dictionary file path is not found!")
       }
     }
   }
@@ -744,7 +744,7 @@ object GlobalDictionaryUtil extends Logging {
           }
         }
       } else {
-        logInfo("[ALL_DICTIONARY] Generate global dictionary from dictionary files!")
+        logInfo("Generate global dictionary from dictionary files!")
         val isNonempty = validateAllDictionaryPath(allDictionaryPath)
         if(isNonempty) {
           // fill the map[columnIndex -> columnName]
@@ -777,7 +777,7 @@ object GlobalDictionaryUtil extends Logging {
             // check result status
             checkStatus(carbonLoadModel, sqlContext, model, statusList)
           } else {
-            logInfo("[ALL_DICTIONARY] have no column need to generate global dictionary")
+            logInfo("have no column need to generate global dictionary")
           }
         }
       }


### PR DESCRIPTION
# Why rasied this pr?

When using all dictionary, if we give a wrong dictionary file path, or dictionary file include bad record,
carbon should deal with them properly.
# How to solve?

1.when give a wrong dictionary file path, throw file not found exception
2.when dictionary file include bad record,log error, and replace the bad record as default value.