### PR TITLE
[CARBONDATA-125] Remove usage of currentRestructureNumber from the code

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -64,7 +64,6 @@ import org.apache.carbondata.core.datastorage.store.columnar.UnBlockIndexer;
 import org.apache.carbondata.core.datastorage.store.compression.MeasureMetaDataModel;
 import org.apache.carbondata.core.datastorage.store.compression.ValueCompressionModel;
 import org.apache.carbondata.core.datastorage.store.filesystem.CarbonFile;
-import org.apache.carbondata.core.datastorage.store.filesystem.CarbonFileFilter;
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
 import org.apache.carbondata.core.keygenerator.mdkey.NumberCompressor;
 import org.apache.carbondata.core.metadata.ValueEncoderMeta;
@@ -145,67 +144,6 @@ public final class CarbonUtil {
       return -1;
     }
     return 1;
-  }
-
-  /**
-   * This method checks whether Restructure Folder exists or not
-   * and if not exist then return the number with which folder need to created.
-   *
-   * @param baseStorePath -
-   *                      baselocation where folder will be created.
-   * @return counter
-   * counter with which folder will be created.
-   */
-  public static int checkAndReturnCurrentRestructFolderNumber(String baseStorePath,
-      final String filterType, final boolean isDirectory) {
-    if (null == baseStorePath || 0 == baseStorePath.length()) {
-      return -1;
-    }
-    // change the slashes to /
-    baseStorePath = baseStorePath.replace("\\", "/");
-
-    // check if string wnds with / then remove that.
-    if (baseStorePath.charAt(baseStorePath.length() - 1) == '/') {
-      baseStorePath = baseStorePath.substring(0, baseStorePath.lastIndexOf("/"));
-    }
-    int retValue = createBaseStoreFolders(baseStorePath);
-    if (-1 == retValue) {
-      return retValue;
-    }
-
-    CarbonFile carbonFile =
-        FileFactory.getCarbonFile(baseStorePath, FileFactory.getFileType(baseStorePath));
-
-    // List of directories
-    CarbonFile[] listFiles = carbonFile.listFiles(new CarbonFileFilter() {
-      @Override public boolean accept(CarbonFile pathname) {
-        if (isDirectory && pathname.isDirectory()) {
-          if (pathname.getAbsolutePath().indexOf(filterType) > -1) {
-            return true;
-          }
-        } else {
-          if (pathname.getAbsolutePath().indexOf(filterType) > -1) {
-            return true;
-          }
-        }
-
-        return false;
-      }
-    });
-
-    int counter = -1;
-
-    // if no folder exists then return -1
-    if (listFiles.length == 0) {
-      return counter;
-    }
-
-    counter = findCounterValue(filterType, listFiles, counter);
-    return counter;
-  }
-
-  public static int checkAndReturnCurrentLoadFolderNumber(String baseStorePath) {
-    return checkAndReturnCurrentRestructFolderNumber(baseStorePath, "Load_", true);
   }
 
   /**
@@ -867,20 +805,6 @@ public final class CarbonUtil {
       }
     }
     return currentPath;
-  }
-
-  /**
-   * @param location
-   * @param factTableName
-   * @return
-   */
-  public static int getRestructureNumber(String location, String factTableName) {
-    String restructName =
-        location.substring(location.indexOf(CarbonCommonConstants.RESTRUCTRE_FOLDER));
-    int factTableIndex = restructName.indexOf(factTableName) - 1;
-    String restructNumber =
-        restructName.substring(CarbonCommonConstants.RESTRUCTRE_FOLDER.length(), factTableIndex);
-    return Integer.parseInt(restructNumber);
   }
 
   /**

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -18,21 +18,7 @@
  */
 package org.apache.carbondata.hadoop.test.util;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
+import com.google.gson.Gson;
 import org.apache.carbondata.core.cache.Cache;
 import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.cache.CacheType;
@@ -83,7 +69,9 @@ import org.apache.carbondata.processing.graphgenerator.GraphGenerator;
 import org.apache.carbondata.processing.graphgenerator.GraphGeneratorException;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
-import com.google.gson.Gson;
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 /**
  * This class will create store file based on provided schema
@@ -124,7 +112,6 @@ public class StoreCreator {
           absoluteTableIdentifier.getStorePath());
 
       String kettleHomePath = "../processing/carbonplugins";
-      int currentRestructureNumber = 0;
       CarbonTable table = createTable();
       writeDictionary(factFilePath, table);
       CarbonDataLoadSchema schema = new CarbonDataLoadSchema(table);
@@ -137,8 +124,7 @@ public class StoreCreator {
       loadModel.setFactFilePath(factFilePath);
       loadModel.setLoadMetadataDetails(new ArrayList<LoadMetadataDetails>());
 
-      executeGraph(loadModel, absoluteTableIdentifier.getStorePath(), kettleHomePath,
-          currentRestructureNumber);
+      executeGraph(loadModel, absoluteTableIdentifier.getStorePath(), kettleHomePath);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -327,11 +313,10 @@ public class StoreCreator {
    * @param loadModel
    * @param storeLocation
    * @param kettleHomePath
-   * @param currentRestructNumber
    * @throws Exception
    */
