### PR TITLE
[CARBONDATA-193]Fix the bug that negative data compress is not properly when datatype is Double

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
@@ -54,6 +54,7 @@ import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressN
 import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressNoneInt;
 import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressNoneLong;
 import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressNoneShort;
+import org.apache.carbondata.core.datastorage.store.impl.data.uncompressed.DoubleArrayDataFileStore;
 
 public final class ValueCompressionUtil {
 
@@ -78,18 +79,18 @@ public final class ValueCompressionUtil {
   private static DataType getDataType(double value, int decimal, byte dataTypeSelected) {
     DataType dataType = DataType.DATA_DOUBLE;
     if (decimal == 0) {
-      if (value < Byte.MAX_VALUE) {
+      if (value < Byte.MAX_VALUE && value > Byte.MIN_VALUE) {
         dataType = DataType.DATA_BYTE;
-      } else if (value < Short.MAX_VALUE) {
+      } else if (value < Short.MAX_VALUE && value > Short.MIN_VALUE) {
         dataType = DataType.DATA_SHORT;
-      } else if (value < Integer.MAX_VALUE) {
+      } else if (value < Integer.MAX_VALUE && value > Integer.MIN_VALUE) {
         dataType = DataType.DATA_INT;
-      } else if (value < Long.MAX_VALUE) {
+      } else if (value < Long.MAX_VALUE && value > Long.MIN_VALUE) {
         dataType = DataType.DATA_LONG;
       }
     } else {
       if (dataTypeSelected == 1) {
-        if (value < Float.MAX_VALUE) {
+        if (value < Float.MAX_VALUE && value > Float.MIN_VALUE) {
           float floatValue = (float) value;
           if (floatValue - value != 0) {
             dataType = DataType.DATA_DOUBLE;
@@ -97,7 +98,7 @@ public final class ValueCompressionUtil {
           } else {
             dataType = DataType.DATA_FLOAT;
           }
-        } else if (value < Double.MAX_VALUE) {
+        } else if (value < Double.MAX_VALUE && value > Double.MIN_VALUE) {
           dataType = DataType.DATA_DOUBLE;
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
@@ -78,18 +78,18 @@ public final class ValueCompressionUtil {
   private static DataType getDataType(double value, int decimal, byte dataTypeSelected) {
     DataType dataType = DataType.DATA_DOUBLE;
     if (decimal == 0) {
-      if (value < Byte.MAX_VALUE && value > Byte.MIN_VALUE) {
+      if (value < Byte.MAX_VALUE) {
         dataType = DataType.DATA_BYTE;
-      } else if (value < Short.MAX_VALUE && value > Short.MIN_VALUE) {
+      } else if (value < Short.MAX_VALUE) {
         dataType = DataType.DATA_SHORT;
-      } else if (value < Integer.MAX_VALUE && value > Integer.MIN_VALUE) {
+      } else if (value < Integer.MAX_VALUE) {
         dataType = DataType.DATA_INT;
-      } else if (value < Long.MAX_VALUE && value > Long.MIN_VALUE) {
+      } else if (value < Long.MAX_VALUE) {
         dataType = DataType.DATA_LONG;
       }
     } else {
       if (dataTypeSelected == 1) {
-        if (value < Float.MAX_VALUE && value > Float.MIN_VALUE) {
+        if (value < Float.MAX_VALUE) {
           float floatValue = (float) value;
           if (floatValue - value != 0) {
             dataType = DataType.DATA_DOUBLE;
@@ -97,7 +97,7 @@ public final class ValueCompressionUtil {
           } else {
             dataType = DataType.DATA_FLOAT;
           }
-        } else if (value < Double.MAX_VALUE && value > Double.MIN_VALUE) {
+        } else if (value < Double.MAX_VALUE) {
           dataType = DataType.DATA_DOUBLE;
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
@@ -154,28 +154,31 @@ public final class ValueCompressionUtil {
       default:
         break;
     }
+    //Here we should use the Max abs as max to getDatatype, let's say -1 and -10000000, -1 is max,
+    //but we can't use -1 to getDatatype, we should use -10000000.
+    double absMaxValue = Math.max(Math.abs((double) maxValue), Math.abs((double) minValue));
     // None Decimal
     if (decimal == 0) {
-      if (getSize(getDataType((double) maxValue, decimal, dataTypeSelected)) > getSize(
+      if (getSize(getDataType(absMaxValue, decimal, dataTypeSelected)) > getSize(
           getDataType((double) maxValue - (double) minValue, decimal, dataTypeSelected))) {
         return new CompressionFinder(COMPRESSION_TYPE.MAX_MIN, DataType.DATA_DOUBLE,
             getDataType((double) maxValue - (double) minValue, decimal, dataTypeSelected));
-      } else if (getSize(getDataType((double) maxValue, decimal, dataTypeSelected)) < getSize(
+      } else if (getSize(getDataType(absMaxValue, decimal, dataTypeSelected)) < getSize(
               getDataType((double) maxValue - (double) minValue, decimal, dataTypeSelected))) {
         return new CompressionFinder(COMPRESSION_TYPE.NONE, DataType.DATA_DOUBLE,
                 getDataType((double) maxValue - (double) minValue, decimal, dataTypeSelected));
       } else {
         return new CompressionFinder(COMPRESSION_TYPE.NONE, DataType.DATA_DOUBLE,
-            getDataType((double) maxValue, decimal, dataTypeSelected));
+            getDataType(absMaxValue, decimal, dataTypeSelected));
       }
     }
     // decimal
     else {
-      DataType actualDataType = getDataType((double) maxValue, decimal, dataTypeSelected);
+      DataType actualDataType = getDataType(absMaxValue, decimal, dataTypeSelected);
       DataType diffDataType =
           getDataType((double) maxValue - (double) minValue, decimal, dataTypeSelected);
       DataType maxNonDecDataType =
-          getDataType(Math.pow(10, decimal) * (double) maxValue, 0, dataTypeSelected);
+          getDataType(Math.pow(10, decimal) * absMaxValue, 0, dataTypeSelected);
       DataType diffNonDecDataType =
           getDataType(Math.pow(10, decimal) * ((double) maxValue - (double) minValue), 0,
               dataTypeSelected);

--- a/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
@@ -54,7 +54,6 @@ import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressN
 import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressNoneInt;
 import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressNoneLong;
 import org.apache.carbondata.core.datastorage.store.compression.type.UnCompressNoneShort;
-import org.apache.carbondata.core.datastorage.store.impl.data.uncompressed.DoubleArrayDataFileStore;
 
 public final class ValueCompressionUtil {
 

--- a/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
@@ -78,18 +78,18 @@ public final class ValueCompressionUtil {
   private static DataType getDataType(double value, int decimal, byte dataTypeSelected) {
     DataType dataType = DataType.DATA_DOUBLE;
     if (decimal == 0) {
-      if (value < Byte.MAX_VALUE) {
+      if (value <= Byte.MAX_VALUE && value >= Byte.MIN_VALUE) {
         dataType = DataType.DATA_BYTE;
-      } else if (value < Short.MAX_VALUE) {
+      } else if (value <= Short.MAX_VALUE && value >= Short.MIN_VALUE) {
         dataType = DataType.DATA_SHORT;
-      } else if (value < Integer.MAX_VALUE) {
+      } else if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
         dataType = DataType.DATA_INT;
-      } else if (value < Long.MAX_VALUE) {
+      } else if (value <= Long.MAX_VALUE && value >= Long.MIN_VALUE) {
         dataType = DataType.DATA_LONG;
       }
     } else {
       if (dataTypeSelected == 1) {
-        if (value < Float.MAX_VALUE) {
+        if (value <= Float.MAX_VALUE && value >= Float.MIN_VALUE) {
           float floatValue = (float) value;
           if (floatValue - value != 0) {
             dataType = DataType.DATA_DOUBLE;
@@ -97,7 +97,7 @@ public final class ValueCompressionUtil {
           } else {
             dataType = DataType.DATA_FLOAT;
           }
-        } else if (value < Double.MAX_VALUE) {
+        } else if (value <= Double.MAX_VALUE && value >= Double.MIN_VALUE) {
           dataType = DataType.DATA_DOUBLE;
         }
       }
@@ -156,7 +156,8 @@ public final class ValueCompressionUtil {
     }
     //Here we should use the Max abs as max to getDatatype, let's say -1 and -10000000, -1 is max,
     //but we can't use -1 to getDatatype, we should use -10000000.
-    double absMaxValue = Math.max(Math.abs((double) maxValue), Math.abs((double) minValue));
+    double absMaxValue = Math.abs((double) maxValue) >= Math.abs((double) minValue) ?
+        (double) maxValue:(double) minValue;
     // None Decimal
     if (decimal == 0) {
       if (getSize(getDataType(absMaxValue, decimal, dataTypeSelected)) > getSize(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
@@ -105,6 +105,30 @@ class ValueCompressionDataTypeTestCase extends QueryTest with BeforeAndAfterAll 
     }
   }
 
+  test("When the values of Double datatype have both postive and negative values") {
+    val tempFilePath = "./src/test/resources/temp/doublePAN.csv"
+    try {
+      sql("drop table if exists doublePAN")
+      sql("drop table if exists doublePAN_hive")
+      sql("CREATE TABLE doublePAN (name String, value double) STORED BY 'org.apache.carbondata.format'")
+      sql("CREATE TABLE doublePAN_hive (name String, value double)row format delimited fields terminated by ','")
+      val data ="a,-7489.7976000000\nb,11234567489.797\nc,-11234567489.7\nd,-1.2\ne,2\nf,-11234567489.7976000000\ng,11234567489.7976000000"
+      writedata(tempFilePath, data)
+      sql(s"LOAD data local inpath '${tempFilePath}' into table doublePAN options('fileheader'='name,value')")
+      sql(s"LOAD data local inpath '${tempFilePath}' into table doublePAN_hive")
+
+      checkAnswer(sql("select * from doublePAN"),
+        sql("select * from doublePAN_hive"))
+    } catch{
+      case ex:Exception => ex.printStackTrace()
+        assert(false)
+    } finally {
+      sql("drop table if exists doublePAN")
+      sql("drop table if exists doublePAN_hive")
+      deleteFile(tempFilePath)
+    }
+  }
+
   def writedata(filePath: String, data: String) = {
     val dis = FileFactory.getDataOutputStream(filePath, FileFactory.getFileType(filePath))
     dis.writeBytes(data.toString())

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
@@ -81,6 +81,28 @@ class ValueCompressionDataTypeTestCase extends QueryTest with BeforeAndAfterAll 
     }
   }
 
+  test("When the values of Double datatype are negative values") {
+    val tempFilePath = "./src/test/resources/temp/doubleISnegtive.csv"
+    try {
+      sql("CREATE TABLE doubleISnegtive (name String, value double) STORED BY 'org.apache.carbondata.format'")
+      sql("CREATE TABLE doubleISnegtive_hive (name String, value double)row format delimited fields terminated by ','")
+      val data ="a,-7489.7976000000\nb,-11234567489.797\nc,-11234567489.7\nd,-1.2\ne,-2\nf,-11234567489.7976000000\ng,-11234567489.7976000000"
+      writedata(tempFilePath, data)
+      sql(s"LOAD data local inpath '${tempFilePath}' into table doubleISnegtive options('fileheader'='name,value')")
+      sql(s"LOAD data local inpath '${tempFilePath}' into table doubleISnegtive_hive")
+
+      checkAnswer(sql("select * from doubleISnegtive"),
+        sql("select * from doubleISnegtive_hive"))
+    } catch{
+      case ex:Exception => ex.printStackTrace()
+        assert(false)
+    } finally {
+      sql("drop table if exists doubleISnegtive")
+      sql("drop table if exists doubleISnegtive_hive")
+      deleteFile(tempFilePath)
+    }
+  }
+
   def writedata(filePath: String, data: String) = {
     val dis = FileFactory.getDataOutputStream(filePath, FileFactory.getFileType(filePath))
     dis.writeBytes(data.toString())

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
@@ -84,6 +84,8 @@ class ValueCompressionDataTypeTestCase extends QueryTest with BeforeAndAfterAll 
   test("When the values of Double datatype are negative values") {
     val tempFilePath = "./src/test/resources/temp/doubleISnegtive.csv"
     try {
+      sql("drop table if exists doubleISnegtive")
+      sql("drop table if exists doubleISnegtive_hive")
       sql("CREATE TABLE doubleISnegtive (name String, value double) STORED BY 'org.apache.carbondata.format'")
       sql("CREATE TABLE doubleISnegtive_hive (name String, value double)row format delimited fields terminated by ','")
       val data ="a,-7489.7976000000\nb,-11234567489.797\nc,-11234567489.7\nd,-1.2\ne,-2\nf,-11234567489.7976000000\ng,-11234567489.7976000000"

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -882,7 +882,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
    * @return it return no of value after decimal
    */
   private int getDecimalCount(double value) {
-    String strValue = BigDecimal.valueOf(Math.abs(value)).toPlainString();
+    String strValue = Double.toString(Math.abs(value));
     int integerPlaces = strValue.indexOf('.');
     int decimalPlaces = 0;
     if (-1 != integerPlaces) {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -882,7 +882,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
    * @return it return no of value after decimal
    */
   private int getDecimalCount(double value) {
-    String strValue = Double.toString(Math.abs(value));
+    String strValue = BigDecimal.valueOf(Math.abs(value)).toPlainString();
     int integerPlaces = strValue.indexOf('.');
     int decimalPlaces = 0;
     if (-1 != integerPlaces) {


### PR DESCRIPTION
## Why raise this pr?
**Fix bug: negative data compress is not properly when datatype is Double.**
For example, If the column datatype is double and it data is like this:
-7489.7976
-11234567490
-11234567490
-1.2
-2
-11234567490
-11234567490
-11234567490
-11234567490
**the query result would be all 0, this is a bug.**
## How to solve?
1. This bug is becasue we only consider the MAX value of this column is +values, we should use Math.max(Math.abs((double)maxValue), Math.abs((double)minValue)) to get the datatype instead of max, bacasue -1 > -1223434545454, but we shoudl use -1223434545454.
2. When we use the new max values, the former code only check +values, but never ensure the values should >= Datatype.Min, for example, when the max value is -200, it < Byte.MAX, the code let it use byte, but it <Byte.Min, this is wrong. We should both check the upper and lower limit for one datatype.

## How to test?
Added test case: test("When the values of Double datatype are negative values"), should pass all the exist cases and this new testcase, ensure carbon's output is the same to hive.