### PR TITLE
When query result is null, getPartitions function should return empty Arrary[Partition]

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -157,14 +157,10 @@ class CarbonScanRDD[V: ClassTag](
         }
       } else {
         logInfo("No blocks identified to scan")
-        val nodesPerBlock = new util.ArrayList[TableBlockInfo]()
-        result.add(new CarbonSparkPartition(id, 0, Seq("").toArray, nodesPerBlock))
       }
     }
     else {
       logInfo("No valid segments found to scan")
-      val nodesPerBlock = new util.ArrayList[TableBlockInfo]()
-      result.add(new CarbonSparkPartition(id, 0, Seq("").toArray, nodesPerBlock))
     }
     result.toArray(new Array[Partition](result.size()))
   }


### PR DESCRIPTION
# Why rasied this pr?
For query, it will call CarbonScanRdd, when used filter, if getSplits result is empty, then no need to compute

# How to solve?
when getSplits result is empty, no need to add "new CarbonSparkPartition" to result list