### PR TITLE
[CARBONDATA-239] Handling the exception cases in compaction.

### DIFF
--- a/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/CarbonCompactionUtil.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 import org.apache.carbondata.core.carbon.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.carbon.datastore.block.TaskBlockInfo;
 import org.apache.carbondata.core.carbon.datastore.exception.IndexBuilderException;
@@ -215,7 +216,7 @@ public class CarbonCompactionUtil {
         }
       }
     } catch (IOException e) {
-      LOGGER.error("Exception in deleting the compaction request file " + e.getMessage() );
+      LOGGER.error("Exception in deleting the compaction request file " + e.getMessage());
     }
     return false;
   }
@@ -254,14 +255,19 @@ public class CarbonCompactionUtil {
 
   /**
    * This will check if any compaction request has been received for any table.
+   *
    * @param tableMetas
    * @return
    */
-  public static TableMeta getNextTableToCompact(TableMeta[] tableMetas) {
+  public static TableMeta getNextTableToCompact(TableMeta[] tableMetas,
+      List<CarbonTableIdentifier> skipList) {
     for (TableMeta table : tableMetas) {
       CarbonTable ctable = table.carbonTable();
       String metadataPath = ctable.getMetaDataFilepath();
-      if (CarbonCompactionUtil.isCompactionRequiredForTable(metadataPath)) {
+      // check for the compaction required file and at the same time exclude the tables which are
+      // present in the skip list.
+      if (CarbonCompactionUtil.isCompactionRequiredForTable(metadataPath) && !skipList
+          .contains(table.carbonTableIdentifier())) {
         return table;
       }
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -811,16 +811,26 @@ private[sql] case class AlterTableCompaction(alterTableModel: AlterTableModel) e
         System.getProperty("java.io.tmpdir")
       )
     storeLocation = storeLocation + "/carbonstore/" + System.nanoTime()
-
-    CarbonDataRDDFactory
-      .alterTableForCompaction(sqlContext,
-        alterTableModel,
-        carbonLoadModel,
-        partitioner,
-        relation.tableMeta.storePath,
-        kettleHomePath,
-        storeLocation
-      )
+    try {
+      CarbonDataRDDFactory
+        .alterTableForCompaction(sqlContext,
+          alterTableModel,
+          carbonLoadModel,
+          partitioner,
+          relation.tableMeta.storePath,
+          kettleHomePath,
+          storeLocation
+        )
+    }
+    catch {
+      case e: Exception =>
+        if (null != e.getMessage) {
+          sys.error("Compaction failed." + e.getMessage)
+        }
+        else {
+          sys.error("Exception in compaction.")
+        }
+    }
 
     Seq.empty
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -825,10 +825,10 @@ private[sql] case class AlterTableCompaction(alterTableModel: AlterTableModel) e
     catch {
       case e: Exception =>
         if (null != e.getMessage) {
-          sys.error("Compaction failed." + e.getMessage)
+          sys.error("Compaction failed. Please check logs for more info." + e.getMessage)
         }
         else {
-          sys.error("Exception in compaction.")
+          sys.error("Exception in compaction. Please check logs for more info.")
         }
     }
 


### PR DESCRIPTION
Why raise this pr?
If a compaction is triggered by the user on table1 , and other requests will go to queue. and if the compaction is failed for table1 then the requests in queue is not getting completed.

How to resolve?
If the compaction is failed then the requests in queue should continue the compaction.

if compaction is failed for table, requested by user then need to show error message in the beeline.
