### PR TITLE
[CARBONDATA-187]Fix the bug that when using Decimal type as dictionary the generated surrogate key would mismatch for the same values during increment load.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/tasks/DictionaryWriterTask.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/tasks/DictionaryWriterTask.scala
@@ -63,15 +63,13 @@ class DictionaryWriterTask(valuesBuffer: mutable.HashSet[String],
       if (values.length >= 1) {
         if (model.dictFileExists(columnIndex)) {
           for (value <- values) {
-            if (dictionary.getSurrogateKey(value) ==
-                CarbonCommonConstants.INVALID_SURROGATE_KEY) {
-              val parsedValue = org.apache.carbondata.core.util.DataTypeUtil
-                .normalizeColumnValueForItsDataType(value,
-                  model.primDimensions(columnIndex))
-              if (null != parsedValue) {
-                writer.write(parsedValue)
-                distinctValues.add(parsedValue)
-              }
+            val parsedValue = org.apache.carbondata.core.util.DataTypeUtil
+              .normalizeColumnValueForItsDataType(value,
+                model.primDimensions(columnIndex))
+            if (null != parsedValue && dictionary.getSurrogateKey(parsedValue) ==
+              CarbonCommonConstants.INVALID_SURROGATE_KEY) {
+              writer.write(parsedValue)
+              distinctValues.add(parsedValue)
             }
           }
 


### PR DESCRIPTION
## Why raise this pr?
**Fix bug: when using Decimal type as dictionary gen surrogate key will mismatch for the same values during increment load.**
For example, when we specify Decimal type column using dictionary, as the using of `DataTypeUtil.normalizeColumnValueForItsDataType`, deciaml data for example 45, if we specify the precision of this column as 3, parsedValue would be 45.000, and this  45.000 would be written into dic file by writer.write(parsedValue). As a result, the second time we load the same data 45, dictionary.getSurrogateKey(value) would compare the value with dic value, but here the value is 45, our dic value is 45.000 stored as string, so dic would think that i don not have 45, this would lead to repeated values in dic.
The dic would be like this: @NU#LL$!100.050 100.055 45.000 100.050 45.000,  this is a bug.
## How to solve this?
Before check the surrogate key, using his parsedValue as value to check, this would not take 45 itself as different value.
## How to test
Pass the exist test cases.