### PR TITLE
[CARBONDATA-238]CarbonOptimizer shouldn't add CarbonDictionaryCatalystDecoder for HiveTable

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -73,6 +73,14 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
     transformCarbonPlan(plan, relations)
   }
 
+  private def hasRelation(currentPlan: LogicalPlan,
+      pf: PartialFunction[LogicalPlan, LogicalRelation]): Boolean = {
+    currentPlan collectFirst pf match {
+      case Some(_) => true
+      case None => false
+    }
+  }
+
   /**
    * Steps for changing the plan.
    * 1. It finds out the join condition columns and dimension aggregate columns which are need to
@@ -90,311 +98,343 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
     val aliasMap = CarbonAliasDecoderRelation()
     // collect alias information before hand.
     collectInformationOnAttributes(plan, aliasMap)
+
+    val hasNonCarbonRelation = hasRelation(plan, {case l: LogicalRelation
+      if !l.relation.isInstanceOf[CarbonDatasourceRelation] => l})
+
+    def checkRelation(currentPlan: LogicalPlan): Boolean = {
+      if (hasNonCarbonRelation) {
+        hasRelation(currentPlan, {case l: LogicalRelation
+          if l.relation.isInstanceOf[CarbonDatasourceRelation] => l})
+      } else {
+        true
+      }
+    }
+
     val transFormedPlan =
       plan transformDown {
         case cd: CarbonDictionaryTempDecoder if cd.isOuter =>
           decoder = true
           cd
-        case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-          val attrsOnSort = new util.HashSet[AttributeReferenceWrapper]()
-          sort.order.map { s =>
-            s.collect {
-              case attr: AttributeReference
-                if isDictionaryEncoded(attr, relations, aliasMap) =>
-                attrsOnSort.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-            }
-          }
-          var child = sort.child
-          if (attrsOnSort.size() > 0 && !child.isInstanceOf[Sort]) {
-            child = CarbonDictionaryTempDecoder(attrsOnSort,
-              new util.HashSet[AttributeReferenceWrapper](), sort.child)
-          }
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](),
-              Sort(sort.order, sort.global, child),
-              isOuter = true)
-          } else {
-            Sort(sort.order, sort.global, child)
-          }
+        case currentPlan =>
+           checkRelation(currentPlan) match {
+            case true =>
+              currentPlan match {
+                case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+                  val attrsOnSort = new util.HashSet[AttributeReferenceWrapper]()
+                  sort.order.map { s =>
+                    s.collect {
+                      case attr: AttributeReference
+                        if isDictionaryEncoded(attr, relations, aliasMap) =>
+                        attrsOnSort.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
+                    }
+                  }
+                  var child = sort.child
+                  if (attrsOnSort.size() > 0 && !child.isInstanceOf[Sort]) {
+                    child = CarbonDictionaryTempDecoder(attrsOnSort,
+                      new util.HashSet[AttributeReferenceWrapper](), sort.child)
+                  }
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      Sort(sort.order, sort.global, child),
+                      isOuter = true)
+                  } else {
+                    Sort(sort.order, sort.global, child)
+                  }
 
-        case union: Union
-          if !(union.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
-               union.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
-          val leftCondAttrs = new util.HashSet[AttributeReferenceWrapper]
-          val rightCondAttrs = new util.HashSet[AttributeReferenceWrapper]
-          union.left.output.foreach(attr =>
-            leftCondAttrs.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr))))
-          union.right.output.foreach(attr =>
-            rightCondAttrs.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr))))
-          var leftPlan = union.left
-          var rightPlan = union.right
-          if (leftCondAttrs.size() > 0 &&
-              !leftPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
-            leftPlan = CarbonDictionaryTempDecoder(leftCondAttrs,
-              new util.HashSet[AttributeReferenceWrapper](),
-              union.left)
-          }
-          if (rightCondAttrs.size() > 0 &&
-              !rightPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
-            rightPlan = CarbonDictionaryTempDecoder(rightCondAttrs,
-              new util.HashSet[AttributeReferenceWrapper](),
-              union.right)
-          }
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](),
-              Union(leftPlan, rightPlan),
-              isOuter = true)
-          } else {
-            Union(leftPlan, rightPlan)
-          }
+                case union: Union
+                  if !(union.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
+                       union.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
+                  val leftCondAttrs = new util.HashSet[AttributeReferenceWrapper]
+                  val rightCondAttrs = new util.HashSet[AttributeReferenceWrapper]
+                  union.left.output.foreach(attr =>
+                    leftCondAttrs.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr))))
+                  union.right.output.foreach(attr =>
+                    rightCondAttrs.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr))))
+                  var leftPlan = union.left
+                  var rightPlan = union.right
+                  if (leftCondAttrs.size() > 0 &&
+                      !leftPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
+                    leftPlan = CarbonDictionaryTempDecoder(leftCondAttrs,
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      union.left)
+                  }
+                  if (rightCondAttrs.size() > 0 &&
+                      !rightPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
+                    rightPlan = CarbonDictionaryTempDecoder(rightCondAttrs,
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      union.right)
+                  }
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      Union(leftPlan, rightPlan),
+                      isOuter = true)
+                  } else {
+                    Union(leftPlan, rightPlan)
+                  }
 
-        case agg: Aggregate if !agg.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-          val attrsOndimAggs = new util.HashSet[AttributeReferenceWrapper]
-          agg.aggregateExpressions.map {
-            case attr: AttributeReference =>
-            case a@Alias(attr: AttributeReference, name) =>
-            case aggExp: AggregateExpression =>
-              aggExp.transform {
-                case aggExp: AggregateExpression =>
-                  collectDimensionAggregates(aggExp, attrsOndimAggs, aliasMap)
-                  aggExp
+                case agg: Aggregate if !agg.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+                  val attrsOndimAggs = new util.HashSet[AttributeReferenceWrapper]
+                  agg.aggregateExpressions.map {
+                    case attr: AttributeReference =>
+                    case a@Alias(attr: AttributeReference, name) =>
+                    case aggExp: AggregateExpression =>
+                      aggExp.transform {
+                        case aggExp: AggregateExpression =>
+                          collectDimensionAggregates(aggExp, attrsOndimAggs, aliasMap)
+                          aggExp
+                      }
+                    case others =>
+                      others.collect {
+                        case attr: AttributeReference
+                          if isDictionaryEncoded(attr, relations, aliasMap) =>
+                          attrsOndimAggs.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                              attr)))
+                      }
+                  }
+                  var child = agg.child
+                  // Incase if the child also aggregate then push down decoder to child
+                  if (attrsOndimAggs.size() > 0 && !child.equals(agg)) {
+                    child = CarbonDictionaryTempDecoder(attrsOndimAggs,
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      agg.child)
+                  }
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child),
+                      isOuter = true)
+                  } else {
+                    Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child)
+                  }
+                case expand: Expand if !expand.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+                  val attrsOnExpand = new util.HashSet[AttributeReferenceWrapper]
+                  expand.projections.map {s =>
+                    s.map {
+                      case attr: AttributeReference =>
+                      case a@Alias(attr: AttributeReference, name) =>
+                      case others =>
+                        others.collect {
+                          case attr: AttributeReference
+                            if isDictionaryEncoded(attr, relations, aliasMap) =>
+                            attrsOnExpand.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                                attr)))
+                        }
+                    }
+                  }
+                  var child = expand.child
+                  if (attrsOnExpand.size() > 0 && !child.isInstanceOf[Expand]) {
+                    child = CarbonDictionaryTempDecoder(attrsOnExpand,
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      expand.child)
+                  }
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      CodeGenerateFactory.getInstance().expandFactory.createExpand(expand, child),
+                      isOuter = true)
+                  } else {
+                    CodeGenerateFactory.getInstance().expandFactory.createExpand(expand, child)
+                  }
+                case filter: Filter if !filter.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+                  val attrsOnConds = new util.HashSet[AttributeReferenceWrapper]
+                  // In case the child is join then we cannot push down the filters
+                  // so decode them earlier
+                  if (filter.child.isInstanceOf[Join] || filter.child.isInstanceOf[Sort]) {
+                    filter.condition.collect {
+                      case attr: AttributeReference =>
+                        attrsOnConds.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
+                    }
+                  } else {
+                    CarbonFilters
+                      .selectFilters(splitConjunctivePredicates(filter.condition), attrsOnConds,
+                          aliasMap)
+                  }
+
+                  var child = filter.child
+                  if (attrsOnConds.size() > 0 && !child.isInstanceOf[Filter]) {
+                    child = CarbonDictionaryTempDecoder(attrsOnConds,
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      filter.child)
+                  }
+
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      Filter(filter.condition, child),
+                      isOuter = true)
+                  } else {
+                    Filter(filter.condition, child)
+                  }
+
+                case j: Join
+                  if !(j.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
+                       j.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
+                  val attrsOnJoin = new util.HashSet[Attribute]
+                  j.condition match {
+                    case Some(expression) =>
+                      expression.collect {
+                        case attr: AttributeReference
+                          if isDictionaryEncoded(attr, relations, aliasMap) =>
+                          attrsOnJoin.add(aliasMap.getOrElse(attr, attr))
+                      }
+                    case _ =>
+                  }
+
+                  val leftCondAttrs = new util.HashSet[AttributeReferenceWrapper]
+                  val rightCondAttrs = new util.HashSet[AttributeReferenceWrapper]
+                  if (attrsOnJoin.size() > 0) {
+                    attrsOnJoin.asScala.map { attr =>
+                      if (qualifierPresence(j.left, attr)) {
+                        leftCondAttrs.add(AttributeReferenceWrapper(attr))
+                      }
+                      if (qualifierPresence(j.right, attr)) {
+                        rightCondAttrs.add(AttributeReferenceWrapper(attr))
+                      }
+                    }
+                    var leftPlan = j.left
+                    var rightPlan = j.right
+                    if (leftCondAttrs.size() > 0 &&
+                        !leftPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
+                      leftPlan = CarbonDictionaryTempDecoder(leftCondAttrs,
+                        new util.HashSet[AttributeReferenceWrapper](),
+                        j.left)
+                    }
+                    if (rightCondAttrs.size() > 0 &&
+                        !rightPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
+                      rightPlan = CarbonDictionaryTempDecoder(rightCondAttrs,
+                        new util.HashSet[AttributeReferenceWrapper](),
+                        j.right)
+                    }
+                    if (!decoder) {
+                      decoder = true
+                      CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                        new util.HashSet[AttributeReferenceWrapper](),
+                        Join(leftPlan, rightPlan, j.joinType, j.condition),
+                        isOuter = true)
+                    } else {
+                      Join(leftPlan, rightPlan, j.joinType, j.condition)
+                    }
+                  } else {
+                    j
+                  }
+
+                case p: Project
+                  if relations.nonEmpty && !p.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+                  val attrsOnProjects = new util.HashSet[AttributeReferenceWrapper]
+                  p.projectList.map {
+                    case attr: AttributeReference =>
+                    case a@Alias(attr: AttributeReference, name) =>
+                    case others =>
+                      others.collect {
+                        case attr: AttributeReference
+                          if isDictionaryEncoded(attr, relations, aliasMap) =>
+                          attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                              attr)))
+                      }
+                  }
+                  var child = p.child
+                  if (attrsOnProjects.size() > 0 && !child.isInstanceOf[Project]) {
+                    child = CarbonDictionaryTempDecoder(attrsOnProjects,
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      p.child)
+                  }
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      Project(p.projectList, child),
+                      isOuter = true)
+                  } else {
+                    Project(p.projectList, child)
+                  }
+
+                case wd: Window if !wd.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
+                  val attrsOnProjects = new util.HashSet[AttributeReferenceWrapper]
+                  wd.projectList.map {
+                    case attr: AttributeReference =>
+                    case others =>
+                      others.collect {
+                        case attr: AttributeReference
+                          if isDictionaryEncoded(attr, relations, aliasMap) =>
+                          attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                              attr)))
+                      }
+                  }
+                  wd.windowExpressions.map {
+                    case others =>
+                      others.collect {
+                        case attr: AttributeReference
+                          if isDictionaryEncoded(attr, relations, aliasMap) =>
+                          attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                              attr)))
+                      }
+                  }
+                  wd.partitionSpec.map{
+                    case attr: AttributeReference =>
+                    case others =>
+                      others.collect {
+                        case attr: AttributeReference
+                          if isDictionaryEncoded(attr, relations, aliasMap) =>
+                          attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                              attr)))
+                      }
+                  }
+                  wd.orderSpec.map { s =>
+                    s.collect {
+                      case attr: AttributeReference
+                        if isDictionaryEncoded(attr, relations, aliasMap) =>
+                        attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                            attr)))
+                    }
+                  }
+                  wd.partitionSpec.map { s =>
+                    s.collect {
+                      case attr: AttributeReference
+                        if isDictionaryEncoded(attr, relations, aliasMap) =>
+                        attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr,
+                            attr)))
+                    }
+                  }
+                  var child = wd.child
+                  if (attrsOnProjects.size() > 0 && !child.isInstanceOf[Project]) {
+                    child = CarbonDictionaryTempDecoder(attrsOnProjects,
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      wd.child)
+                  }
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](),
+                      Window(wd.projectList, wd.windowExpressions, wd.partitionSpec, wd.orderSpec,
+                          child),
+                      isOuter = true)
+                  } else {
+                    Window(wd.projectList, wd.windowExpressions, wd.partitionSpec, wd.orderSpec,
+                        child)
+                  }
+
+                case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
+                  if (!decoder) {
+                    decoder = true
+                    CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+                      new util.HashSet[AttributeReferenceWrapper](), l, isOuter = true)
+                  } else {
+                    l
+                  }
+
+                case others => others
               }
-            case others =>
-              others.collect {
-                case attr: AttributeReference
-                  if isDictionaryEncoded(attr, relations, aliasMap) =>
-                  attrsOndimAggs.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-              }
+            case false =>
+              currentPlan
           }
-          var child = agg.child
-          // Incase if the child also aggregate then push down decoder to child
-          if (attrsOndimAggs.size() > 0 && !child.equals(agg)) {
-            child = CarbonDictionaryTempDecoder(attrsOndimAggs,
-              new util.HashSet[AttributeReferenceWrapper](),
-              agg.child)
-          }
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](),
-              Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child),
-              isOuter = true)
-          } else {
-            Aggregate(agg.groupingExpressions, agg.aggregateExpressions, child)
-          }
-        case expand: Expand if !expand.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-          val attrsOnExpand = new util.HashSet[AttributeReferenceWrapper]
-          expand.projections.map {s =>
-            s.map {
-              case attr: AttributeReference =>
-              case a@Alias(attr: AttributeReference, name) =>
-              case others =>
-                others.collect {
-                  case attr: AttributeReference
-                    if isDictionaryEncoded(attr, relations, aliasMap) =>
-                    attrsOnExpand.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-                }
-            }
-          }
-          var child = expand.child
-          if (attrsOnExpand.size() > 0 && !child.isInstanceOf[Expand]) {
-            child = CarbonDictionaryTempDecoder(attrsOnExpand,
-              new util.HashSet[AttributeReferenceWrapper](),
-              expand.child)
-          }
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](),
-              CodeGenerateFactory.getInstance().expandFactory.createExpand(expand, child),
-              isOuter = true)
-          } else {
-            CodeGenerateFactory.getInstance().expandFactory.createExpand(expand, child)
-          }
-        case filter: Filter if !filter.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-          val attrsOnConds = new util.HashSet[AttributeReferenceWrapper]
-          // In case the child is join then we cannot push down the filters so decode them earlier
-          if (filter.child.isInstanceOf[Join] || filter.child.isInstanceOf[Sort]) {
-            filter.condition.collect {
-              case attr: AttributeReference =>
-                attrsOnConds.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-            }
-          } else {
-            CarbonFilters
-              .selectFilters(splitConjunctivePredicates(filter.condition), attrsOnConds, aliasMap)
-          }
-
-          var child = filter.child
-          if (attrsOnConds.size() > 0 && !child.isInstanceOf[Filter]) {
-            child = CarbonDictionaryTempDecoder(attrsOnConds,
-              new util.HashSet[AttributeReferenceWrapper](),
-              filter.child)
-          }
-
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](),
-              Filter(filter.condition, child),
-              isOuter = true)
-          } else {
-            Filter(filter.condition, child)
-          }
-
-        case j: Join
-          if !(j.left.isInstanceOf[CarbonDictionaryTempDecoder] ||
-               j.right.isInstanceOf[CarbonDictionaryTempDecoder]) =>
-          val attrsOnJoin = new util.HashSet[Attribute]
-          j.condition match {
-            case Some(expression) =>
-              expression.collect {
-                case attr: AttributeReference
-                  if isDictionaryEncoded(attr, relations, aliasMap) =>
-                  attrsOnJoin.add(aliasMap.getOrElse(attr, attr))
-              }
-            case _ =>
-          }
-
-          val leftCondAttrs = new util.HashSet[AttributeReferenceWrapper]
-          val rightCondAttrs = new util.HashSet[AttributeReferenceWrapper]
-          if (attrsOnJoin.size() > 0) {
-
-            attrsOnJoin.asScala.map { attr =>
-              if (qualifierPresence(j.left, attr)) {
-                leftCondAttrs.add(AttributeReferenceWrapper(attr))
-              }
-              if (qualifierPresence(j.right, attr)) {
-                rightCondAttrs.add(AttributeReferenceWrapper(attr))
-              }
-            }
-            var leftPlan = j.left
-            var rightPlan = j.right
-            if (leftCondAttrs.size() > 0 &&
-                !leftPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
-              leftPlan = CarbonDictionaryTempDecoder(leftCondAttrs,
-                new util.HashSet[AttributeReferenceWrapper](),
-                j.left)
-            }
-            if (rightCondAttrs.size() > 0 &&
-                !rightPlan.isInstanceOf[CarbonDictionaryCatalystDecoder]) {
-              rightPlan = CarbonDictionaryTempDecoder(rightCondAttrs,
-                new util.HashSet[AttributeReferenceWrapper](),
-                j.right)
-            }
-            if (!decoder) {
-              decoder = true
-              CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-                new util.HashSet[AttributeReferenceWrapper](),
-                Join(leftPlan, rightPlan, j.joinType, j.condition),
-                isOuter = true)
-            } else {
-              Join(leftPlan, rightPlan, j.joinType, j.condition)
-            }
-          } else {
-            j
-          }
-
-        case p: Project
-          if relations.nonEmpty && !p.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-          val attrsOnProjects = new util.HashSet[AttributeReferenceWrapper]
-          p.projectList.map {
-            case attr: AttributeReference =>
-            case a@Alias(attr: AttributeReference, name) =>
-            case others =>
-              others.collect {
-                case attr: AttributeReference
-                  if isDictionaryEncoded(attr, relations, aliasMap) =>
-                  attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-              }
-          }
-          var child = p.child
-          if (attrsOnProjects.size() > 0 && !child.isInstanceOf[Project]) {
-            child = CarbonDictionaryTempDecoder(attrsOnProjects,
-              new util.HashSet[AttributeReferenceWrapper](),
-              p.child)
-          }
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](),
-              Project(p.projectList, child),
-              isOuter = true)
-          } else {
-            Project(p.projectList, child)
-          }
-
-        case wd: Window if !wd.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
-          val attrsOnProjects = new util.HashSet[AttributeReferenceWrapper]
-          wd.projectList.map {
-            case attr: AttributeReference =>
-            case others =>
-              others.collect {
-                case attr: AttributeReference
-                  if isDictionaryEncoded(attr, relations, aliasMap) =>
-                  attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-              }
-          }
-          wd.windowExpressions.map {
-            case others =>
-              others.collect {
-                case attr: AttributeReference
-                  if isDictionaryEncoded(attr, relations, aliasMap) =>
-                  attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-              }
-          }
-          wd.partitionSpec.map{
-            case attr: AttributeReference =>
-            case others =>
-              others.collect {
-                case attr: AttributeReference
-                  if isDictionaryEncoded(attr, relations, aliasMap) =>
-                  attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-              }
-          }
-          wd.orderSpec.map { s =>
-            s.collect {
-              case attr: AttributeReference
-                if isDictionaryEncoded(attr, relations, aliasMap) =>
-                attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-            }
-          }
-          wd.partitionSpec.map { s =>
-            s.collect {
-              case attr: AttributeReference
-                if isDictionaryEncoded(attr, relations, aliasMap) =>
-                attrsOnProjects.add(AttributeReferenceWrapper(aliasMap.getOrElse(attr, attr)))
-            }
-          }
-          var child = wd.child
-          if (attrsOnProjects.size() > 0 && !child.isInstanceOf[Project]) {
-            child = CarbonDictionaryTempDecoder(attrsOnProjects,
-              new util.HashSet[AttributeReferenceWrapper](),
-              wd.child)
-          }
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](),
-              Window(wd.projectList, wd.windowExpressions, wd.partitionSpec, wd.orderSpec, child),
-              isOuter = true)
-          } else {
-            Window(wd.projectList, wd.windowExpressions, wd.partitionSpec, wd.orderSpec, child)
-          }
-
-        case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
-          if (!decoder) {
-            decoder = true
-            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
-              new util.HashSet[AttributeReferenceWrapper](), l, isOuter = true)
-          } else {
-            l
-          }
-
-        case others => others
       }
 
     val processor = new CarbonDecoderProcessor

--- a/integration/spark/src/test/scala/org/apache/spark/sql/CarbonOptimizerTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/sql/CarbonOptimizerTestCase.scala
@@ -1,0 +1,79 @@
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.scalatest.BeforeAndAfterAll
+
+/**
+  * Created by c00318382 on 2016/9/18.
+  */
+class CarbonOptimizerTestCase extends QueryTest with BeforeAndAfterAll {
+  override def beforeAll: Unit = {
+    sql("drop table if exists carbonTable")
+    sql("drop table if exists hiveTable")
+    sql(
+      """CREATE TABLE carbonTable (empno int, empname String, designation String, doj String,
+        workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        projectcode int, projectjoindate String, projectenddate String,attendance double,
+        utilization double,salary double) STORED BY 'org.apache.carbondata.format'""")
+    sql(
+      """CREATE TABLE hiveTable (empno int, empname String, designation String, doj String,
+        workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        projectcode int, projectjoindate String, projectenddate String,attendance double,
+        utilization double,salary double) ROW FORMAT DELIMITED FIELDS TERMINATED BY ','""")
+  }
+
+  def checkPlan(sqlString: String): Unit = {
+    val plan = sql(sqlString).queryExecution.optimizedPlan
+    println(plan)
+    // CarbonDictionaryCatalystDecoder need contain a carbon relation child
+    var hasCarbon = true
+    plan transformDown {
+      case decoder: CarbonDictionaryCatalystDecoder =>
+        val hasCarbonRelation = decoder.collectFirst {
+          case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] => l
+        } match {
+          case Some(_) => true
+          case None => false
+        }
+        if (!hasCarbonRelation) {
+          hasCarbon = false
+        }
+        decoder
+    }
+    assert(hasCarbon)
+  }
+
+  test("Carbon table union Hive table") {
+    checkPlan("""select empname from carbonTable
+         union
+        select empname from hiveTable""")
+  }
+
+  test("Hive table union Carbon table") {
+    checkPlan("""select empname from hiveTable
+         union
+        select empname from carbonTable""")
+  }
+
+  test("Carbon table join Hive table") {
+    checkPlan(
+      """select ct1.empname, ct1.designation
+         from carbonTable ct1
+         join hiveTable ht1 on ct1.empname = ht1.empname """)
+  }
+
+  test("Hive table join Carbon table") {
+    checkPlan(
+      """select ct1.empname, ct1.designation
+         from hiveTable ht1
+         join carbonTable ct1 on ct1.empname = ht1.empname """)
+  }
+
+  override def afterAll: Unit = {
+    sql("drop table if exists carbonTable")
+    sql("drop table if exists hiveTable")
+  }
+}


### PR DESCRIPTION
**Root Cause Analysis:** 
When carbon table union hive table, CarbonOptimizer will add CarbonDictionaryCatalystDecoder for all tables.

**Solution:**
If the child logical plan doesn't contain CarbonRelation, no need to add CarbonDictionaryCatalystDecoder