### PR TITLE
[CARBONDATA-220] TimeStampDirectDictionaryGenerator_UT.java is not running in the build

### DIFF
--- a/processing/src/test/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampDirectDictionaryGeneratorTest.java
+++ b/processing/src/test/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampDirectDictionaryGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.keygenerator.directdictionary.timestamp;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonProperties;
@@ -86,6 +87,7 @@ public class TimeStampDirectDictionaryGeneratorTest {
         .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
             CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
     timeParser.setLenient(false);
+    timeParser.setTimeZone(TimeZone.getTimeZone("IST"));
     String actualValue = timeParser.format(date);
     Assert.assertEquals("1970-01-01 05:30:00", actualValue);
   }


### PR DESCRIPTION
# **Why raise this pr?**

Our build script does not execute the test case if the class name does not have Test or TestCase 
There was no boundary value test case for the timestamp datatype.

# **How to resolve?**

We have to refactor the class and have to add the boundary test cases.