### PR TITLE
Show query statistics as millseconds instead of seconds

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorder.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorder.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 
-import static org.apache.carbondata.core.util.CarbonUtil.add;
 import static org.apache.carbondata.core.util.CarbonUtil.printLine;
 
 import org.apache.commons.lang3.StringUtils;
@@ -121,8 +120,8 @@ public class DriverQueryStatisticsRecorder {
     String load_meta_time = "";
     String block_allocation_time = "";
     String block_identification_time = "";
-    Double driver_part_time_tmp = 0.0;
-    Double driver_part_time_tmp2 = 0.0;
+    long driver_part_time_tmp = 0L;
+    long driver_part_time_tmp2 = 0L;
     String splitChar = " ";
     try {
       // get statistic time from the QueryStatistic
@@ -130,21 +129,21 @@ public class DriverQueryStatisticsRecorder {
         switch (statistic.getMessage()) {
           case QueryStatisticsConstants.SQL_PARSE:
             sql_parse_time += statistic.getTimeTaken() + splitChar;
-            driver_part_time_tmp = add(driver_part_time_tmp, statistic.getTimeTaken());
+            driver_part_time_tmp += statistic.getTimeTaken();
             break;
           case QueryStatisticsConstants.LOAD_META:
             load_meta_time += statistic.getTimeTaken() + splitChar;
-            driver_part_time_tmp = add(driver_part_time_tmp, statistic.getTimeTaken());
+            driver_part_time_tmp += statistic.getTimeTaken();
             break;
           case QueryStatisticsConstants.BLOCK_ALLOCATION:
             block_allocation_time += statistic.getTimeTaken() + splitChar;
-            driver_part_time_tmp = add(driver_part_time_tmp, statistic.getTimeTaken());
-            driver_part_time_tmp2 = add(driver_part_time_tmp2, statistic.getTimeTaken());
+            driver_part_time_tmp += statistic.getTimeTaken();
+            driver_part_time_tmp2 += statistic.getTimeTaken();
             break;
           case QueryStatisticsConstants.BLOCK_IDENTIFICATION:
             block_identification_time += statistic.getTimeTaken() + splitChar;
-            driver_part_time_tmp = add(driver_part_time_tmp, statistic.getTimeTaken());
-            driver_part_time_tmp2 = add(driver_part_time_tmp2, statistic.getTimeTaken());
+            driver_part_time_tmp += statistic.getTimeTaken();
+            driver_part_time_tmp2 += statistic.getTimeTaken();
             break;
           default:
             break;

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatistic.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatistic.java
@@ -98,8 +98,8 @@ public class QueryStatistic implements Serializable {
     return this.message;
   }
 
-  public double getTimeTaken() {
-    return (double)this.timeTaken/1000;
+  public long getTimeTaken() {
+    return  this.timeTaken;
   }
 
   public long getCount() {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1432,17 +1432,5 @@ public final class CarbonUtil {
     return builder.toString();
   }
 
-  /**
-   * Below method will for double plus double
-   *
-   * @param v1
-   * @param v2
-   */
-  public static double add(double v1, double v2)
-  {
-    BigDecimal b1 = new BigDecimal(Double.toString(v1));
-    BigDecimal b2 = new BigDecimal(Double.toString(v2));
-    return  b1.add(b2).doubleValue();
-  }
 }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -28,7 +28,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;


### PR DESCRIPTION
# Why raised this PR?

It is more proper to show time cost of statistics as millseconds instead of seconds