### PR TITLE
[CARBONDATA-203]Use static string to set Hadoop configuration

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -28,7 +28,7 @@ import scala.util.control.Breaks._
 
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.mapreduce.Job
-import org.apache.hadoop.mapreduce.lib.input.FileSplit
+import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat, FileSplit}
 import org.apache.spark.{util => _, _}
 import org.apache.spark.sql.{CarbonEnv, SQLContext}
 import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionCallableModel, CompactionModel, Partitioner}
@@ -231,8 +231,7 @@ object CarbonDataRDDFactory extends Logging {
       if (newSplitSize < CarbonCommonConstants.CARBON_16MB) {
         newSplitSize = CarbonCommonConstants.CARBON_16MB
       }
-      hadoopConfiguration.set(
-        "mapreduce.input.fileinputformat.split.maxsize", newSplitSize.toString)
+      hadoopConfiguration.set(FileInputFormat.SPLIT_MAXSIZE, newSplitSize.toString)
       logInfo("totalInputSpaceConsumed : " + spaceConsumed +
         " , defaultParallelism : " + defaultParallelism)
       logInfo("mapreduce.input.fileinputformat.split.maxsize : " + newSplitSize.toString)
@@ -907,8 +906,8 @@ object CarbonDataRDDFactory extends Logging {
           val hadoopConfiguration = new Configuration(sqlContext.sparkContext.hadoopConfiguration)
           // FileUtils will skip file which is no csv, and return all file path which split by ','
           val filePaths = carbonLoadModel.getFactFilePath
-          hadoopConfiguration.set("mapreduce.input.fileinputformat.inputdir", filePaths)
-          hadoopConfiguration.set("mapreduce.input.fileinputformat.input.dir.recursive", "true")
+          hadoopConfiguration.set(FileInputFormat.INPUT_DIR, filePaths)
+          hadoopConfiguration.set(FileInputFormat.INPUT_DIR_RECURSIVE, "true")
 
           configSplitMaxSize(sqlContext.sparkContext, filePaths, hadoopConfiguration)
 

--- a/integration/spark/src/main/scala/org/apache/spark/util/SplitUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/SplitUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.util
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.{LongWritable, Text}
-import org.apache.hadoop.mapreduce.lib.input.FileSplit
+import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat, FileSplit}
 import org.apache.spark.rdd.{NewHadoopPartition, NewHadoopRDD}
 import org.apache.spark.SparkContext
 
@@ -44,8 +44,8 @@ object SplitUtils {
       // clone the hadoop configuration
       val hadoopConfiguration = new Configuration(sc.hadoopConfiguration)
       // set folder or file
-      hadoopConfiguration.set("mapreduce.input.fileinputformat.inputdir", filePath)
-      hadoopConfiguration.set("mapreduce.input.fileinputformat.input.dir.recursive", "true")
+      hadoopConfiguration.set(FileInputFormat.INPUT_DIR, filePath)
+      hadoopConfiguration.set(FileInputFormat.INPUT_DIR_RECURSIVE, "true")
       val newHadoopRDD = new NewHadoopRDD[LongWritable, Text](
         sc,
         classOf[org.apache.hadoop.mapreduce.lib.input.TextInputFormat],


### PR DESCRIPTION
Should use static string in FileInputFormat class as the configuration key to set the corresponding configuration value in Hadoop Configuration

Some places currently is not doing like this. This PR made a fix.