### PR TITLE
[CARBONDATA-221] Fix the bug of inverted index that store inverted index in metadata.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
@@ -75,11 +75,6 @@ public class ColumnSchema implements Serializable {
   private boolean isDimensionColumn;
 
   /**
-   * Whether the column should use inverted index
-   */
-  private boolean useInvertedIndex = true;
-
-  /**
    * The group ID for column used for row format columns,
    * where in columns in each group are chunked together.
    */
@@ -180,14 +175,22 @@ public class ColumnSchema implements Serializable {
    * the isUseInvertedIndex
    */
   public boolean isUseInvertedIndex() {
-    return useInvertedIndex;
+    return this.hasEncoding(Encoding.INVERTED_INDEX);
   }
 
   /**
    * @param useInvertedIndex the useInvertedIndex to set
    */
   public void setUseInvertedIndex(boolean useInvertedIndex) {
-    this.useInvertedIndex = useInvertedIndex;
+    if (useInvertedIndex) {
+      if (!hasEncoding(Encoding.INVERTED_INDEX)) {
+        this.getEncodingList().add(Encoding.INVERTED_INDEX);
+      }
+    } else {
+      if (hasEncoding(Encoding.INVERTED_INDEX)) {
+        this.getEncodingList().remove(Encoding.INVERTED_INDEX);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -708,6 +708,7 @@ public final class CarbonCommonConstants {
   public static final String PARTITIONCLASS = "partitionclass";
   public static final String PARTITIONCOUNT = "partitioncount";
   public static final String COLUMN_PROPERTIES = "columnproperties";
+  public static final String NO_INVERTED_INDEX = "no_inverted_index";
 
   /**
    * this variable is to enable/disable identify high cardinality during first data loading

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -183,7 +183,9 @@ public class CarbonMetadataUtil {
       if (!isSortedKeyColumn[i]) {
         dataChunk.setRowid_page_offset(blockletInfoColumnar.getKeyBlockIndexOffSets()[j]);
         dataChunk.setRowid_page_length(blockletInfoColumnar.getKeyBlockIndexLength()[j]);
-        encodings.add(Encoding.INVERTED_INDEX);
+        if (!encodings.contains(Encoding.INVERTED_INDEX)) {
+          encodings.add(Encoding.INVERTED_INDEX);
+        }
         j++;
       }
 

--- a/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -37,7 +37,6 @@ object CarbonExample {
            (ID Int, date Timestamp, country String,
            name String, phonetype String, serialname String, salary Int)
            STORED BY 'carbondata'
-           TBLPROPERTIES('NO_INVERTED_INDEX'='country,name,phonetype')
            """)
 
     cc.sql(s"""
@@ -51,5 +50,6 @@ object CarbonExample {
            GROUP BY country
            """).show()
 
+    cc.sql("DROP TABLE IF EXISTS t3")
   }
 }

--- a/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -37,6 +37,7 @@ object CarbonExample {
            (ID Int, date Timestamp, country String,
            name String, phonetype String, serialname String, salary Int)
            STORED BY 'carbondata'
+           TBLPROPERTIES('NO_INVERTED_INDEX'='country,name,phonetype')
            """)
 
     cc.sql(s"""
@@ -50,6 +51,5 @@ object CarbonExample {
            GROUP BY country
            """).show()
 
-    cc.sql("DROP TABLE IF EXISTS t3")
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -650,9 +650,9 @@ class CarbonSqlParser()
     var noInvertedIdxColsProps: Array[String] = Array[String]()
     var noInvertedIdxCols: Seq[String] = Seq[String]()
 
-    if (tableProperties.get("NO_INVERTED_INDEX").isDefined) {
+    if (tableProperties.get(CarbonCommonConstants.NO_INVERTED_INDEX).isDefined) {
       noInvertedIdxColsProps =
-        tableProperties.get("NO_INVERTED_INDEX").get.split(',').map(_.trim)
+        tableProperties.get(CarbonCommonConstants.NO_INVERTED_INDEX).get.split(',').map(_.trim)
       noInvertedIdxColsProps
         .map { noInvertedIdxColProp =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(noInvertedIdxColProp))) {

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -1838,6 +1838,8 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
       dimListExcludingNoDictionaryColumn =
           new ArrayList<>(dimensionsList.size() - meta.noDictionaryCols.length);
       for (CarbonDimension dimension : dimensionsList) {
+        // Here if dimension.getEncoder() lnly contains Encoding.INVERTED_INDEX, it
+        // means that NoDicColumn using InvertedIndex, so not put it into dic dims list.
         if (!dimension.getEncoder().isEmpty() && !((1 == dimension.getEncoder().size()) &&
             dimension.getEncoder().contains(Encoding.INVERTED_INDEX))) {
           dimListExcludingNoDictionaryColumn.add(dimension);

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -48,6 +48,7 @@ import org.apache.carbondata.common.logging.impl.StandardLogService;
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
 import org.apache.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
+import org.apache.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
@@ -1837,7 +1838,8 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
       dimListExcludingNoDictionaryColumn =
           new ArrayList<>(dimensionsList.size() - meta.noDictionaryCols.length);
       for (CarbonDimension dimension : dimensionsList) {
-        if (!dimension.getEncoder().isEmpty()) {
+        if (!dimension.getEncoder().isEmpty() && !((1 == dimension.getEncoder().size()) &&
+            dimension.getEncoder().contains(Encoding.INVERTED_INDEX))) {
           dimListExcludingNoDictionaryColumn.add(dimension);
         }
       }


### PR DESCRIPTION
## Why raise this pr?
Inverted index in ddl info was not stored into store, and when we restart the culster, query might mismatch.
## How to solve?
Using the Encoding as the indentifier to check whether using inverted index.
