### PR TITLE
[CARBONDATA-234]wrong message getting displayed while compaction.

### DIFF
--- a/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
@@ -214,8 +214,7 @@ public class CarbonCompactionUtil {
         } else {
           LOGGER.error("Unable to delete the compaction request file " + statusFile);
         }
-      }
-      else {
+      } else {
         LOGGER.info("Compaction request file is not present. file is : " + statusFile);
       }
     } catch (IOException e) {
@@ -249,8 +248,7 @@ public class CarbonCompactionUtil {
           LOGGER.error("Not able to create a compaction required file - " + statusFile);
           return false;
         }
-      }
-      else {
+      } else {
         LOGGER.info("Compaction request file : " + statusFile + " already exist.");
       }
     } catch (IOException e) {

--- a/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
@@ -198,27 +198,30 @@ public class CarbonCompactionUtil {
    */
   public static boolean deleteCompactionRequiredFile(String metaFolderPath,
       CompactionType compactionType) {
-    String statusFile;
+    String compactionRequiredFile;
     if (compactionType.equals(CompactionType.MINOR_COMPACTION)) {
-      statusFile = metaFolderPath + CarbonCommonConstants.FILE_SEPARATOR
+      compactionRequiredFile = metaFolderPath + CarbonCommonConstants.FILE_SEPARATOR
           + CarbonCommonConstants.minorCompactionRequiredFile;
     } else {
-      statusFile = metaFolderPath + CarbonCommonConstants.FILE_SEPARATOR
+      compactionRequiredFile = metaFolderPath + CarbonCommonConstants.FILE_SEPARATOR
           + CarbonCommonConstants.majorCompactionRequiredFile;
     }
     try {
-      if (FileFactory.isFileExist(statusFile, FileFactory.getFileType(statusFile))) {
-        if (FileFactory.getCarbonFile(statusFile, FileFactory.getFileType(statusFile)).delete()) {
-          LOGGER.info("Deleted the compaction request file " + statusFile);
+      if (FileFactory
+          .isFileExist(compactionRequiredFile, FileFactory.getFileType(compactionRequiredFile))) {
+        if (FileFactory
+            .getCarbonFile(compactionRequiredFile, FileFactory.getFileType(compactionRequiredFile))
+            .delete()) {
+          LOGGER.info("Deleted the compaction request file " + compactionRequiredFile);
           return true;
         } else {
-          LOGGER.error("Unable to delete the compaction request file " + statusFile);
+          LOGGER.error("Unable to delete the compaction request file " + compactionRequiredFile);
         }
       } else {
-        LOGGER.info("Compaction request file is not present. file is : " + statusFile);
+        LOGGER.info("Compaction request file is not present. file is : " + compactionRequiredFile);
       }
     } catch (IOException e) {
-      LOGGER.error("Exception in deleting the compaction request file " + e.getMessage() );
+      LOGGER.error("Exception in deleting the compaction request file " + e.getMessage());
     }
     return false;
   }

--- a/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -210,9 +211,13 @@ public class CarbonCompactionUtil {
       if (FileFactory.isFileExist(statusFile, FileFactory.getFileType(statusFile))) {
         if (FileFactory.getCarbonFile(statusFile, FileFactory.getFileType(statusFile)).delete()) {
           LOGGER.info("Deleted the compaction request file " + statusFile);
+          return true;
         } else {
           LOGGER.error("Unable to delete the compaction request file " + statusFile);
         }
+      }
+      else {
+        LOGGER.info("Compaction request file is not present. file is : " + statusFile);
       }
     } catch (IOException e) {
       LOGGER.error("Exception in deleting the compaction request file " + e.getMessage() );
@@ -245,6 +250,9 @@ public class CarbonCompactionUtil {
           LOGGER.error("Not able to create a compaction required file - " + statusFile);
           return false;
         }
+      }
+      else {
+        LOGGER.info("Compaction request file : " + statusFile + " already exist.");
       }
     } catch (IOException e) {
       LOGGER.error("Exception in creating the compaction request file " + e.getMessage() );

--- a/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;


### PR DESCRIPTION
Why raise this pr?

for each compaction the error message "compaction request file can not be deleted " is printing even though it has been deleted from the file system.

How to resolve?

The return of the boolean value is missing in the API deleteCompactionRequiredFile(). Need to return the boolean value correctly for getting the delete status.