### PR TITLE
[CARBONDATA-217]Fixed data mismatch issue after compaction

### DIFF
--- a/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/RowResultMerger.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/RowResultMerger.java
@@ -34,6 +34,7 @@ import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 import org.apache.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.carbon.path.CarbonStorePath;
@@ -250,6 +251,14 @@ public class RowResultMerger {
             loadModel.getPartitionId(), loadModel.getSegmentId());
     carbonFactDataHandlerModel.setCarbonDataDirectoryPath(carbonDataDirectoryPath);
 
+    List<CarbonDimension> dimensionByTableName =
+        loadModel.getCarbonDataLoadSchema().getCarbonTable().getDimensionByTableName(tableName);
+    boolean[] isUseInvertedIndexes = new boolean[dimensionByTableName.size()];
+    int index = 0;
+    for (CarbonDimension dimension : dimensionByTableName) {
+      isUseInvertedIndexes[index++] = dimension.isUseInvertedIndnex();
+    }
+    carbonFactDataHandlerModel.setIsUseInvertedIndex(isUseInvertedIndexes);
     return carbonFactDataHandlerModel;
   }
 


### PR DESCRIPTION
Step1: Run Data load and restart server
Step2: Start compaxction
Step3: Run Query
Query is giving different result after compaction
Problem:In compaction flow we are not setting the useInvertedIndex boolean for key column so it is false and it is not writing column data in sorted order and binary search is failing 
Solution: Need to set the useInvertedIndex array from carbon table
