### PR TITLE
stop compaction flow after metadata updation failed

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
@@ -127,6 +127,8 @@ object Compactor {
           .error("Compaction request failed for table " + carbonLoadModel
             .getDatabaseName + "." + carbonLoadModel.getTableName
           )
+        throw new Exception("Compaction failed to update metadata for table " + carbonLoadModel
+            .getDatabaseName + "." + carbonLoadModel.getTableName)
       }
       else {
         logger


### PR DESCRIPTION
**1 Cause Analysis**
When the metadata updation failed,  it will do compaction again and again.

**2 Solution**
Throwing a exception to stop compaction flow.