### PR TITLE
[CARBONDATA-160]Data mismatch issue in case of multiple segment with different dictionary key size

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
@@ -23,18 +23,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -68,17 +57,7 @@ import org.apache.carbondata.scan.expression.UnknownExpression;
 import org.apache.carbondata.scan.expression.conditional.ListExpression;
 import org.apache.carbondata.scan.expression.exception.FilterIllegalMemberException;
 import org.apache.carbondata.scan.expression.exception.FilterUnsupportedException;
-import org.apache.carbondata.scan.filter.executer.AndFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.DimColumnExecuterFilterInfo;
-import org.apache.carbondata.scan.filter.executer.ExcludeColGroupFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.ExcludeFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.FilterExecuter;
-import org.apache.carbondata.scan.filter.executer.IncludeColGroupFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.IncludeFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.OrFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.RestructureFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.RowLevelFilterExecuterImpl;
-import org.apache.carbondata.scan.filter.executer.RowLevelRangeTypeExecuterFacory;
+import org.apache.carbondata.scan.filter.executer.*;
 import org.apache.carbondata.scan.filter.intf.ExpressionType;
 import org.apache.carbondata.scan.filter.intf.FilterExecuterType;
 import org.apache.carbondata.scan.filter.intf.RowImpl;
@@ -659,6 +638,8 @@ public final class FilterUtil {
             keys[carbonDimension.getKeyOrdinal()] = surrogate;
             filterValuesList
                 .add(getMaskedKey(rangesForMaskedByte, blockLevelKeyGenerator.generateKey(keys)));
+          } else {
+            break;
           }
         } catch (KeyGenException e) {
           LOGGER.error(e.getMessage());

--- a/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
@@ -23,7 +23,18 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -57,7 +68,17 @@ import org.apache.carbondata.scan.expression.UnknownExpression;
 import org.apache.carbondata.scan.expression.conditional.ListExpression;
 import org.apache.carbondata.scan.expression.exception.FilterIllegalMemberException;
 import org.apache.carbondata.scan.expression.exception.FilterUnsupportedException;
-import org.apache.carbondata.scan.filter.executer.*;
+import org.apache.carbondata.scan.filter.executer.AndFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.DimColumnExecuterFilterInfo;
+import org.apache.carbondata.scan.filter.executer.ExcludeColGroupFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.ExcludeFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.FilterExecuter;
+import org.apache.carbondata.scan.filter.executer.IncludeColGroupFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.IncludeFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.OrFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.RestructureFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.RowLevelFilterExecuterImpl;
+import org.apache.carbondata.scan.filter.executer.RowLevelRangeTypeExecuterFacory;
 import org.apache.carbondata.scan.filter.intf.ExpressionType;
 import org.apache.carbondata.scan.filter.intf.FilterExecuterType;
 import org.apache.carbondata.scan.filter.intf.RowImpl;
@@ -111,7 +132,7 @@ public final class FilterUtil {
         case RESTRUCTURE:
           return new RestructureFilterExecuterImpl(
               filterExpressionResolverTree.getDimColResolvedFilterInfo(),
-              segmentProperties.getDimensionKeyGenerator());
+              segmentProperties);
         case ROWLEVEL_LESSTHAN:
         case ROWLEVEL_LESSTHAN_EQUALTO:
         case ROWLEVEL_GREATERTHAN_EQUALTO:
@@ -609,12 +630,23 @@ public final class FilterUtil {
     return columnFilterInfo;
   }
 
+  /**
+   * Below method will be used to covert the filter surrogate keys
+   * to mdkey
+   *
+   * @param dimColumnFilterInfo
+   * @param carbonDimension
+   * @param segmentProperties
+   * @return
+   */
   public static byte[][] getKeyArray(DimColumnFilterInfo dimColumnFilterInfo,
-      CarbonDimension carbonDimension, KeyGenerator blockLevelKeyGenerator) {
+      CarbonDimension carbonDimension, SegmentProperties segmentProperties) {
     if (!carbonDimension.hasEncoding(Encoding.DICTIONARY)) {
       return dimColumnFilterInfo.getNoDictionaryFilterValuesList()
           .toArray((new byte[dimColumnFilterInfo.getNoDictionaryFilterValuesList().size()][]));
     }
+    KeyGenerator blockLevelKeyGenerator = segmentProperties.getDimensionKeyGenerator();
+    int[] dimColumnsCardinality = segmentProperties.getDimColumnsCardinality();
     int[] keys = new int[blockLevelKeyGenerator.getDimCount()];
     List<byte[]> filterValuesList = new ArrayList<byte[]>(20);
     Arrays.fill(keys, 0);
@@ -623,9 +655,11 @@ public final class FilterUtil {
     if (null != dimColumnFilterInfo) {
       for (Integer surrogate : dimColumnFilterInfo.getFilterList()) {
         try {
-          keys[carbonDimension.getKeyOrdinal()] = surrogate;
-          filterValuesList
-              .add(getMaskedKey(rangesForMaskedByte, blockLevelKeyGenerator.generateKey(keys)));
+          if (surrogate <= dimColumnsCardinality[carbonDimension.getKeyOrdinal()]) {
+            keys[carbonDimension.getKeyOrdinal()] = surrogate;
+            filterValuesList
+                .add(getMaskedKey(rangesForMaskedByte, blockLevelKeyGenerator.generateKey(keys)));
+          }
         } catch (KeyGenException e) {
           LOGGER.error(e.getMessage());
         }
@@ -979,14 +1013,14 @@ public final class FilterUtil {
    * API will prepare the Keys from the surrogates of particular filter resolver
    *
    * @param filterValues
-   * @param blockKeyGenerator
+   * @param segmentProperties
    * @param dimension
    * @param dimColumnExecuterInfo
    */
   public static void prepareKeysFromSurrogates(DimColumnFilterInfo filterValues,
-      KeyGenerator blockKeyGenerator, CarbonDimension dimension,
+      SegmentProperties segmentProperties, CarbonDimension dimension,
       DimColumnExecuterFilterInfo dimColumnExecuterInfo) {
-    byte[][] keysBasedOnFilter = getKeyArray(filterValues, dimension, blockKeyGenerator);
+    byte[][] keysBasedOnFilter = getKeyArray(filterValues, dimension, segmentProperties);
     dimColumnExecuterInfo.setFilterKeys(keysBasedOnFilter);
 
   }

--- a/core/src/main/java/org/apache/carbondata/scan/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/executer/ExcludeFilterExecuterImpl.java
@@ -42,9 +42,8 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     this.dimColEvaluatorInfo = dimColEvaluatorInfo;
     dimColumnExecuterInfo = new DimColumnExecuterFilterInfo();
     this.segmentProperties = segmentProperties;
-    FilterUtil.prepareKeysFromSurrogates(dimColEvaluatorInfo.getFilterValues(),
-        segmentProperties.getDimensionKeyGenerator(), dimColEvaluatorInfo.getDimension(),
-        dimColumnExecuterInfo);
+    FilterUtil.prepareKeysFromSurrogates(dimColEvaluatorInfo.getFilterValues(), segmentProperties,
+        dimColEvaluatorInfo.getDimension(), dimColumnExecuterInfo);
   }
 
   @Override public BitSet applyFilter(BlocksChunkHolder blockChunkHolder) {
@@ -58,8 +57,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
       blockChunkHolder.getDimensionDataChunk()[blockIndex] = blockChunkHolder.getDataBlock()
           .getDimensionChunk(blockChunkHolder.getFileReader(), blockIndex);
     }
-    return getFilteredIndexes(
-        blockChunkHolder.getDimensionDataChunk()[blockIndex],
+    return getFilteredIndexes(blockChunkHolder.getDimensionDataChunk()[blockIndex],
         blockChunkHolder.getDataBlock().nodeSize());
   }
 

--- a/core/src/main/java/org/apache/carbondata/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -42,9 +42,9 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     this.dimColumnEvaluatorInfo = dimColumnEvaluatorInfo;
     this.segmentProperties = segmentProperties;
     dimColumnExecuterInfo = new DimColumnExecuterFilterInfo();
-    FilterUtil.prepareKeysFromSurrogates(dimColumnEvaluatorInfo.getFilterValues(),
-        segmentProperties.getDimensionKeyGenerator(), dimColumnEvaluatorInfo.getDimension(),
-        dimColumnExecuterInfo);
+    FilterUtil
+        .prepareKeysFromSurrogates(dimColumnEvaluatorInfo.getFilterValues(), segmentProperties,
+            dimColumnEvaluatorInfo.getDimension(), dimColumnExecuterInfo);
 
   }
 

--- a/core/src/main/java/org/apache/carbondata/scan/filter/executer/RestructureFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/executer/RestructureFilterExecuterImpl.java
@@ -20,21 +20,20 @@ package org.apache.carbondata.scan.filter.executer;
 
 import java.util.BitSet;
 
-import org.apache.carbondata.core.keygenerator.KeyGenerator;
+import org.apache.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.apache.carbondata.scan.filter.FilterUtil;
 import org.apache.carbondata.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 import org.apache.carbondata.scan.processor.BlocksChunkHolder;
-
 
 public class RestructureFilterExecuterImpl implements FilterExecuter {
 
   DimColumnExecuterFilterInfo dimColumnExecuterInfo;
 
   public RestructureFilterExecuterImpl(DimColumnResolvedFilterInfo dimColumnResolvedFilterInfo,
-      KeyGenerator blockKeyGenerator) {
+      SegmentProperties segmentProperties) {
     dimColumnExecuterInfo = new DimColumnExecuterFilterInfo();
     FilterUtil
-        .prepareKeysFromSurrogates(dimColumnResolvedFilterInfo.getFilterValues(), blockKeyGenerator,
+        .prepareKeysFromSurrogates(dimColumnResolvedFilterInfo.getFilterValues(), segmentProperties,
             dimColumnResolvedFilterInfo.getDimension(), dimColumnExecuterInfo);
   }
 

--- a/core/src/main/java/org/apache/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -88,7 +88,7 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
         .get(0).getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
       return FilterUtil.getKeyArray(this.dimColEvaluatorInfoList.get(0).getFilterValues(),
           this.dimColEvaluatorInfoList.get(0).getDimension(),
-          segmentProperties.getDimensionKeyGenerator());
+          segmentProperties);
     }
     return null;
 


### PR DESCRIPTION
Problem:In case of multiple segment and each segment keygenertaor key size is not same in that case when we are converting the surrogate key to mdkey values which are not present in the older segments using keygenertaor in that case  keygenerator is giving some values which is less than column cardinality 

Solutions: Need add only those surrogate keys which is less than equal to cardinality of the segment