### PR TITLE
[CARBONDATA-190]Data mismatch issue in case of filter query 

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
@@ -77,7 +77,7 @@ public class ColumnSchema implements Serializable {
   /**
    * Whether the column should use inverted index
    */
-  private boolean useInvertedIndex;
+  private boolean useInvertedIndex = true;
 
   /**
    * The group ID for column used for row format columns,


### PR DESCRIPTION
Issue steps:1. create table , then restart the server and then do data load, in that case filter query record count is not matching.
Problem: When user is creating any table and if user has not disabled inverted index false for any key column we are setting the inverted index true in column schema object. As we are not persisting this information in schema file, so after restarting the server useInvertedIndex property is false in columnschema object and in data loading column data is not sorted and in filter execution we are doing binary search, as data is not sorted binary search is failing and it is skipping some of the record.
Solution : In this pr default value is set to true. One more PR will be raised to handle inverted index disabled sceario. By default Inverted index will be enabled for all the column for better query performance