### PR TITLE
[CARBONDATA-186] Except compaction all other alter operations on carbon table will be unsupported.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -152,7 +152,8 @@ case class CarbonMergerMapping(storeLocation: String, hdfsStoreLocation: String,
 case class NodeInfo(TaskId: String, noOfBlocks: Int)
 
 
-case class AlterTableModel(dbName: Option[String], tableName: String, compactionType: String)
+case class AlterTableModel(dbName: Option[String], tableName: String,
+  compactionType: String, alterSql: String)
 
 case class CompactionModel(compactionSize: Long,
   compactionType: CompactionType,

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
@@ -44,6 +44,28 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbontable")
   }
   
+  test("Test table rename operation on carbon table and on hive table") {
+    sql("create table hivetable(test1 int, test2 array<String>,test3 array<bigint>,"+
+        "test4 array<int>,test5 array<decimal>,test6 array<timestamp>,test7 array<double>)"+
+        "row format delimited fields terminated by ',' collection items terminated by '$' map keys terminated by ':'")
+    sql("alter table hivetable rename To hiveRenamedTable")
+    sql("create table carbontable(test1 int, test2 array<String>,test3 array<bigint>,"+
+        "test4 array<int>,test5 array<decimal>,test6 array<timestamp>,test7 array<double>)"+
+        "STORED BY 'org.apache.carbondata.format'")
+    sql("alter table carbontable compact 'minor'")
+    try {
+      sql("alter table carbontable rename To carbonRenamedTable")
+      assert(false)
+    } catch {
+      case e : MalformedCarbonCommandException => {
+        assert(e.getMessage.equals("Unsupported alter operation on carbon table"))
+      }
+    }
+    sql("drop table if exists hiveRenamedTable")
+    sql("drop table if exists carbontable")
+  }
+
+  
   test("test carbon table create with complex datatype as dictionary exclude") {
     try {
       sql("create table carbontable(id int, name string, dept string, mobile array<string>, "+


### PR DESCRIPTION
Reason: As Carbon table will not support alter operations except compaction, all the alter operations on carbon table should be skipped and error message should be displayed as "Unsupported alter operation on carbon table"
Whereas if the alter operation is on hive table, it should be transferred to hive for performing the operation.