### PR TITLE
[CARBONDATA-236] fix maven compile warning

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -97,11 +97,6 @@
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-format</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
       <version>3.4.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,11 @@
             <additionalparam>-Xdoclint:missing</additionalparam>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>2.4.3</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
fix below two warning when maven compile:

1. maven-shade-plugin omit version
2. [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.carbondata:carbondata-format:jar -> duplicate declaration of version ${project.version} @ line 99, column 17