### PR TITLE
[CARBONDATA-197]Changed List To Queue for storing block execution infos

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -18,12 +18,7 @@
  */
 package org.apache.carbondata.scan.executor.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -192,22 +187,27 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     return restructureInfos;
   }
 
-  protected List<BlockExecutionInfo> getBlockExecutionInfos(QueryModel queryModel)
+  protected Queue<BlockExecutionInfo> getBlockExecutionInfos(QueryModel queryModel)
       throws QueryExecutionException {
     initQuery(queryModel);
-    List<BlockExecutionInfo> blockExecutionInfoList = new ArrayList<BlockExecutionInfo>();
+    Queue<BlockExecutionInfo> blockExecutionInfoList =
+        new ArrayDeque<BlockExecutionInfo>(queryProperties.dataBlocks.size());
+    BlockExecutionInfo blockExecutionInfoForBlock = null;
     // fill all the block execution infos for all the blocks selected in
     // query
     // and query will be executed based on that infos
     for (int i = 0; i < queryProperties.dataBlocks.size(); i++) {
-      blockExecutionInfoList.add(
+      blockExecutionInfoForBlock =
           getBlockExecutionInfoForBlock(queryModel, queryProperties.dataBlocks.get(i),
               queryModel.getTableBlockInfos().get(i).getBlockletInfos().getStartBlockletNumber(),
               queryModel.getTableBlockInfos().get(i).getBlockletInfos()
-                  .getNumberOfBlockletToScan()));
+                  .getNumberOfBlockletToScan());
+      blockExecutionInfoList.add(blockExecutionInfoForBlock);
+      if (i == queryProperties.dataBlocks.size() - 1) {
+        queryProperties.complexDimensionInfoMap =
+            blockExecutionInfoForBlock.getComlexDimensionInfoMap();
+      }
     }
-    queryProperties.complexDimensionInfoMap =
-        blockExecutionInfoList.get(blockExecutionInfoList.size() - 1).getComlexDimensionInfoMap();
     if (null != queryModel.getStatisticsRecorder()) {
       QueryStatistic queryStatistic = new QueryStatistic();
       queryStatistic.addCountStatistic(QueryStatisticsConstants.SCAN_BLOCKS_NUM,

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
@@ -18,7 +18,7 @@
  */
 package org.apache.carbondata.scan.executor.impl;
 
-import java.util.List;
+import java.util.Queue;
 
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.scan.executor.exception.QueryExecutionException;
@@ -35,7 +35,7 @@ public class DetailQueryExecutor extends AbstractQueryExecutor {
 
   @Override public CarbonIterator<Object[]> execute(QueryModel queryModel)
       throws QueryExecutionException {
-    List<BlockExecutionInfo> blockExecutionInfoList = getBlockExecutionInfos(queryModel);
+    Queue<BlockExecutionInfo> blockExecutionInfoList = getBlockExecutionInfos(queryModel);
     return new DetailQueryResultIterator(blockExecutionInfoList, queryModel);
   }
 

--- a/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -70,7 +70,6 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
 
   protected boolean nextBatch = false;
 
-  
   /**
    * total time scan the blocks
    */
@@ -82,7 +81,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
   protected boolean isStatisticsRecorded;
 
   /**
-   *  QueryStatisticsRecorder
+   * QueryStatisticsRecorder
    */
   protected QueryStatisticsRecorder recorder;
 
@@ -138,9 +137,9 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
         statistic.addFixedTimeStatistic(QueryStatisticsConstants.SCAN_BLOCKS_TIME, totalScanTime);
         recorder.recordStatistics(statistic);
         isStatisticsRecorded = true;
-    }
+      }
       return false;
-  }
+    }
   }
 
   protected void updateDataBlockIterator() {

--- a/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -18,7 +18,7 @@
  */
 package org.apache.carbondata.scan.result.iterator;
 
-import java.util.List;
+import java.util.Queue;
 
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogService;
@@ -54,7 +54,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
   /**
    * execution info of the block
    */
-  protected List<BlockExecutionInfo> blockExecutionInfos;
+  protected Queue<BlockExecutionInfo> blockExecutionInfos;
 
   /**
    * number of cores which can be used
@@ -70,6 +70,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
 
   protected boolean nextBatch = false;
 
+  
   /**
    * total time scan the blocks
    */
@@ -85,7 +86,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
    */
   protected QueryStatisticsRecorder recorder;
 
-  public AbstractDetailQueryResultIterator(List<BlockExecutionInfo> infos, QueryModel queryModel) {
+  public AbstractDetailQueryResultIterator(Queue<BlockExecutionInfo> infos, QueryModel queryModel) {
     String batchSizeString =
         CarbonProperties.getInstance().getProperty(CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE);
     if (null != batchSizeString) {
@@ -137,9 +138,9 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
         statistic.addFixedTimeStatistic(QueryStatisticsConstants.SCAN_BLOCKS_TIME, totalScanTime);
         recorder.recordStatistics(statistic);
         isStatisticsRecorded = true;
-      }
-      return false;
     }
+      return false;
+  }
   }
 
   protected void updateDataBlockIterator() {
@@ -153,8 +154,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
 
   private DataBlockIteratorImpl getDataBlockIterator() {
     if(blockExecutionInfos.size() > 0) {
-      BlockExecutionInfo executionInfo = blockExecutionInfos.get(0);
-      blockExecutionInfos.remove(executionInfo);
+      BlockExecutionInfo executionInfo = blockExecutionInfos.poll();
       return new DataBlockIteratorImpl(executionInfo, fileReader, batchSize);
     }
     return null;

--- a/core/src/main/java/org/apache/carbondata/scan/result/iterator/DetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/result/iterator/DetailQueryResultIterator.java
@@ -18,7 +18,7 @@
  */
 package org.apache.carbondata.scan.result.iterator;
 
-import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,7 +43,7 @@ public class DetailQueryResultIterator extends AbstractDetailQueryResultIterator
 
   private final Object lock = new Object();
 
-  public DetailQueryResultIterator(List<BlockExecutionInfo> infos, QueryModel queryModel) {
+  public DetailQueryResultIterator(Queue<BlockExecutionInfo> infos, QueryModel queryModel) {
     super(infos, queryModel);
   }
 


### PR DESCRIPTION
Problem: we are maintaining block execution infos for each block in a list and in detail query executor we are removing it for execution. If number of infos in list is more than removal will be time taking operation as we are removing from to top index and it will sink every time.
Solution:Queue will be proper data structure for this scenario 
