### PR TITLE
[CARBONDATA-229] Array Index of bound exception thrown from dictionary look up while writing sort index file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
@@ -95,7 +95,7 @@ public class DictionaryCacheLoaderImpl implements DictionaryCacheLoader {
     int dictionaryChunkSize = CarbonUtil.getDictionaryChunkSize();
     int sizeOfLastDictionaryChunk = dictionaryInfo.getSizeOfLastDictionaryChunk();
     int sizeOfOneDictionaryChunk = dictionaryChunkSize - sizeOfLastDictionaryChunk;
-    if (sizeOfOneDictionaryChunk == 0) {
+    if (sizeOfOneDictionaryChunk <= 0) {
       sizeOfOneDictionaryChunk = dictionaryChunkSize;
     }
     List<List<byte[]>> dictionaryChunks =
@@ -111,7 +111,9 @@ public class DictionaryCacheLoaderImpl implements DictionaryCacheLoader {
       }
     }
     for (List<byte[]> dictionaryChunk : dictionaryChunks) {
-      dictionaryInfo.addDictionaryChunk(dictionaryChunk);
+      if (!dictionaryChunk.isEmpty()) {
+        dictionaryInfo.addDictionaryChunk(dictionaryChunk);
+      }
     }
   }
 


### PR DESCRIPTION
Problem: Array Index of bound exception thrown from dictionary look up while writing sort index file

Analysis: Whenever we load dictionary data into memory, then in case of populating reverse dictionary object sometimes a chunk which has no value is also getting added to the dictionary chunk list. This is happening because the logic for dictionary chunk distribution in case of forward dictionary is not implemented for reverse dictionary and 0 size dictionary chunks are not getting removed while adding to the list of dictionary chunks.

Solution: Add the same distribution logic we have in forward dictionary for populating reverse dictionary object

Impact area: Sort index generation