-  public static void executeGraph(LoadModel loadModel, String storeLocation, String kettleHomePath,
-      int currentRestructNumber) throws Exception {
+  public static void executeGraph(LoadModel loadModel, String storeLocation, String kettleHomePath)
+      throws Exception {
     System.setProperty("KETTLE_HOME", kettleHomePath);
     new File(storeLocation).mkdirs();
     String outPutLoc = storeLocation + "/etl";
@@ -372,7 +357,7 @@ public class StoreCreator {
     info.setTableName(tableName);
 
     generateGraph(schmaModel, info, loadModel.getTableName(), "0", loadModel.getSchema(), null,
-        currentRestructNumber, loadModel.getLoadMetadataDetails());
+        loadModel.getLoadMetadataDetails());
 
     DataGraphExecuter graphExecuter = new DataGraphExecuter(schmaModel);
     graphExecuter
@@ -460,13 +445,12 @@ public class StoreCreator {
    * @param partitionID
    * @param schema
    * @param factStoreLocation
-   * @param currentRestructNumber
    * @param loadMetadataDetails
    * @throws GraphGeneratorException
    */
   private static void generateGraph(IDataProcessStatus schmaModel, SchemaInfo info,
       String tableName, String partitionID, CarbonDataLoadSchema schema, String factStoreLocation,
-      int currentRestructNumber, List<LoadMetadataDetails> loadMetadataDetails)
+      List<LoadMetadataDetails> loadMetadataDetails)
       throws GraphGeneratorException {
     DataLoadModel model = new DataLoadModel();
     model.setCsvLoad(null != schmaModel.getCsvFilePath() || null != schmaModel.getFilesToProcess());
@@ -489,7 +473,7 @@ public class StoreCreator {
         .getProperty("store_output_location", "../carbon-store/system/carbon/etl");
     GraphGenerator generator =
         new GraphGenerator(model, hdfsReadMode, partitionID, factStoreLocation,
-            currentRestructNumber, allocate, schema, "0", outputLocation);
+            allocate, schema, "0", outputLocation);
     generator.generateGraph();
   }
 

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
@@ -19,7 +19,6 @@
 package org.apache.carbondata.spark.load;
 
 import java.io.BufferedWriter;
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -55,8 +54,6 @@ import org.apache.carbondata.core.carbon.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
-import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
-import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.carbon.path.CarbonStorePath;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -85,9 +82,6 @@ import org.apache.carbondata.spark.merger.NodeBlockRelation;
 import org.apache.carbondata.spark.merger.NodeMultiBlockRelation;
 
 import com.google.gson.Gson;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.IOUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.util.Utils;
 
@@ -112,19 +106,12 @@ public final class CarbonLoaderUtil {
     }
   }
 
-  /**
-   * dfs.bytes-per-checksum
-   * HDFS checksum length, block size for a file should be exactly divisible
-   * by this value
-   */
-  private static final int HDFS_CHECKSUM_LENGTH = 512;
-
   private CarbonLoaderUtil() {
 
   }
 
   private static void generateGraph(IDataProcessStatus schmaModel, SchemaInfo info,
-      int currentRestructNumber, CarbonLoadModel loadModel, String outputLocation)
+      CarbonLoadModel loadModel, String outputLocation)
       throws GraphGeneratorException {
     DataLoadModel model = new DataLoadModel();
     model.setCsvLoad(null != schmaModel.getCsvFilePath() || null != schmaModel.getFilesToProcess());
@@ -146,13 +133,13 @@ public final class CarbonLoaderUtil {
         schmaModel.getCsvFilePath() != null && schmaModel.getCsvFilePath().startsWith("hdfs:");
     int allocate = null != schmaModel.getCsvFilePath() ? 1 : schmaModel.getFilesToProcess().size();
     GraphGenerator generator = new GraphGenerator(model, hdfsReadMode, loadModel.getPartitionId(),
-        loadModel.getStorePath(), currentRestructNumber, allocate,
+        loadModel.getStorePath(), allocate,
         loadModel.getCarbonDataLoadSchema(), loadModel.getSegmentId(), outputLocation);
     generator.generateGraph();
   }
 
   public static void executeGraph(CarbonLoadModel loadModel, String storeLocation,
-      String hdfsStoreLocation, String kettleHomePath, int currentRestructNumber) throws Exception {
+      String hdfsStoreLocation, String kettleHomePath) throws Exception {
     System.setProperty("KETTLE_HOME", kettleHomePath);
     if (!new File(storeLocation).mkdirs()) {
       LOGGER.error("Error while creating the temp store path: " + storeLocation);
@@ -202,7 +189,7 @@ public final class CarbonLoaderUtil {
     info.setComplexDelimiterLevel2(loadModel.getComplexDelimiterLevel2());
     info.setSerializationNullFormat(loadModel.getSerializationNullFormat());
 
-    generateGraph(schmaModel, info, currentRestructNumber, loadModel, outPutLoc);
+    generateGraph(schmaModel, info, loadModel, outPutLoc);
 
     DataGraphExecuter graphExecuter = new DataGraphExecuter(schmaModel);
     graphExecuter
@@ -210,87 +197,9 @@ public final class CarbonLoaderUtil {
             info, loadModel.getPartitionId(), loadModel.getCarbonDataLoadSchema());
   }
 
-  public static String[] getStorelocs(String databaseName, String tableName, String factTableName,
-      String hdfsStoreLocation, int currentRestructNumber) {
-    String[] loadFolders;
-
-    String baseStorelocation =
-        hdfsStoreLocation + File.separator + databaseName + File.separator + tableName;
-
-    String factStorepath =
-        baseStorelocation + File.separator + CarbonCommonConstants.RESTRUCTRE_FOLDER
-            + currentRestructNumber + File.separator + factTableName;
-
-    // Change to LOCAL for testing in local
-    CarbonFile file =
-        FileFactory.getCarbonFile(factStorepath, FileFactory.getFileType(factStorepath));
-
-    if (!file.exists()) {
-      return new String[0];
-    }
-    CarbonFile[] listFiles = file.listFiles(new CarbonFileFilter() {
-      @Override public boolean accept(CarbonFile path) {
-        return path.getName().startsWith(CarbonCommonConstants.LOAD_FOLDER) && !path.getName()
-            .endsWith(CarbonCommonConstants.FILE_INPROGRESS_STATUS);
-      }
-    });
-
-    loadFolders = new String[listFiles.length];
-    int count = 0;
-
-    for (CarbonFile loadFile : listFiles) {
-      loadFolders[count++] = loadFile.getAbsolutePath();
-    }
-
-    return loadFolders;
-  }
-
   public static List<String> addNewSliceNameToList(String newSlice, List<String> activeSlices) {
     activeSlices.add(newSlice);
     return activeSlices;
-  }
-
-  public static String getAggLoadFolderLocation(String loadFolderName, String databaseName,
-      String tableName, String aggTableName, String hdfsStoreLocation, int currentRestructNumber) {
-    for (int i = currentRestructNumber; i >= 0; i--) {
-      String aggTableLocation =
-          getTableLocation(databaseName, tableName, aggTableName, hdfsStoreLocation, i);
-      String aggStorepath = aggTableLocation + File.separator + loadFolderName;
-      try {
-        if (FileFactory.isFileExist(aggStorepath, FileFactory.getFileType(aggStorepath))) {
-          return aggStorepath;
-        }
-      } catch (IOException e) {
-        LOGGER.error("Problem checking file existence :: " + e.getMessage());
-      }
-    }
-    return null;
-  }
-
-  public static String getTableLocation(String databaseName, String tableName, String aggTableName,
-      String hdfsStoreLocation, int currentRestructNumber) {
-    String baseStorelocation =
-        hdfsStoreLocation + File.separator + databaseName + File.separator + tableName;
-    String aggTableLocation =
-        baseStorelocation + File.separator + CarbonCommonConstants.RESTRUCTRE_FOLDER
-            + currentRestructNumber + File.separator + aggTableName;
-    return aggTableLocation;
-  }
-
-  public static void deleteTable(int partitionCount, String databaseName, String tableName,
-      String aggTableName, String hdfsStoreLocation, int currentRestructNumber) {
-    String aggTableLoc = null;
-    String partitionDatabaseName = null;
-    String partitionTableName = null;
-    for (int i = 0; i < partitionCount; i++) {
-      partitionDatabaseName = databaseName + '_' + i;
-      partitionTableName = tableName + '_' + i;
-      for (int j = currentRestructNumber; j >= 0; j--) {
-        aggTableLoc = getTableLocation(partitionDatabaseName, partitionTableName, aggTableName,
-            hdfsStoreLocation, j);
-        deleteStorePath(aggTableLoc);
-      }
-    }
   }
 
   public static void deleteSegment(CarbonLoadModel loadModel, int currentLoad) {
@@ -301,22 +210,6 @@ public final class CarbonLoaderUtil {
     for (int i = 0; i < carbonTable.getPartitionCount(); i++) {
       String segmentPath = carbonTablePath.getCarbonDataDirectoryPath(i + "", currentLoad + "");
       deleteStorePath(segmentPath);
-    }
-  }
-
-  public static void deleteSlice(int partitionCount, String databaseName, String tableName,
-      String hdfsStoreLocation, int currentRestructNumber, String loadFolder) {
-    String tableLoc = null;
-    String partitionDatabaseName = null;
-    String partitionTableName = null;
-    for (int i = 0; i < partitionCount; i++) {
-      partitionDatabaseName = databaseName + '_' + i;
-      partitionTableName = tableName + '_' + i;
-      tableLoc =
-          getTableLocation(partitionDatabaseName, partitionTableName, tableName, hdfsStoreLocation,
-              currentRestructNumber);
-      tableLoc = tableLoc + File.separator + loadFolder;
-      deleteStorePath(tableLoc);
     }
   }
 
@@ -383,24 +276,6 @@ public final class CarbonLoaderUtil {
     }
   }
 
-  public static boolean isSliceValid(String loc, List<String> activeSlices,
-      List<String> updatedSlices, String factTableName) {
-    String loadFolderName = loc.substring(loc.indexOf(CarbonCommonConstants.LOAD_FOLDER));
-    String sliceNum = loadFolderName.substring(CarbonCommonConstants.LOAD_FOLDER.length());
-    if (activeSlices.contains(loadFolderName) || updatedSlices.contains(sliceNum)) {
-      String factFileLoc =
-          loc + File.separator + factTableName + "_0" + CarbonCommonConstants.FACT_FILE_EXT;
-      try {
-        if (FileFactory.isFileExist(factFileLoc, FileFactory.getFileType(factFileLoc))) {
-          return true;
-        }
-      } catch (IOException e) {
-        LOGGER.error("Problem checking file existence :: " + e.getMessage());
-      }
-    }
-    return false;
-  }
-
   public static List<String> getListOfValidSlices(LoadMetadataDetails[] details) {
     List<String> activeSlices =
         new ArrayList<String>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
@@ -439,24 +314,6 @@ public final class CarbonLoaderUtil {
     // TODO: Remove from memory
   }
 
-  public static void createEmptyLoadFolder(CarbonLoadModel model, String factLoadFolderLocation,
-      String hdfsStoreLocation, int currentRestructNumber) {
-    String loadFolderName = factLoadFolderLocation
-        .substring(factLoadFolderLocation.indexOf(CarbonCommonConstants.LOAD_FOLDER));
-    String aggLoadFolderLocation =
-        getTableLocation(model.getDatabaseName(), model.getTableName(), model.getAggTableName(),
-            hdfsStoreLocation, currentRestructNumber);
-    aggLoadFolderLocation = aggLoadFolderLocation + File.separator + loadFolderName;
-    FileType fileType = FileFactory.getFileType(hdfsStoreLocation);
-    try {
-      FileFactory.mkdirs(aggLoadFolderLocation, fileType);
-    } catch (IOException e) {
-      LOGGER
-          .error("Problem creating empty folder created for aggregation table: " + e.getMessage());
-    }
-    LOGGER.info("Empty folder created for aggregation table");
-  }
-
   /**
    * This method will delete the local data load folder location after data load is complete
    *
@@ -484,48 +341,6 @@ public final class CarbonLoaderUtil {
   }
 
   /**
-   * This method will copy the current segment load to cgiven carbon store path
-   *
-   * @param loadModel
-   * @param segmentName
-   * @param updatedSlices
-   * @throws IOException
-   * @throws CarbonUtilException
-   */
-  public static void copyCurrentLoadToHDFS(CarbonLoadModel loadModel, String segmentName,
-      List<String> updatedSlices) throws IOException, CarbonUtilException {
-    //Copy the current load folder to carbon store
-    boolean copyStore =
-        Boolean.valueOf(CarbonProperties.getInstance().getProperty("dataload.hdfs.copy", "true"));
-    String databaseName = loadModel.getDatabaseName();
-    String tableName = loadModel.getTableName();
-    String aggTableName = loadModel.getAggTableName();
-    if (copyStore) {
-      CarbonTableIdentifier carbonTableIdentifier =
-          loadModel.getCarbonDataLoadSchema().getCarbonTable().getCarbonTableIdentifier();
-      String segmentId = segmentName.substring(CarbonCommonConstants.LOAD_FOLDER.length());
-      // form carbon store location
-      String carbonStoreLocation = getStoreLocation(
-          CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION_HDFS),
-          carbonTableIdentifier, segmentId, loadModel.getPartitionId());
-      String tempLocationKey = databaseName + '_' + tableName;
-      // form local store location
-      String localStoreLocation = getStoreLocation(CarbonProperties.getInstance()
-              .getProperty(tempLocationKey, CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL),
-          carbonTableIdentifier, segmentId, loadModel.getPartitionId());
-      localStoreLocation = localStoreLocation + File.separator + loadModel.getTaskNo();
-      boolean isUpdate = false;
-      if (loadModel.isAggLoadRequest() && null != aggTableName) {
-        if (updatedSlices.contains(segmentId)) {
-          isUpdate = true;
-        }
-      }
-      copyToHDFS(carbonStoreLocation, localStoreLocation, isUpdate);
-      CarbonUtil.deleteFoldersAndFiles(new File[] { new File(localStoreLocation) });
-    }
-  }
-
-  /**
    * This method will get the store location for the given path, segemnt id and partition id
    *
    * @param storePath
@@ -540,205 +355,6 @@ public final class CarbonLoaderUtil {
         CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier);
     String carbonDataFilePath = carbonTablePath.getCarbonDataDirectoryPath(partitionId, segmentId);
     return carbonDataFilePath;
-  }
-
-  /**
-   * This method will copy the carbon data files form local store segment folder
-   * to carbon store segment location
-   *
-   * @param carbonStoreLocation
-   * @param localStoreLocation
-   * @param isUpdate
-   * @throws IOException
-   */
-  private static void copyToHDFS(String carbonStoreLocation, String localStoreLocation,
-      boolean isUpdate) throws IOException {
-    //If the carbon store and the local store configured differently, then copy
-    if (carbonStoreLocation != null && !carbonStoreLocation.equals(localStoreLocation)) {
-      long copyStartTime = System.currentTimeMillis();
-      // isUpdate will be true only when the below 2 conditions are satisfied
-      // 1. slice is marked for update, 2. request is for aggregate table creation
-      if (isUpdate) {
-        renameFactFile(localStoreLocation);
-      }
-      LOGGER.info("Copying " + localStoreLocation + " --> " + carbonStoreLocation);
-      CarbonUtil.checkAndCreateFolder(carbonStoreLocation);
-      long blockSize = getBlockSize();
-      int bufferSize = CarbonCommonConstants.BYTEBUFFER_SIZE;
-      CarbonFile carbonFile = FileFactory
-          .getCarbonFile(localStoreLocation, FileFactory.getFileType(localStoreLocation));
-      CarbonFile[] listFiles = carbonFile.listFiles(new CarbonFileFilter() {
-        @Override public boolean accept(CarbonFile path) {
-          return path.getName().endsWith(CarbonCommonConstants.FACT_FILE_EXT) && !path.getName()
-              .endsWith(CarbonCommonConstants.FILE_INPROGRESS_STATUS);
-        }
-      });
-      for (int i = 0; i < listFiles.length; i++) {
-        String localFilePath = listFiles[i].getCanonicalPath();
-        CarbonFile localCarbonFile =
-            FileFactory.getCarbonFile(localFilePath, FileFactory.getFileType(localFilePath));
-        String carbonFilePath = carbonStoreLocation + localFilePath
-            .substring(localFilePath.lastIndexOf(File.separator));
-        copyLocalFileToHDFS(carbonFilePath, localFilePath, bufferSize,
-            getMaxOfBlockAndFileSize(blockSize, localCarbonFile.getSize()));
-      }
-      LOGGER.info("Total copy time (ms):  " + (System.currentTimeMillis() - copyStartTime));
-    } else {
-      LOGGER.info("Separate carbon.storelocation.hdfs is not configured for carbon store path");
-    }
-  }
-
-  /**
-   * This method will return max of block size and file size
-   *
-   * @param blockSize
-   * @param fileSize
-   * @return
-   */
-  private static long getMaxOfBlockAndFileSize(long blockSize, long fileSize) {
-    long maxSize = blockSize;
-    if (fileSize > blockSize) {
-      maxSize = fileSize;
-    }
-    // block size should be exactly divisible by 512 which is  maintained by HDFS as bytes
-    // per checksum, dfs.bytes-per-checksum=512 must divide block size
-    long remainder = maxSize % HDFS_CHECKSUM_LENGTH;
-    if (remainder > 0) {
-      maxSize = maxSize + HDFS_CHECKSUM_LENGTH - remainder;
-    }
-    return maxSize;
-  }
-
-  /**
-   * This method will return the block size for file to be copied in HDFS
-   *
-   * @return
-   */
-  private static long getBlockSize() {
-    CarbonProperties carbonProperties = CarbonProperties.getInstance();
-    long blockSizeInBytes = Long.parseLong(carbonProperties
-        .getProperty(CarbonCommonConstants.MAX_FILE_SIZE,
-            CarbonCommonConstants.MAX_FILE_SIZE_DEFAULT_VAL))
-        * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR
-        * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR * 1L;
-    return blockSizeInBytes;
-  }
-
-  /**
-   * This method will read the local carbon data file and write to carbon data file in HDFS
-   *
-   * @param carbonStoreFilePath
-   * @param localFilePath
-   * @param bufferSize
-   * @param blockSize
-   * @throws IOException
-   */
-  private static void copyLocalFileToHDFS(String carbonStoreFilePath, String localFilePath,
-      int bufferSize, long blockSize) throws IOException {
-    DataOutputStream dataOutputStream = null;
-    DataInputStream dataInputStream = null;
-    try {
-      LOGGER.debug(
-          "HDFS file block size for file: " + carbonStoreFilePath + " is " + blockSize + " (bytes");
-      dataOutputStream = FileFactory
-          .getDataOutputStream(carbonStoreFilePath, FileFactory.getFileType(carbonStoreFilePath),
-              bufferSize, blockSize);
-      dataInputStream = FileFactory
-          .getDataInputStream(localFilePath, FileFactory.getFileType(localFilePath), bufferSize);
-      IOUtils.copyBytes(dataInputStream, dataOutputStream, bufferSize);
-    } finally {
-      CarbonUtil.closeStreams(dataInputStream, dataOutputStream);
-    }
-  }
-
-  private static void renameFactFile(String localStoreLocation) {
-    FileType fileType = FileFactory.getFileType(localStoreLocation);
-    try {
-      if (FileFactory.isFileExist(localStoreLocation, fileType)) {
-        CarbonFile carbonFile = FileFactory.getCarbonFile(localStoreLocation, fileType);
-        CarbonFile[] listFiles = carbonFile.listFiles(new CarbonFileFilter() {
-          @Override public boolean accept(CarbonFile path) {
-            return path.getName().endsWith(CarbonCommonConstants.FACT_FILE_EXT) && !path.getName()
-                .endsWith(CarbonCommonConstants.FILE_INPROGRESS_STATUS);
-          }
-        });
-        for (int i = 0; i < listFiles.length; i++) {
-          carbonFile = listFiles[i];
-          String factFilePath = carbonFile.getCanonicalPath();
-          String changedFileName = factFilePath.replace(CarbonCommonConstants.FACT_FILE_EXT,
-              CarbonCommonConstants.FACT_UPDATE_EXTENSION);
-          carbonFile.renameTo(changedFileName);
-        }
-      }
-    } catch (IOException e) {
-      LOGGER.error("Inside renameFactFile. Problem checking file existence :: " + e.getMessage());
-    }
-  }
-
-  /**
-   * API will provide the load number inorder to record the same in metadata file.
-   */
-  public static int getLoadCount(CarbonLoadModel loadModel, int currentRestructNumber)
-      throws IOException {
-
-    String hdfsLoadedTable = getLoadFolderPath(loadModel, null, null, currentRestructNumber);
-    int loadCounter = CarbonUtil.checkAndReturnCurrentLoadFolderNumber(hdfsLoadedTable);
-
-    String hdfsStoreLoadFolder =
-        hdfsLoadedTable + File.separator + CarbonCommonConstants.LOAD_FOLDER + loadCounter;
-    hdfsStoreLoadFolder = hdfsStoreLoadFolder.replace("\\", "/");
-
-    String loadFolerCount = hdfsStoreLoadFolder
-        .substring(hdfsStoreLoadFolder.lastIndexOf('_') + 1, hdfsStoreLoadFolder.length());
-    return Integer.parseInt(loadFolerCount) + 1;
-  }
-
-  /**
-   * API will provide the load folder path for the store inorder to store the same
-   * in the metadata.
-   */
-  public static String getLoadFolderPath(CarbonLoadModel loadModel, String tableName,
-      String databaseName, int currentRestructNumber) {
-
-    //CHECKSTYLE:OFF    Approval No:Approval-V1R2C10_005
-
-    boolean copyStore =
-        Boolean.valueOf(CarbonProperties.getInstance().getProperty("dataload.hdfs.copy", "true"));
-
-    // CHECKSTYLE:ON
-    if (null == tableName && null == databaseName) {
-      databaseName = loadModel.getDatabaseName();
-      tableName = loadModel.getTableName();
-    }
-    String factTable = loadModel.getTableName();
-    String hdfsLoadedTable = null;
-    if (copyStore) {
-      String hdfsLocation =
-          CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION_HDFS);
-      String localStore = CarbonProperties.getInstance()
-          .getProperty(CarbonCommonConstants.STORE_LOCATION,
-              CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL);
-
-      if (!hdfsLocation.equals(localStore)) {
-        String hdfsStoreLocation = hdfsLocation;
-        hdfsStoreLocation =
-            hdfsStoreLocation + File.separator + databaseName + File.separator + tableName;
-
-        int rsCounter = currentRestructNumber;
-        if (rsCounter == -1) {
-          rsCounter = 0;
-        }
-
-        hdfsLoadedTable =
-            hdfsStoreLocation + File.separator + CarbonCommonConstants.RESTRUCTRE_FOLDER + rsCounter
-                + File.separator + factTable;
-
-        hdfsLoadedTable = hdfsLoadedTable.replace("\\", "/");
-      }
-
-    }
-    return hdfsLoadedTable;
-
   }
 
   /**
@@ -873,140 +489,6 @@ public final class CarbonLoaderUtil {
         org.apache.carbondata.core.carbon.metadata.CarbonMetadata.getInstance()
             .getCarbonTable(loadModel.getDatabaseName() + '_' + loadModel.getTableName());
     return carbonTable.getMetaDataFilepath();
-  }
-
-  /**
-   * This method will provide the dimension column list for a given aggregate
-   * table
-   */
-  public static Set<String> getColumnListFromAggTable(CarbonLoadModel model) {
-    Set<String> columnList = new HashSet<String>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
-    CarbonTable carbonTable =
-        org.apache.carbondata.core.carbon.metadata.CarbonMetadata.getInstance()
-            .getCarbonTable(model.getDatabaseName() + '_' + model.getTableName());
-    List<CarbonDimension> dimensions = carbonTable.getDimensionByTableName(model.getAggTableName());
-    List<CarbonMeasure> measures = carbonTable.getMeasureByTableName(model.getAggTableName());
-    for (CarbonDimension carbonDimension : dimensions) {
-      columnList.add(carbonDimension.getColName());
-    }
-    for (CarbonMeasure carbonMeasure : measures) {
-      columnList.add(carbonMeasure.getColName());
-    }
-    return columnList;
-  }
-
-  public static void copyMergedLoadToHDFS(CarbonLoadModel loadModel, int currentRestructNumber,
-      String mergedLoadName) {
-    //Copy the current load folder to HDFS
-    boolean copyStore =
-        Boolean.valueOf(CarbonProperties.getInstance().getProperty("dataload.hdfs.copy", "true"));
-
-    String databaseName = loadModel.getDatabaseName();
-    String tableName = loadModel.getTableName();
-    String factTable = loadModel.getTableName();
-    String aggTableName = loadModel.getAggTableName();
-
-    if (copyStore) {
-      String hdfsLocation =
-          CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION_HDFS);
-
-      String localStore = CarbonProperties.getInstance()
-          .getProperty(CarbonCommonConstants.STORE_LOCATION,
-              CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL);
-      if (!loadModel.isAggLoadRequest()) {
-        copyMergeToHDFS(databaseName, tableName, factTable, hdfsLocation, localStore,
-            currentRestructNumber, mergedLoadName);
-      }
-      if (null != aggTableName) {
-        copyMergeToHDFS(databaseName, tableName, aggTableName, hdfsLocation, localStore,
-            currentRestructNumber, mergedLoadName);
-      }
-      try {
-        CarbonUtil.deleteFoldersAndFiles(new File[] {
-            new File(localStore + File.separator + databaseName + File.separator + tableName) });
-      } catch (CarbonUtilException e) {
-        LOGGER.error("Error while CarbonUtil.deleteFoldersAndFiles ");
-      }
-    }
-  }
-
-  public static void copyMergeToHDFS(String databaseName, String tableName, String factTable,
-      String hdfsLocation, String localStore, int currentRestructNumber, String mergedLoadName) {
-    try {
-      //If the hdfs store and the local store configured differently, then copy
-      if (hdfsLocation != null && !hdfsLocation.equals(localStore)) {
-        /**
-         * Identify the Load_X folder from the local store folder
-         */
-        String currentloadedStore = localStore;
-        currentloadedStore =
-            currentloadedStore + File.separator + databaseName + File.separator + tableName;
-
-        int rsCounter = currentRestructNumber;
-
-        if (rsCounter == -1) {
-          LOGGER.info("Unable to find the local store details (RS_-1) " + currentloadedStore);
-          return;
-        }
-        String localLoadedTable =
-            currentloadedStore + File.separator + CarbonCommonConstants.RESTRUCTRE_FOLDER
-                + rsCounter + File.separator + factTable;
-
-        localLoadedTable = localLoadedTable.replace("\\", "/");
-
-        int loadCounter = CarbonUtil.checkAndReturnCurrentLoadFolderNumber(localLoadedTable);
-
-        if (loadCounter == -1) {
-          LOGGER.info("Unable to find the local store details (Load_-1) " + currentloadedStore);
-
-          return;
-        }
-
-        String localLoadName = CarbonCommonConstants.LOAD_FOLDER + mergedLoadName;
-        String localLoadFolder =
-            localLoadedTable + File.separator + CarbonCommonConstants.LOAD_FOLDER + mergedLoadName;
-
-        LOGGER.info("Local data loaded folder ... = " + localLoadFolder);
-
-        //Identify the Load_X folder in the HDFS store
-        String hdfsStoreLocation = hdfsLocation;
-        hdfsStoreLocation =
-            hdfsStoreLocation + File.separator + databaseName + File.separator + tableName;
-
-        rsCounter = currentRestructNumber;
-        if (rsCounter == -1) {
-          rsCounter = 0;
-        }
-
-        String hdfsLoadedTable =
-            hdfsStoreLocation + File.separator + CarbonCommonConstants.RESTRUCTRE_FOLDER + rsCounter
-                + File.separator + factTable;
-
-        hdfsLoadedTable = hdfsLoadedTable.replace("\\", "/");
-
-        String hdfsStoreLoadFolder = hdfsLoadedTable + File.separator + localLoadName;
-
-        LOGGER.info("HDFS data load folder ... = " + hdfsStoreLoadFolder);
-
-        // Copy the data created through latest ETL run, to the HDFS store
-        LOGGER.info("Copying " + localLoadFolder + " --> " + hdfsStoreLoadFolder);
-
-        hdfsStoreLoadFolder = hdfsStoreLoadFolder.replace("\\", "/");
-        Path path = new Path(hdfsStoreLocation);
-
-        FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
-        fs.copyFromLocalFile(true, true, new Path(localLoadFolder), new Path(hdfsStoreLoadFolder));
-
-        LOGGER.info("Copying sliceMetaData from " + localLoadedTable + " --> " + hdfsLoadedTable);
-
-      } else {
-        LOGGER.info("Separate carbon.storelocation.hdfs is not configured for hdfs store path");
-      }
-    } catch (RuntimeException e) {
-      LOGGER.info(e.getMessage());
-    } catch (Exception e) {
-      LOGGER.info(e.getMessage());
-    }
   }
 
   public static Dictionary getDictionary(DictionaryColumnUniqueIdentifier columnIdentifier,

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/util/LoadMetadataUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/util/LoadMetadataUtil.java
@@ -28,13 +28,8 @@
  */
 package org.apache.carbondata.spark.util;
 
-import java.io.File;
-
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.datastorage.store.filesystem.CarbonFile;
-import org.apache.carbondata.core.datastorage.store.filesystem.CarbonFileFilter;
-import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
 import org.apache.carbondata.core.load.LoadMetadataDetails;
 import org.apache.carbondata.lcm.status.SegmentStatusManager;
 import org.apache.carbondata.spark.load.CarbonLoadModel;
@@ -64,50 +59,5 @@ public final class LoadMetadataUtil {
 
     return false;
 
-  }
-
-  public static String createLoadFolderPath(CarbonLoadModel model, String hdfsStoreLocation,
-      int partitionId, int currentRestructNumber) {
-    hdfsStoreLocation =
-        hdfsStoreLocation + File.separator + model.getDatabaseName() + '_' + partitionId
-            + File.separator + model.getTableName() + '_' + partitionId;
-    int rsCounter = currentRestructNumber;
-    if (rsCounter == -1) {
-      rsCounter = 0;
-    }
-    String hdfsLoadedTable =
-        hdfsStoreLocation + File.separator + CarbonCommonConstants.RESTRUCTRE_FOLDER + rsCounter
-            + File.separator + model.getTableName();
-    hdfsLoadedTable = hdfsLoadedTable.replace("\\", "/");
-    return hdfsLoadedTable;
-  }
-
-  public static CarbonFile[] getAggregateTableList(final CarbonLoadModel model,
-      String hdfsStoreLocation, int partitionId, int currentRestructNumber) {
-    hdfsStoreLocation =
-        hdfsStoreLocation + File.separator + model.getDatabaseName() + '_' + partitionId
-            + File.separator + model.getTableName() + '_' + partitionId;
-
-    int rsCounter = currentRestructNumber;
-    if (rsCounter == -1) {
-      rsCounter = 0;
-    }
-
-    String hdfsLoadedTable =
-        hdfsStoreLocation + File.separator + CarbonCommonConstants.RESTRUCTRE_FOLDER + rsCounter;
-
-    CarbonFile rsFile =
-        FileFactory.getCarbonFile(hdfsLoadedTable, FileFactory.getFileType(hdfsLoadedTable));
-
-    CarbonFile[] aggFiles = rsFile.listFiles(new CarbonFileFilter() {
-
-      @Override public boolean accept(CarbonFile file) {
-        return file.getName().startsWith(
-            CarbonCommonConstants.AGGREGATE_TABLE_START_TAG + CarbonCommonConstants.UNDERSCORE
-                + model.getTableName());
-      }
-    });
-
-    return aggFiles;
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
@@ -41,8 +41,7 @@ class CarbonDeleteLoadByDateRDD[K, V](
     factTableName: String,
     dimTableName: String,
     hdfsStoreLocation: String,
-    loadMetadataDetails: List[LoadMetadataDetails],
-    currentRestructFolder: Integer)
+    loadMetadataDetails: List[LoadMetadataDetails])
   extends RDD[(K, V)](sc, Nil) with Logging {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")

--- a/processing/src/main/java/org/apache/carbondata/processing/csvreaderstep/CsvInputMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/csvreaderstep/CsvInputMeta.java
@@ -93,8 +93,6 @@ public class CsvInputMeta extends BaseStepMeta
 
   private boolean newlinePossibleInFields;
 
-  private int currentRestructNumber;
-
   private String blocksID;
 
   private String partitionID;
@@ -120,7 +118,6 @@ public class CsvInputMeta extends BaseStepMeta
     lazyConversionActive = true;
     isaddresult = false;
     bufferSize = "50000";
-    currentRestructNumber = -1;
     blocksID = "";
     partitionID = "";
     escapeCharacter ="\\";
@@ -157,8 +154,6 @@ public class CsvInputMeta extends BaseStepMeta
         newlinePossibleInFields = "Y".equalsIgnoreCase(nlp);
       }
       encoding = XMLHandler.getTagValue(stepnode, getXmlCode("ENCODING"));
-      currentRestructNumber =
-          Integer.parseInt(XMLHandler.getTagValue(stepnode, "currentRestructNumber"));
       blocksID = XMLHandler.getTagValue(stepnode, "blocksID");
       partitionID = XMLHandler.getTagValue(stepnode, "partitionID");
       escapeCharacter = XMLHandler.getTagValue(stepnode, "escapeCharacter");
@@ -222,8 +217,6 @@ public class CsvInputMeta extends BaseStepMeta
     retval.append("    ")
         .append(XMLHandler.addTagValue(getXmlCode("NEWLINE_POSSIBLE"), newlinePossibleInFields));
     retval.append("    ").append(XMLHandler.addTagValue(getXmlCode("ENCODING"), encoding));
-    retval.append("    ")
-        .append(XMLHandler.addTagValue("currentRestructNumber", currentRestructNumber));
     retval.append("    ").append(XMLHandler.addTagValue("blocksID", blocksID));
     retval.append("    ").append(XMLHandler.addTagValue("partitionID", partitionID));
     retval.append("    ").append(XMLHandler.addTagValue("escapeCharacter", escapeCharacter));
@@ -277,7 +270,6 @@ public class CsvInputMeta extends BaseStepMeta
           rep.getStepAttributeBoolean(idStep, 0, getRepCode("NEWLINE_POSSIBLE"),
               !runningInParallel);
       encoding = rep.getStepAttributeString(idStep, getRepCode("ENCODING"));
-      currentRestructNumber = (int) rep.getStepAttributeInteger(idStep, "currentRestructNumber");
       blocksID = rep.getStepAttributeString(idStep, getRepCode("blocksID"));
       partitionID = rep.getStepAttributeString(idStep, getRepCode("partitionID"));
       escapeCharacter = rep.getStepAttributeString(idStep, getRepCode("escapeCharacter"));
@@ -333,8 +325,6 @@ public class CsvInputMeta extends BaseStepMeta
       rep.saveStepAttribute(idTransformation, idStep, getRepCode("NEWLINE_POSSIBLE"),
           newlinePossibleInFields);
       rep.saveStepAttribute(idTransformation, idStep, getRepCode("ENCODING"), encoding);
-      rep.saveStepAttribute(idTransformation, idStep, "currentRestructNumber",
-          currentRestructNumber);
       rep.saveStepAttribute(idTransformation, idStep, getRepCode("blocksID"), blocksID);
       rep.saveStepAttribute(idTransformation, idStep, getRepCode("partitionID"), partitionID);
       rep.saveStepAttribute(idTransformation, idStep, getRepCode("escapeCharacter"),
@@ -832,8 +822,6 @@ public class CsvInputMeta extends BaseStepMeta
           isaddresult = (Boolean) entry.getValue();
         } else if ("ENCODING".equals(attributeKey)) {
           encoding = (String) entry.getValue();
-        } else if ("currentRestructNumber".equals(attributeKey)) {
-          currentRestructNumber = (Integer) entry.getValue();
         } else if ("blocksID".equals(attributeKey)) {
           blocksID = (String) entry.getValue();
         } else if ("partitionID".equals(attributeKey)) {
@@ -918,20 +906,6 @@ public class CsvInputMeta extends BaseStepMeta
    */
   public void setNewlinePossibleInFields(boolean newlinePossibleInFields) {
     this.newlinePossibleInFields = newlinePossibleInFields;
-  }
-
-  /**
-   * @return the currentRestructNumber
-   */
-  public int getCurrentRestructNumber() {
-    return currentRestructNumber;
-  }
-
-  /**
-   * @param currentRestructNum the currentRestructNumber to set
-   */
-  public void setCurrentRestructNumber(int currentRestructNum) {
-    this.currentRestructNumber = currentRestructNum;
   }
 
   public void setPartitionID(String partitionID) {

--- a/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
@@ -46,7 +46,6 @@ import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeas
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.load.BlockDetails;
 import org.apache.carbondata.core.util.CarbonProperties;
-import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.processing.api.dataloader.DataLoadModel;
 import org.apache.carbondata.processing.api.dataloader.SchemaInfo;
 import org.apache.carbondata.processing.csvreaderstep.CsvInputMeta;
@@ -184,7 +183,6 @@ public class GraphGenerator {
   private boolean isColumnar;
   private String factTableName;
   private String factStoreLocation;
-  private int currentRestructNumber;
   private String blocksID;
   private String escapeCharacter;
   /**
@@ -205,7 +203,7 @@ public class GraphGenerator {
   private String maxColumns;
 
   public GraphGenerator(DataLoadModel dataLoadModel, boolean isHDFSReadMode, String partitionID,
-      String factStoreLocation, int currentRestructNum, int allocate,
+      String factStoreLocation, int allocate,
       CarbonDataLoadSchema carbonDataLoadSchema, String segmentId) {
     CarbonMetadata.getInstance().addCarbonTable(carbonDataLoadSchema.getCarbonTable());
     this.schemaInfo = dataLoadModel.getSchemaInfo();
@@ -219,7 +217,6 @@ public class GraphGenerator {
     this.partitionID = partitionID;
     this.factStoreLocation = factStoreLocation;
     this.isColumnar = Boolean.parseBoolean(CarbonCommonConstants.IS_COLUMNAR_STORAGE_DEFAULTVALUE);
-    this.currentRestructNumber = currentRestructNum;
     this.blocksID = dataLoadModel.getBlocksID();
     this.taskNo = dataLoadModel.getTaskNo();
     this.factTimeStamp = dataLoadModel.getFactTimeStamp();
@@ -231,10 +228,10 @@ public class GraphGenerator {
   }
 
   public GraphGenerator(DataLoadModel dataLoadModel, boolean isHDFSReadMode, String partitionID,
-      String factStoreLocation, int currentRestructNum, int allocate,
-      CarbonDataLoadSchema carbonDataLoadSchema, String segmentId, String outputLocation) {
-    this(dataLoadModel, isHDFSReadMode, partitionID, factStoreLocation, currentRestructNum,
-        allocate, carbonDataLoadSchema, segmentId);
+      String factStoreLocation, int allocate, CarbonDataLoadSchema carbonDataLoadSchema,
+      String segmentId, String outputLocation) {
+    this(dataLoadModel, isHDFSReadMode, partitionID, factStoreLocation, allocate,
+        carbonDataLoadSchema, segmentId);
     this.outputLocation = outputLocation;
   }
 
@@ -442,7 +439,6 @@ public class GraphGenerator {
     csvInputMeta.setEnclosure("\"");
     csvInputMeta.setHeaderPresent(true);
     csvInputMeta.setMaxColumns(maxColumns);
-    csvInputMeta.setCurrentRestructNumber(graphConfiguration.getCurrentRestructNumber());
     StepMeta csvDataStep =
         new StepMeta(GraphGeneratorConstants.CSV_INPUT, (StepMetaInterface) csvInputMeta);
     csvDataStep.setLocation(100, 100);
@@ -473,12 +469,6 @@ public class GraphGenerator {
     sliceMerger.setTabelName(configurationInfo.getTableName());
     sliceMerger.setTableName(schemaInfo.getTableName());
     sliceMerger.setDatabaseName(schemaInfo.getDatabaseName());
-    if (null != this.factStoreLocation) {
-      sliceMerger.setCurrentRestructNumber(
-          CarbonUtil.getRestructureNumber(this.factStoreLocation, this.factTableName));
-    } else {
-      sliceMerger.setCurrentRestructNumber(configurationInfo.getCurrentRestructNumber());
-    }
     sliceMerger.setGroupByEnabled(isAutoAggRequest + "");
     if (isAutoAggRequest) {
       String[] aggType = configurationInfo.getAggType();
@@ -559,7 +549,6 @@ public class GraphGenerator {
     seqMeta.setDatabaseName(schemaInfo.getDatabaseName());
     seqMeta.setComplexDelimiterLevel1(schemaInfo.getComplexDelimiterLevel1());
     seqMeta.setComplexDelimiterLevel2(schemaInfo.getComplexDelimiterLevel2());
-    seqMeta.setCurrentRestructNumber(graphConfiguration.getCurrentRestructNumber());
     seqMeta.setCarbonMetaHier(graphConfiguration.getMetaHeirString());
     seqMeta.setCarbonmsr(graphConfiguration.getMeasuresString());
     seqMeta.setCarbonProps(graphConfiguration.getPropertiesString());
@@ -620,7 +609,6 @@ public class GraphGenerator {
     carbonMdKey.setDatabaseName(schemaInfo.getDatabaseName());
     carbonMdKey.setTableName(schemaInfo.getTableName());
     carbonMdKey.setComplexTypeString(graphConfiguration.getComplexTypeString());
-    carbonMdKey.setCurrentRestructNumber(graphConfiguration.getCurrentRestructNumber());
     carbonMdKey.setAggregateLevels(CarbonDataProcessorUtil
         .getLevelCardinalitiesString(graphConfiguration.getDimCardinalities(),
             graphConfiguration.getDimensions()));
@@ -765,7 +753,6 @@ public class GraphGenerator {
     sortRowsMeta.setTableName(schemaInfo.getTableName());
     sortRowsMeta.setDatabaseName(schemaInfo.getDatabaseName());
     sortRowsMeta.setOutputRowSize(actualMeasures.length + 1 + "");
-    sortRowsMeta.setCurrentRestructNumber(graphConfiguration.getCurrentRestructNumber());
     sortRowsMeta.setDimensionCount(graphConfiguration.getDimensions().length + "");
     sortRowsMeta.setComplexDimensionCount(graphConfiguration.getComplexTypeString().isEmpty() ?
         "0" :
@@ -797,7 +784,6 @@ public class GraphGenerator {
       CarbonDataLoadSchema carbonDataLoadSchema) throws GraphGeneratorException {
     //
     GraphConfigurationInfo graphConfiguration = new GraphConfigurationInfo();
-    graphConfiguration.setCurrentRestructNumber(currentRestructNumber);
     List<CarbonDimension> dimensions = carbonDataLoadSchema.getCarbonTable()
         .getDimensionByTableName(carbonDataLoadSchema.getCarbonTable().getFactTableName());
     prepareIsUseInvertedIndex(dimensions, graphConfiguration);

--- a/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
@@ -186,7 +186,6 @@ public class GraphConfigurationInfo {
    * type
    */
   private char[] type;
-  private int currentRestructNumber;
   private String levelAnddataType;
 
   private Boolean[] isNoDictionaryDimMapping;
@@ -948,17 +947,6 @@ public class GraphConfigurationInfo {
    */
   public void setType(char[] type) {
     this.type = type;
-  }
-
-  /**
-   * @return currentRestructNumber the current Restruct Number
-   */
-  public int getCurrentRestructNumber() {
-    return currentRestructNumber;
-  }
-
-  public void setCurrentRestructNumber(int currentRestructNum) {
-    this.currentRestructNumber = currentRestructNum;
   }
 
   public String getLevelAnddataType() {

--- a/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStepMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStepMeta.java
@@ -97,8 +97,6 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
 
   private Map<String, GenericDataType> complexTypes;
 
-  private int currentRestructNumber;
-
   /**
    * It is column groups in below format
    * 0,1~2~3,4,5,6~7~8,9
@@ -155,7 +153,6 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
     databaseName = "";
     columnGroupsString = "";
     noDictionaryDims = "";
-    currentRestructNumber = -1;
     measureDataType = "";
     taskNo = "";
     factTimeStamp = "";
@@ -178,8 +175,6 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
     retval.append("    ").append(XMLHandler.addTagValue("dimensionCount", dimensionCount));
     retval.append("    ").append(XMLHandler.addTagValue("complexDimsCount", complexDimsCount));
     retval.append("    ").append(XMLHandler.addTagValue("complexTypeString", complexTypeString));
-    retval.append("    ")
-        .append(XMLHandler.addTagValue("currentRestructNumber", currentRestructNumber));
     retval.append("    ").append(XMLHandler.addTagValue("measureDataType", measureDataType));
     retval.append("    ").append(XMLHandler.addTagValue("taskNo", taskNo));
     retval.append("    ").append(XMLHandler.addTagValue("factTimeStamp", factTimeStamp));
@@ -207,8 +202,6 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
       dimensionCount = XMLHandler.getTagValue(stepnode, "dimensionCount");
       complexDimsCount = XMLHandler.getTagValue(stepnode, "complexDimsCount");
       complexTypeString = XMLHandler.getTagValue(stepnode, "complexTypeString");
-      currentRestructNumber =
-          Integer.parseInt(XMLHandler.getTagValue(stepnode, "currentRestructNumber"));
       measureDataType = XMLHandler.getTagValue(stepnode, "measureDataType");
       taskNo = XMLHandler.getTagValue(stepnode, "taskNo");
       factTimeStamp = XMLHandler.getTagValue(stepnode, "factTimeStamp");
@@ -235,8 +228,6 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
       rep.saveStepAttribute(idTransformation, idStep, "dimensionCount", dimensionCount);
       rep.saveStepAttribute(idTransformation, idStep, "complexDimsCount", complexDimsCount);
       rep.saveStepAttribute(idTransformation, idStep, "complexTypeString", complexTypeString);
-      rep.saveStepAttribute(idTransformation, idStep, "currentRestructNumber",
-          currentRestructNumber);
       rep.saveStepAttribute(idTransformation, idStep, "measureDataType", measureDataType);
       rep.saveStepAttribute(idTransformation, idStep, "taskNo", taskNo);
       rep.saveStepAttribute(idTransformation, idStep, "factTimeStamp", factTimeStamp);
@@ -267,7 +258,6 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
       dimensionCount = rep.getStepAttributeString(idStep, "dimensionCount");
       complexDimsCount = rep.getStepAttributeString(idStep, "complexDimsCount");
       complexTypeString = rep.getStepAttributeString(idStep, "complexTypeString");
-      currentRestructNumber = (int) rep.getStepAttributeInteger(idStep, "currentRestructNumber");
       measureDataType = rep.getStepAttributeString(idStep, "measureDataType");
       taskNo = rep.getStepAttributeString(idStep, "taskNo");
       factTimeStamp = rep.getStepAttributeString(idStep, "factTimeStamp");
@@ -397,20 +387,6 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
    */
   public void setComplexTypeString(String complexTypeString) {
     this.complexTypeString = complexTypeString;
-  }
-
-  /**
-   * @return the currentRestructNumber
-   */
-  public int getCurrentRestructNumber() {
-    return currentRestructNumber;
-  }
-
-  /**
-   * @param currentRestructNum the currentRestructNumber to set
-   */
-  public void setCurrentRestructNumber(int currentRestructNum) {
-    this.currentRestructNumber = currentRestructNum;
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/step/CarbonSliceMergerStepMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/step/CarbonSliceMergerStepMeta.java
@@ -102,8 +102,6 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
    */
   private String factDimLensString;
 
-  private int currentRestructNumber = -1;
-
   private String levelAnddataTypeString;
   /**
    * partitionID
@@ -139,7 +137,6 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
     aggregatorClassString = "";
     aggregatorString = "";
     factDimLensString = "";
-    currentRestructNumber = -1;
     levelAnddataTypeString = "";
     partitionID = "";
     segmentId = "";
@@ -165,8 +162,6 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
         .append(XMLHandler.addTagValue("aggregatorClassString", aggregatorClassString));
     retval.append("    ").append(XMLHandler.addTagValue("aggregatorString", aggregatorString));
     retval.append("    ").append(XMLHandler.addTagValue("factDimLensString", factDimLensString));
-    retval.append("    ")
-        .append(XMLHandler.addTagValue("currentRestructNumber", currentRestructNumber));
     retval.append("    ")
         .append(XMLHandler.addTagValue("levelAnddataTypeString", levelAnddataTypeString));
     retval.append("    ").append(XMLHandler.addTagValue("partitionID", partitionID));
@@ -197,8 +192,6 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
       aggregatorString = XMLHandler.getTagValue(stepnode, "aggregatorString");
       factDimLensString = XMLHandler.getTagValue(stepnode, "factDimLensString");
       levelAnddataTypeString = XMLHandler.getTagValue(stepnode, "levelAnddataTypeString");
-      currentRestructNumber =
-          Integer.parseInt(XMLHandler.getTagValue(stepnode, "currentRestructNumber"));
       partitionID = XMLHandler.getTagValue(stepnode, "partitionID");
       segmentId = XMLHandler.getTagValue(stepnode, "segmentId");
       taskNo = XMLHandler.getTagValue(stepnode, "taskNo");
@@ -232,8 +225,6 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
       rep.saveStepAttribute(idTransformation, idStep, "factDimLensString", factDimLensString);
       rep.saveStepAttribute(idTransformation, idStep, "levelAnddataTypeString",
           levelAnddataTypeString);
-      rep.saveStepAttribute(idTransformation, idStep, "currentRestructNumber",
-          currentRestructNumber);
       rep.saveStepAttribute(idTransformation, idStep, "partitionID", partitionID);
       rep.saveStepAttribute(idTransformation, idStep, "segmentId", segmentId);
       rep.saveStepAttribute(idTransformation, idStep, "taskNo", taskNo);
@@ -278,7 +269,6 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
       aggregatorString = rep.getStepAttributeString(idStep, "aggregatorString");
       factDimLensString = rep.getStepAttributeString(idStep, "factDimLensString");
       levelAnddataTypeString = rep.getStepAttributeString(idStep, "levelAnddataTypeString");
-      currentRestructNumber = (int) rep.getStepAttributeInteger(idStep, "currentRestructNumber");
       partitionID = rep.getStepAttributeString(idStep, "partitionID");
       segmentId = rep.getStepAttributeString(idStep, "segmentId");
       taskNo = rep.getStepAttributeString(idStep, "taskNo");
@@ -516,20 +506,6 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
    */
   public void setFactDimLensString(String factDimLensString1) {
     this.factDimLensString = factDimLensString1;
-  }
-
-  /**
-   * @return the currentRestructNumber
-   */
-  public int getCurrentRestructNumber() {
-    return currentRestructNumber;
-  }
-
-  /**
-   * @param currentRestructNum the currentRestructNumber to set
-   */
-  public void setCurrentRestructNumber(int currentRestructNum) {
-    this.currentRestructNumber = currentRestructNum;
   }
 
   public String getLevelAnddataTypeString() {

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdatastep/SortKeyStepMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdatastep/SortKeyStepMeta.java
@@ -97,8 +97,6 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
    */
   private String updateMemberRequest;
 
-  private int currentRestructNumber;
-
   private String measureDataType;
 
   private String noDictionaryDims;
@@ -134,7 +132,6 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
     complexDimensionCount = "";
     measureCount = "";
     updateMemberRequest = "";
-    currentRestructNumber = -1;
     measureDataType = "";
     partitionID = "";
     segmentId = "";
@@ -163,8 +160,6 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append("    ").append(XMLHandler.addTagValue("measureCount", this.measureCount));
     retval.append("    ")
         .append(XMLHandler.addTagValue("isUpdateMemberRequest", this.updateMemberRequest));
-    retval.append("    ")
-        .append(XMLHandler.addTagValue("currentRestructNumber", currentRestructNumber));
     retval.append("    ").append(XMLHandler.addTagValue("measureDataType", measureDataType));
     retval.append("    ").append(XMLHandler.addTagValue("partitionID", partitionID));
     retval.append("    ").append(XMLHandler.addTagValue("segmentId", segmentId));
@@ -195,8 +190,6 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
       this.measureCount = XMLHandler.getTagValue(stepnode, "measureCount");
       this.updateMemberRequest = XMLHandler.getTagValue(stepnode, "isUpdateMemberRequest");
       this.measureDataType = XMLHandler.getTagValue(stepnode, "measureDataType");
-      currentRestructNumber =
-          Integer.parseInt(XMLHandler.getTagValue(stepnode, "currentRestructNumber"));
       this.partitionID = XMLHandler.getTagValue(stepnode, "partitionID");
       this.segmentId = XMLHandler.getTagValue(stepnode, "segmentId");
       this.taskNo = XMLHandler.getTagValue(stepnode, "taskNo");
@@ -231,8 +224,6 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
       rep.saveStepAttribute(idTransformation, idStep, "measureCount", this.measureCount);
       rep.saveStepAttribute(idTransformation, idStep, "isUpdateMemberRequest",
           this.updateMemberRequest);
-      rep.saveStepAttribute(idTransformation, idStep, "currentRestructNumber",
-          currentRestructNumber);
       rep.saveStepAttribute(idTransformation, idStep, "measureDataType", measureDataType);
       rep.saveStepAttribute(idTransformation, idStep, "partitionID", partitionID);
       rep.saveStepAttribute(idTransformation, idStep, "segmentId", segmentId);
@@ -267,8 +258,6 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
       this.measureCount = rep.getStepAttributeString(idStep, "measureCount");
       this.updateMemberRequest = rep.getStepAttributeString(idStep, "isUpdateMemberRequest");
       this.measureDataType = rep.getStepAttributeString(idStep, "measureDataType");
-      this.currentRestructNumber =
-          (int) rep.getStepAttributeInteger(idStep, "currentRestructNumber");
       this.partitionID = rep.getStepAttributeString(idStep, "partitionID");
       this.segmentId = rep.getStepAttributeString(idStep, "segmentId");
       this.taskNo = rep.getStepAttributeString(idStep, "taskNo");
@@ -448,20 +437,6 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
    */
   public void setIsUpdateMemberRequest(String isUpdateMemberRequest) {
     this.updateMemberRequest = isUpdateMemberRequest;
-  }
-
-  /**
-   * @return the currentRestructNumber
-   */
-  public int getCurrentRestructNumber() {
-    return currentRestructNumber;
-  }
-
-  /**
-   * @param currentRestructNum the currentRestructNumber to set
-   */
-  public void setCurrentRestructNumber(int currentRestructNum) {
-    this.currentRestructNumber = currentRestructNum;
   }
 
   public String getMeasureDataType() {

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
@@ -349,7 +349,6 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
    * databaseName
    */
   private String databaseName;
-  private int currentRestructNumber;
   /**
    * partitionID
    */
@@ -646,7 +645,6 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     measureDataType = "";
     columnAndTableNameColumnMapForAggString = "";
     denormColumNames = "";
-    currentRestructNumber = -1;
     partitionID = "";
     segmentId = "";
     taskNo = "";
@@ -711,8 +709,6 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     retval.append("    ").append(XMLHandler.addTagValue("databaseName", databaseName));
     retval.append("    ").append(XMLHandler.addTagValue("tableName", tableName));
     retval.append("    ").append(XMLHandler.addTagValue("denormColumNames", denormColumNames));
-    retval.append("    ")
-        .append(XMLHandler.addTagValue("currentRestructNumber", currentRestructNumber));
     retval.append("    ").append(XMLHandler.addTagValue("partitionID", partitionID));
     retval.append("    ").append(XMLHandler.addTagValue("segmentId", segmentId));
     retval.append("    ").append(XMLHandler.addTagValue("taskNo", taskNo));
@@ -763,8 +759,6 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
       tableName = XMLHandler.getTagValue(stepnode, "tableName");
       databaseName = XMLHandler.getTagValue(stepnode, "databaseName");
       denormColumNames = XMLHandler.getTagValue(stepnode, "denormColumNames");
-      currentRestructNumber =
-          Integer.parseInt(XMLHandler.getTagValue(stepnode, "currentRestructNumber"));
       partitionID = XMLHandler.getTagValue(stepnode, "partitionID");
       segmentId = XMLHandler.getTagValue(stepnode, "segmentId");
       taskNo = XMLHandler.getTagValue(stepnode, "taskNo");
@@ -1334,7 +1328,6 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
 
       tableName = rep.getStepAttributeString(idStep, "tableName");
       denormColumNames = rep.getStepAttributeString(idStep, "denormColumNames");
-      currentRestructNumber = (int) rep.getStepAttributeInteger(idStep, "currentRestructNumber");
       partitionID = rep.getStepAttributeString(idStep, "partitionID");
       segmentId = rep.getStepAttributeString(idStep, "segmentId");
       taskNo = rep.getStepAttributeString(idStep, "taskNo");
@@ -1388,8 +1381,6 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
       rep.saveStepAttribute(idTransformation, idStep, "databaseName", databaseName);
       rep.saveStepAttribute(idTransformation, idStep, "tableName", tableName);
       rep.saveStepAttribute(idTransformation, idStep, "denormColumNames", denormColumNames);
-      rep.saveStepAttribute(idTransformation, idStep, "currentRestructNumber",
-          currentRestructNumber);
       rep.saveStepAttribute(idTransformation, idStep, "partitionID", partitionID);
       rep.saveStepAttribute(idTransformation, idStep, "segmentId", segmentId);
       rep.saveStepAttribute(idTransformation, idStep, "taskNo", taskNo);
@@ -1587,14 +1578,6 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
 
   public void setDenormColumNames(String denormColumNames) {
     this.denormColumNames = denormColumNames;
-  }
-
-  public int getCurrentRestructNumber() {
-    return currentRestructNumber;
-  }
-
-  public void setCurrentRestructNumber(int currentRestructNum) {
-    this.currentRestructNumber = currentRestructNum;
   }
 
   public String getNoDictionaryDims() {


### PR DESCRIPTION
This PR is mainly to improve code quality of Carbon which includes removal of an unwanted feature.

Problem: Code contains currentRestructureNumber variable which is not used in the code now

Impact area: Data load flow

Fix: Remove the usage of currentRestructureNumber variable everywhere in the code