### PR TITLE
[CARBONDATA-199]Fix the bug that when subquery with sort and filter the result is empty.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -218,7 +218,7 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
         case filter: Filter if !filter.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
           val attrsOnConds = new util.HashSet[AttributeReferenceWrapper]
           // In case the child is join then we cannot push down the filters so decode them earlier
-          if (filter.child.isInstanceOf[Join]) {
+          if (filter.child.isInstanceOf[Join] || filter.child.isInstanceOf[Sort]) {
             filter.condition.collect {
               case attr: AttributeReference =>
                 attrsOnConds.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
@@ -54,7 +54,7 @@ class SubqueryWithFilterAndSortTestCase extends QueryTest with BeforeAndAfterAll
 
   test("When the query has sub-query with sort and has 'like' filter") {
     try {
-      checkAnswer(sql("select name,id from (select * from subqueryfilterwithsort order by id)t where name like'name%' "),
+      checkAnswer(sql("select name,id from (select * from subqueryfilterwithsort order by id)t where name like 'name%' "),
         sql("select name,id from (select * from subqueryfilterwithsort_hive order by id)t where name like 'name%'"))
     } catch{
       case ex:Exception => ex.printStackTrace()

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
@@ -55,7 +55,7 @@ class SubqueryWithFilterAndSortTestCase extends QueryTest with BeforeAndAfterAll
   test("When the query has sub-query with sort and has 'like' filter") {
     try {
       checkAnswer(sql("select name,id from (select * from doubleISnegtive order by id)t where name like'name%' "),
-        sql("select name,id from (select * from doubleISnegtive order by id)t where name='name_c'"))
+        sql("select name,id from (select * from doubleISnegtive order by id)t where name like 'name%'"))
     } catch{
       case ex:Exception => ex.printStackTrace()
         assert(false)

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.detailquery
+
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.datastorage.store.impl.FileFactory
+import org.apache.carbondata.core.datastorage.store.impl.FileFactory.FileType
+
+class SubqueryWithFilterAndSortTestCase extends QueryTest with BeforeAndAfterAll {
+  val tempDirPath = "./src/test/resources/temp"
+  val tempFilePath = "./src/test/resources/temp/subqueryfilterwithsort.csv"
+
+  override def beforeAll {
+    FileFactory.mkdirs(tempDirPath,FileType.LOCAL)
+    sql("drop table if exists subqueryfilterwithsort")
+    sql("drop table if exists subqueryfilterwithsort_hive")
+    sql("CREATE TABLE subqueryfilterwithsort (name String, id int) STORED BY 'org.apache.carbondata.format'")
+    sql("CREATE TABLE subqueryfilterwithsort_hive (name String, id int)row format delimited fields terminated by ','")
+    val data ="name_a,1\nname_b,2\nname_c,3\nname_d,4\nname_e,5\nname_f,6"
+    writedata(tempFilePath, data)
+    sql(s"LOAD data local inpath '${tempFilePath}' into table subqueryfilterwithsort options('fileheader'='name,id')")
+    sql(s"LOAD data local inpath '${tempFilePath}' into table subqueryfilterwithsort_hive")
+  }
+
+  test("When the query has sub-query with sort and has '=' filter") {
+    try {
+      checkAnswer(sql("select name,id from (select * from doubleISnegtive order by id)t where name='name_c' "),
+        sql("select name,id from (select * from doubleISnegtive order by id)t where name='name_c'"))
+    } catch{
+      case ex:Exception => ex.printStackTrace()
+        assert(false)
+    }
+  }
+
+  test("When the query has sub-query with sort and has 'like' filter") {
+    try {
+      checkAnswer(sql("select name,id from (select * from doubleISnegtive order by id)t where name like'name%' "),
+        sql("select name,id from (select * from doubleISnegtive order by id)t where name='name_c'"))
+    } catch{
+      case ex:Exception => ex.printStackTrace()
+        assert(false)
+    }
+  }
+
+  def writedata(filePath: String, data: String) = {
+    val dis = FileFactory.getDataOutputStream(filePath, FileFactory.getFileType(filePath))
+    dis.writeBytes(data.toString())
+    dis.close()
+  }
+  def deleteFile(filePath: String) {
+    val file = FileFactory.getCarbonFile(filePath, FileFactory.getFileType(filePath))
+    file.delete()
+  }
+
+  override def afterAll {
+    sql("drop table if exists subqueryfilterwithsort")
+    sql("drop table if exists subqueryfilterwithsort_hive")
+    deleteFile(tempFilePath)
+    deleteFile(tempDirPath)
+  }
+
+}

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
@@ -44,8 +44,8 @@ class SubqueryWithFilterAndSortTestCase extends QueryTest with BeforeAndAfterAll
 
   test("When the query has sub-query with sort and has '=' filter") {
     try {
-      checkAnswer(sql("select name,id from (select * from doubleISnegtive order by id)t where name='name_c' "),
-        sql("select name,id from (select * from doubleISnegtive order by id)t where name='name_c'"))
+      checkAnswer(sql("select name,id from (select * from subqueryfilterwithsort order by id)t where name='name_c' "),
+        sql("select name,id from (select * from subqueryfilterwithsort_hive order by id)t where name='name_c'"))
     } catch{
       case ex:Exception => ex.printStackTrace()
         assert(false)
@@ -54,8 +54,8 @@ class SubqueryWithFilterAndSortTestCase extends QueryTest with BeforeAndAfterAll
 
   test("When the query has sub-query with sort and has 'like' filter") {
     try {
-      checkAnswer(sql("select name,id from (select * from doubleISnegtive order by id)t where name like'name%' "),
-        sql("select name,id from (select * from doubleISnegtive order by id)t where name like 'name%'"))
+      checkAnswer(sql("select name,id from (select * from subqueryfilterwithsort order by id)t where name like'name%' "),
+        sql("select name,id from (select * from subqueryfilterwithsort_hive order by id)t where name like 'name%'"))
     } catch{
       case ex:Exception => ex.printStackTrace()
         assert(false)

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
@@ -115,16 +115,16 @@ class ValueCompressionDataTypeTestCase extends QueryTest with BeforeAndAfterAll 
       val data ="a,-7489.7976000000\nb,11234567489.797\nc,-11234567489.7\nd,-1.2\ne,2\nf,-11234567489.7976000000\ng,11234567489.7976000000"
       writedata(tempFilePath, data)
       sql(s"LOAD data local inpath '${tempFilePath}' into table doublePAN options('fileheader'='name,value')")
-      sql(s"LOAD data local inpath '${tempFilePath}' into table doublePAN_hive")
+      sql(s"LOAD data local inpath '${tempFilePath}' into table double_hive")
 
-      checkAnswer(sql("select * from doublePAN"),
-        sql("select * from doublePAN_hive"))
+      checkAnswer(sql("select * from doubleISnegtive"),
+        sql("select * from doubleISnegtive_hive"))
     } catch{
       case ex:Exception => ex.printStackTrace()
         assert(false)
     } finally {
-      sql("drop table if exists doublePAN")
-      sql("drop table if exists doublePAN_hive")
+      sql("drop table if exists doubleISnegtive")
+      sql("drop table if exists doubleISnegtive_hive")
       deleteFile(tempFilePath)
     }
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
@@ -115,16 +115,16 @@ class ValueCompressionDataTypeTestCase extends QueryTest with BeforeAndAfterAll 
       val data ="a,-7489.7976000000\nb,11234567489.797\nc,-11234567489.7\nd,-1.2\ne,2\nf,-11234567489.7976000000\ng,11234567489.7976000000"
       writedata(tempFilePath, data)
       sql(s"LOAD data local inpath '${tempFilePath}' into table doublePAN options('fileheader'='name,value')")
-      sql(s"LOAD data local inpath '${tempFilePath}' into table double_hive")
+      sql(s"LOAD data local inpath '${tempFilePath}' into table doublePAN_hive")
 
-      checkAnswer(sql("select * from doubleISnegtive"),
-        sql("select * from doubleISnegtive_hive"))
+      checkAnswer(sql("select * from doublePAN"),
+        sql("select * from doublePAN_hive"))
     } catch{
       case ex:Exception => ex.printStackTrace()
         assert(false)
     } finally {
-      sql("drop table if exists doubleISnegtive")
-      sql("drop table if exists doubleISnegtive_hive")
+      sql("drop table if exists doublePAN")
+      sql("drop table if exists doublePAN_hive")
       deleteFile(tempFilePath)
     }
   }


### PR DESCRIPTION
## Why raise this pr?
Fix this bug: When the query has subquery with sort and filter, it can not return resullt.
## How to solve?
When the query likes this, the optimized plan by spark never push down the filter, and as aresult the sort is not decoded by carbon, when use filter, the int values can not resolved as string values by spark.
So we shoud decode them earlier **when the child of filter is sort**.
## How to test?
Added new testcases and should pass them and pass CI.