### PR TITLE
[CARBONDATA-189] Drop database cascade should be restricted

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -59,6 +59,7 @@ class CarbonSqlParser()
   protected val BEFORE = carbonKeyWord("BEFORE")
   protected val BY = carbonKeyWord("BY")
   protected val CARDINALITY = carbonKeyWord("CARDINALITY")
+  protected val CASCADE = carbonKeyWord("CASCADE")
   protected val CLASS = carbonKeyWord("CLASS")
   protected val CLEAN = carbonKeyWord("CLEAN")
   protected val COLS = carbonKeyWord("COLS")
@@ -67,6 +68,7 @@ class CarbonSqlParser()
   protected val CUBE = carbonKeyWord("CUBE")
   protected val CUBES = carbonKeyWord("CUBES")
   protected val DATA = carbonKeyWord("DATA")
+  protected val DATABASE = carbonKeyWord("DATABASE")
   protected val DATABASES = carbonKeyWord("DATABASES")
   protected val DELETE = carbonKeyWord("DELETE")
   protected val DELIMITER = carbonKeyWord("DELIMITER")
@@ -109,6 +111,7 @@ class CarbonSqlParser()
   protected val PARTITIONER = carbonKeyWord("PARTITIONER")
   protected val QUOTECHAR = carbonKeyWord("QUOTECHAR")
   protected val RELATION = carbonKeyWord("RELATION")
+  protected val SCHEMA = carbonKeyWord("SCHEMA")
   protected val SCHEMAS = carbonKeyWord("SCHEMAS")
   protected val SHOW = carbonKeyWord("SHOW")
   protected val TABLES = carbonKeyWord("TABLES")
@@ -202,7 +205,7 @@ class CarbonSqlParser()
   override protected lazy val start: Parser[LogicalPlan] = explainPlan | startCommand
 
   protected lazy val startCommand: Parser[LogicalPlan] =
-    loadManagement | describeTable | showLoads | alterTable | createTable
+    dropDatabaseCascade | loadManagement | describeTable | showLoads | alterTable | createTable
 
   protected lazy val loadManagement: Parser[LogicalPlan] = deleteLoadsByID | deleteLoadsByLoadDate |
     cleanFiles | loadDataNew
@@ -1342,4 +1345,9 @@ class CarbonSqlParser()
       }
     }
 
+  protected lazy val dropDatabaseCascade: Parser[LogicalPlan] =
+    DROP ~> (DATABASE|SCHEMA) ~> opt(IF ~> EXISTS) ~> ident ~> CASCADE <~ opt(";") ^^ {
+      case cascade => throw new MalformedCarbonCommandException(
+          "Unsupported cascade operation in drop database command")
+    }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -1348,6 +1348,6 @@ class CarbonSqlParser()
   protected lazy val dropDatabaseCascade: Parser[LogicalPlan] =
     DROP ~> (DATABASE|SCHEMA) ~> opt(IF ~> EXISTS) ~> ident ~> CASCADE <~ opt(";") ^^ {
       case cascade => throw new MalformedCarbonCommandException(
-          "Unsupported cascade operation in drop database command")
+          "Unsupported cascade operation in drop database/schema command")
     }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.carbondata.spark.testsuite.deleteTable
 
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 import org.apache.spark.sql.common.util.CarbonHiveContext._
 import org.apache.spark.sql.common.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
@@ -44,6 +45,19 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
   test("drop table Test with new DDL") {
     sql("drop table table1")
 
+  }
+  
+  test("test drop database cascade command") {
+    sql("create database testdb")
+    try {
+      sql("drop database testdb cascade")
+      assert(false)
+    } catch {
+      case e : MalformedCarbonCommandException => {
+        assert(e.getMessage.equals("Unsupported cascade operation in drop database command"))
+      }
+    }
+    sql("drop database testdb")
   }
 
   // deletion case with if exists

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -54,7 +54,7 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
       assert(false)
     } catch {
       case e : MalformedCarbonCommandException => {
-        assert(e.getMessage.equals("Unsupported cascade operation in drop database command"))
+        assert(e.getMessage.equals("Unsupported cascade operation in drop database/schema command"))
       }
     }
     sql("drop database testdb")


### PR DESCRIPTION
Reason: Carbondata will not support "Drop database dbname cascade"
When user provides this command, carbon will validate and give below error message "Unsupported cascade operation in drop database command"