### PR TITLE
Add statistics for counting the size of the query result

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatistic.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatistic.java
@@ -20,6 +20,8 @@ package org.apache.carbondata.core.carbon.querystatistics;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Wrapper class to maintain the query statistics for each phase of the query
  */
@@ -44,6 +46,11 @@ public class QueryStatistic implements Serializable {
    * starttime of the phase
    */
   private long startTime;
+
+  /**
+   * total nums
+   */
+  private long count;
 
   public QueryStatistic() {
     this.startTime = System.currentTimeMillis();
@@ -73,6 +80,19 @@ public class QueryStatistic implements Serializable {
   }
 
   /**
+   * Below method will be used to add count statistic.
+   * For example total numbers of scan or result preparation
+   *
+   * @param message   statistic message
+   * @param count
+   */
+  public void addCountStatistic(String message, long count) {
+    this.timeTaken = -1;
+    this.message = message;
+    this.count = count;
+  }
+
+  /**
    * Below method will be used to get the statistic message, which will
    * be used to log
    *
@@ -80,6 +100,12 @@ public class QueryStatistic implements Serializable {
    * @return statistic message
    */
   public String getStatistics(String queryWithTaskId) {
-    return message + " for the taskid : " + queryWithTaskId + " Is : " + timeTaken;
+    if (timeTaken == -1) {
+      return message + " for the taskid : " + queryWithTaskId + " Is : " + count;
+    } else if (StringUtils.isEmpty(queryWithTaskId)){
+      return message + " Is : " + timeTaken;
+    } else {
+      return message + " for the taskid : " + queryWithTaskId + " Is : " + timeTaken;
+    }
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -212,11 +212,15 @@ class CarbonScanRDD[V: ClassTag](
         if (finished) {
           clearDictionaryCache(queryModel.getColumnToDictionaryMapping)
           if (null != queryModel.getStatisticsRecorder) {
-            val queryStatistic = new QueryStatistic
+            var queryStatistic = new QueryStatistic
             queryStatistic
               .addFixedTimeStatistic("Total Time taken to execute the query in executor Side",
                 System.currentTimeMillis - queryStartTime
               )
+            queryModel.getStatisticsRecorder.recordStatistics(queryStatistic);
+            // add the query result size statistics
+            queryStatistic = new QueryStatistic
+            queryStatistic.addCountStatistic("The record numbers of query result", recordCount)
             queryModel.getStatisticsRecorder.recordStatistics(queryStatistic);
             queryModel.getStatisticsRecorder.logStatistics();
           }
@@ -233,11 +237,15 @@ class CarbonScanRDD[V: ClassTag](
         if (queryModel.getLimit != -1 && recordCount >= queryModel.getLimit) {
           clearDictionaryCache(queryModel.getColumnToDictionaryMapping)
           if (null != queryModel.getStatisticsRecorder) {
-            val queryStatistic = new QueryStatistic
+            var queryStatistic = new QueryStatistic
             queryStatistic
               .addFixedTimeStatistic("Total Time taken to execute the query in executor Side",
                 System.currentTimeMillis - queryStartTime
               )
+            queryModel.getStatisticsRecorder.recordStatistics(queryStatistic);
+            // add the query result size statistics
+            queryStatistic = new QueryStatistic
+            queryStatistic.addCountStatistic("The record numbers of query result", recordCount)
             queryModel.getStatisticsRecorder.recordStatistics(queryStatistic);
             queryModel.getStatisticsRecorder.logStatistics();
           }


### PR DESCRIPTION
# Why rasie this pr?
Users want to know the total records sent from carbon to spark .
# How to solve?
add count statistics in the iterator
# How to test?
running query, and check the executor logs, it will print like the following:

`2016-08-31 15:01:27,270 | STATISTIC | [[Executor task launch worker-70][partitionID:automation;queryID:2421028889045981_0]] | The record numbers of query result for the taskid : 2421028889045981_0 Is : 13 | org.apache.carbondata.common.logging.impl.StandardLogService.statistic(StandardLogService.java:238)`