### PR TITLE
[CARBONDATA-244] Load and delete segment by id queries giving inconsistent results when we execute both parallely

### DIFF
--- a/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
@@ -473,9 +473,8 @@ public final class CarbonLoaderUtil {
 
       }
       CarbonUtil.closeStreams(brWriter);
-
+      writeOperation.close();
     }
-    writeOperation.close();
 
   }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -1173,7 +1173,7 @@ object CarbonDataRDDFactory extends Logging {
           isForceDeletion = true)
       }
       else {
-        val errorMsg = "Clean Files request is failed for " + carbonLoadModel.getDatabaseName +
+        val errorMsg = "Clean files request is failed for " + carbonLoadModel.getDatabaseName +
                        "." + carbonLoadModel.getTableName +
                        ". Not able to acquire the metadata lock."
         logger.audit(errorMsg)

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -1176,8 +1176,8 @@ object CarbonDataRDDFactory extends Logging {
       else {
         val errorMsg = "Clean files request is failed for " + carbonLoadModel.getDatabaseName +
                        "." + carbonLoadModel.getTableName +
-                       ". Not able to acquire the clean files lock due to other operation running " +
-                       "in the background."
+                       ". Not able to acquire the clean files lock due to another clean files " +
+                       "operation is running in the background."
         logger.audit(errorMsg)
         logger.error(errorMsg)
         throw new Exception(errorMsg + " Please try after some time.")

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -1176,7 +1176,7 @@ object CarbonDataRDDFactory extends Logging {
       else {
         val errorMsg = "Clean files request is failed for " + carbonLoadModel.getDatabaseName +
                        "." + carbonLoadModel.getTableName +
-                       ". Not able to acquire the metadata lock due to other operation running " +
+                       ". Not able to acquire the clean files lock due to other operation running " +
                        "in the background."
         logger.audit(errorMsg)
         logger.error(errorMsg)

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -1127,10 +1127,9 @@ object CarbonDataRDDFactory extends Logging {
           )
         }
         else {
-          val errorMsg: String = "Clean files request is failed for " +
-                                 carbonLoadModel.getDatabaseName + "." +
-                                 carbonLoadModel.getTableName
-          ". Not able to acquire the table status lock."
+          val errorMsg = "Clean files request is failed for " + carbonLoadModel.getDatabaseName +
+                         "." + carbonLoadModel.getTableName +
+                         ". Not able to acquire the table status lock."
           logger.audit(errorMsg)
           logger.error(errorMsg)
           throw new Exception(errorMsg + " Please try after some time.")
@@ -1174,10 +1173,9 @@ object CarbonDataRDDFactory extends Logging {
           isForceDeletion = true)
       }
       else {
-        val errorMsg: String = "Clean Files request is failed for " +
-                               carbonLoadModel.getDatabaseName + "." +
-                               carbonLoadModel.getTableName +
-                               ". Not able to acquire the metadata lock."
+        val errorMsg = "Clean Files request is failed for " + carbonLoadModel.getDatabaseName +
+                       "." + carbonLoadModel.getTableName +
+                       ". Not able to acquire the metadata lock."
         logger.audit(errorMsg)
         logger.error(errorMsg)
         throw new Exception(errorMsg + " Please try after some time.")

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -44,7 +44,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.load.{BlockDetails, LoadMetadataDetails}
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.integration.spark.merger.{CarbonCompactionUtil, CompactionCallable, CompactionType}
-import org.apache.carbondata.lcm.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
+import org.apache.carbondata.lcm.locks.{CarbonLockFactory, CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.lcm.status.SegmentStatusManager
 import org.apache.carbondata.processing.etl.DataLoadingException
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil
@@ -52,7 +52,7 @@ import org.apache.carbondata.spark._
 import org.apache.carbondata.spark.load._
 import org.apache.carbondata.spark.merger.CarbonDataMergerUtil
 import org.apache.carbondata.spark.splits.TableSplit
-import org.apache.carbondata.spark.util.{CarbonQueryUtil, LoadMetadataUtil}
+import org.apache.carbondata.spark.util.{CarbonQueryUtil, CarbonScalaUtil, LoadMetadataUtil}
 
 /**
  * This is the factory class which can create different RDD depends on user needs.
@@ -1106,6 +1106,9 @@ object CarbonDataRDDFactory extends Logging {
       val segmentStatusManager = new SegmentStatusManager(table.getAbsoluteTableIdentifier)
       val details = segmentStatusManager
         .readLoadMetadata(loadMetadataFilePath)
+      val carbonTableStatusLock = CarbonLockFactory
+        .getCarbonLockObj(table.getAbsoluteTableIdentifier.getCarbonTableIdentifier,
+          LockUsage.TABLE_STATUS_LOCK)
 
       // Delete marked loads
       val isUpdationRequired = DeleteLoadFolders
@@ -1113,12 +1116,28 @@ object CarbonDataRDDFactory extends Logging {
           partitioner.partitionCount, isForceDeletion, details)
 
       if (isUpdationRequired) {
+        try {
         // Update load metadate file after cleaning deleted nodes
-        CarbonLoaderUtil.writeLoadMetadata(
-          carbonLoadModel.getCarbonDataLoadSchema,
-          carbonLoadModel.getDatabaseName,
-          carbonLoadModel.getTableName, details.toList.asJava
-        )
+        if (carbonTableStatusLock.lockWithRetries()) {
+          CarbonLoaderUtil.writeLoadMetadata(
+            carbonLoadModel.getCarbonDataLoadSchema,
+            carbonLoadModel.getDatabaseName,
+            carbonLoadModel.getTableName, details.toList.asJava
+          )
+        }
+        else {
+          val errorMsg: String = "Clean files request is failed for " +
+                                 carbonLoadModel.getDatabaseName + "." +
+                                 carbonLoadModel.getTableName
+          ". Not able to acquire the table status lock."
+          logger.audit(errorMsg)
+          logger.error(errorMsg)
+          throw new Exception(errorMsg + " Please try after some time.")
+
+        }
+      } finally {
+          CarbonLockUtil.fileUnlock(carbonTableStatusLock, LockUsage.TABLE_STATUS_LOCK)
+        }
       }
     }
   }
@@ -1140,25 +1159,31 @@ object CarbonDataRDDFactory extends Logging {
     val table = org.apache.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
       .getCarbonTable(carbonLoadModel.getDatabaseName + "_" + carbonLoadModel.getTableName)
     val metaDataPath: String = table.getMetaDataFilepath
-    val carbonLock = CarbonLockFactory
+    val carbonMetadataLock = CarbonLockFactory
       .getCarbonLockObj(table.getAbsoluteTableIdentifier.getCarbonTableIdentifier,
         LockUsage.METADATA_LOCK
       )
     try {
-      if (carbonLock.lockWithRetries()) {
+      if (carbonMetadataLock.lockWithRetries()) {
         deleteLoadsAndUpdateMetadata(carbonLoadModel,
           table,
           partitioner,
           hdfsStoreLocation,
           isForceDeletion = true)
       }
+      else {
+        val errorMsg: String = "Clean Files request is failed for " +
+                               carbonLoadModel.getDatabaseName + "." +
+                               carbonLoadModel.getTableName +
+                               ". Not able to acquire the metadata lock."
+        logger.audit(errorMsg)
+        logger.error(errorMsg)
+        throw new Exception(errorMsg + " Please try after some time.")
+
+      }
     }
     finally {
-      if (carbonLock.unlock()) {
-        logInfo("unlock the table metadata file successfully")
-      } else {
-        logError("Unable to unlock the metadata lock")
-      }
+      CarbonLockUtil.fileUnlock(carbonMetadataLock, LockUsage.METADATA_LOCK)
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -1119,6 +1119,7 @@ object CarbonDataRDDFactory extends Logging {
         try {
         // Update load metadate file after cleaning deleted nodes
         if (carbonTableStatusLock.lockWithRetries()) {
+          logger.info("Table status lock has been successfully acquired.")
           CarbonLoaderUtil.writeLoadMetadata(
             carbonLoadModel.getCarbonDataLoadSchema,
             carbonLoadModel.getDatabaseName,
@@ -1165,6 +1166,7 @@ object CarbonDataRDDFactory extends Logging {
       )
     try {
       if (carbonMetadataLock.lockWithRetries()) {
+        logger.info("Metadata lock has been successfully acquired.")
         deleteLoadsAndUpdateMetadata(carbonLoadModel,
           table,
           partitioner,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -987,13 +987,18 @@ private[sql] case class DeleteLoadsByLoadDate(
     }
     val path = carbonTable.getMetaDataFilepath()
 
-    val invalidLoadTimestamps = segmentStatusManager
-      .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long]).asScala
-    if(invalidLoadTimestamps.isEmpty) {
-      LOGGER.audit(s"Delete segment by date is successfull for $dbName.$tableName.")
-    }
-    else {
-      sys.error("Delete segment by date is failed. No matching segment found.")
+    try {
+      val invalidLoadTimestamps = segmentStatusManager
+        .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long]).asScala
+      if (invalidLoadTimestamps.isEmpty) {
+        LOGGER.audit(s"Delete segment by date is successfull for $dbName.$tableName.")
+      }
+      else {
+        sys.error("Delete segment by date is failed. No matching segment found.")
+      }
+    } catch {
+      case ex: Exception =>
+        sys.error(ex.getMessage)
     }
     Seq.empty
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -989,7 +989,8 @@ private[sql] case class DeleteLoadsByLoadDate(
     val path = carbonTable.getMetaDataFilepath()
 
     val invalidLoadTimestamps = segmentStatusManager
-      .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long], dbName, tableName).asScala
+      .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long], dbName, tableName)
+      .asScala
     if(invalidLoadTimestamps.isEmpty) {
       LOGGER.audit(s"Delete segment by date is successfull for $dbName.$tableName.")
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1563,7 +1563,7 @@ private[sql] case class CleanFiles(
       LOGGER.audit(s"Clean files request is successfull for $dbName.$tableName.")
     } catch {
       case ex : Exception =>
-        LOGGER.audit(ex.getMessage)
+        sys.error(ex.getMessage)
     }
     Seq.empty
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -920,8 +920,7 @@ private[sql] case class DeleteLoadsById(
     val segmentStatusManager =
       new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
     try {
-      val invalidLoadIds = segmentStatusManager
-        .updateDeletionStatus(loadids.asJava, path, dbName, tableName).asScala
+      val invalidLoadIds = segmentStatusManager.updateDeletionStatus(loadids.asJava, path).asScala
 
       if (invalidLoadIds.isEmpty) {
 
@@ -989,8 +988,7 @@ private[sql] case class DeleteLoadsByLoadDate(
     val path = carbonTable.getMetaDataFilepath()
 
     val invalidLoadTimestamps = segmentStatusManager
-      .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long], dbName, tableName)
-      .asScala
+      .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long]).asScala
     if(invalidLoadTimestamps.isEmpty) {
       LOGGER.audit(s"Delete segment by date is successfull for $dbName.$tableName.")
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -989,7 +989,7 @@ private[sql] case class DeleteLoadsByLoadDate(
     val path = carbonTable.getMetaDataFilepath()
 
     val invalidLoadTimestamps = segmentStatusManager
-      .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long]).asScala
+      .updateDeletionStatus(loadDate, path, timeObj.asInstanceOf[java.lang.Long], dbName, tableName).asScala
     if(invalidLoadTimestamps.isEmpty) {
       LOGGER.audit(s"Delete segment by date is successfull for $dbName.$tableName.")
     }
@@ -1554,12 +1554,17 @@ private[sql] case class CleanFiles(
     carbonLoadModel.setStorePath(relation.tableMeta.storePath)
     val dataLoadSchema = new CarbonDataLoadSchema(table)
     carbonLoadModel.setCarbonDataLoadSchema(dataLoadSchema)
-    CarbonDataRDDFactory.cleanFiles(
-      sqlContext.sparkContext,
-      carbonLoadModel,
-      relation.tableMeta.storePath,
-      relation.tableMeta.partitioner)
-    LOGGER.audit("Clean files request is successfull.")
+    try {
+      CarbonDataRDDFactory.cleanFiles(
+        sqlContext.sparkContext,
+        carbonLoadModel,
+        relation.tableMeta.storePath,
+        relation.tableMeta.partitioner)
+      LOGGER.audit(s"Clean files request is successfull for $dbName.$tableName.")
+    } catch {
+      case ex : Exception =>
+        LOGGER.audit(ex.getMessage)
+    }
     Seq.empty
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -919,16 +919,21 @@ private[sql] case class DeleteLoadsById(
 
     val segmentStatusManager =
       new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
+    try {
+      val invalidLoadIds = segmentStatusManager
+        .updateDeletionStatus(loadids.asJava, path, dbName, tableName).asScala
 
-    val invalidLoadIds = segmentStatusManager.updateDeletionStatus(loadids.asJava, path).asScala
+      if (invalidLoadIds.isEmpty) {
 
-    if (invalidLoadIds.isEmpty) {
-
-      LOGGER.audit(s"Delete segment by Id is successfull for $databaseName.$tableName.")
-    }
-    else {
-      sys.error("Delete segment by Id is failed. Invalid ID is :"
-                + invalidLoadIds.mkString(","))
+        LOGGER.audit(s"Delete segment by Id is successfull for $databaseName.$tableName.")
+      }
+      else {
+        sys.error("Delete segment by Id is failed. Invalid ID is :"
+                  + invalidLoadIds.mkString(","))
+      }
+    } catch {
+      case ex: Exception =>
+        sys.error(ex.getMessage)
     }
 
     Seq.empty

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
@@ -320,6 +320,6 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     }
     carbonTableStatusLock.unlock()
     //it should pass
-    sql("DELETE SEGMENT 4 FROM TABLE retentionlock")
+    sql("DELETE SEGMENT 0 FROM TABLE retentionlock")
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/CarbonLockUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/CarbonLockUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.lcm.locks;
+
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+
+/**
+ * This is a singleton class for initialization of zookeeper client.
+ */
+public class CarbonLockUtil {
+
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(CarbonLockUtil.class.getName());
+
+  /**
+   * unlocks given file
+   *
+   * @param carbonLock
+   */
+  public static void fileUnlock(ICarbonLock carbonLock, String locktype) {
+    if (carbonLock.unlock()) {
+      if (locktype.equals(LockUsage.METADATA_LOCK)) {
+        LOGGER.info("Metadata lock has been successfully released");
+      } else if (locktype.equals(LockUsage.TABLE_STATUS_LOCK)) {
+        LOGGER.info("Table Status lock has been successfully released");
+      }
+    } else {
+      if (locktype.equals(LockUsage.METADATA_LOCK)) {
+        LOGGER.error("Not able to release the metadata lock");
+      } else if (locktype.equals(LockUsage.TABLE_STATUS_LOCK)) {
+        LOGGER.error("Not able to release the Table Status lock");
+      }
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/CarbonLockUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/CarbonLockUtil.java
@@ -22,7 +22,7 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 
 /**
- * This is a singleton class for initialization of zookeeper client.
+ * This class contains all carbon lock utilities
  */
 public class CarbonLockUtil {
 

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/CarbonLockUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/CarbonLockUtil.java
@@ -39,13 +39,25 @@ public class CarbonLockUtil {
       if (locktype.equals(LockUsage.METADATA_LOCK)) {
         LOGGER.info("Metadata lock has been successfully released");
       } else if (locktype.equals(LockUsage.TABLE_STATUS_LOCK)) {
-        LOGGER.info("Table Status lock has been successfully released");
+        LOGGER.info("Table status lock has been successfully released");
+      }
+      else if (locktype.equals(LockUsage.CLEAN_FILES_LOCK)) {
+        LOGGER.info("Clean files lock has been successfully released");
+      }
+      else if (locktype.equals(LockUsage.DELETE_SEGMENT_LOCK)) {
+        LOGGER.info("Delete segments lock has been successfully released");
       }
     } else {
       if (locktype.equals(LockUsage.METADATA_LOCK)) {
         LOGGER.error("Not able to release the metadata lock");
       } else if (locktype.equals(LockUsage.TABLE_STATUS_LOCK)) {
-        LOGGER.error("Not able to release the Table Status lock");
+        LOGGER.error("Not able to release the table status lock");
+      }
+      else if (locktype.equals(LockUsage.CLEAN_FILES_LOCK)) {
+        LOGGER.info("Not able to release the clean files lock");
+      }
+      else if (locktype.equals(LockUsage.DELETE_SEGMENT_LOCK)) {
+        LOGGER.info("Not able to release the delete segments lock");
       }
     }
   }

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/LockUsage.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/LockUsage.java
@@ -28,5 +28,7 @@ public class LockUsage {
   public static String COMPACTION_LOCK = "compaction.lock";
   public static String SYSTEMLEVEL_COMPACTION_LOCK = "system_level_compaction.lock";
   public static String TABLE_STATUS_LOCK = "tablestatus.lock";
+  public static String DELETE_SEGMENT_LOCK = "delete_segment.lock";
+  public static String CLEAN_FILES_LOCK = "clean_files.lock";
 
 }

--- a/processing/src/main/java/org/apache/carbondata/lcm/locks/LockUsage.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/locks/LockUsage.java
@@ -23,12 +23,12 @@ package org.apache.carbondata.lcm.locks;
  * Each enum value is one specific lock case.
  */
 public class LockUsage {
-  public static String LOCK = ".lock";
-  public static String METADATA_LOCK = "meta.lock";
-  public static String COMPACTION_LOCK = "compaction.lock";
-  public static String SYSTEMLEVEL_COMPACTION_LOCK = "system_level_compaction.lock";
-  public static String TABLE_STATUS_LOCK = "tablestatus.lock";
-  public static String DELETE_SEGMENT_LOCK = "delete_segment.lock";
-  public static String CLEAN_FILES_LOCK = "clean_files.lock";
+  public static final String LOCK = ".lock";
+  public static final String METADATA_LOCK = "meta.lock";
+  public static final String COMPACTION_LOCK = "compaction.lock";
+  public static final String SYSTEMLEVEL_COMPACTION_LOCK = "system_level_compaction.lock";
+  public static final String TABLE_STATUS_LOCK = "tablestatus.lock";
+  public static final String DELETE_SEGMENT_LOCK = "delete_segment.lock";
+  public static final String CLEAN_FILES_LOCK = "clean_files.lock";
 
 }

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -254,16 +254,16 @@ public class SegmentStatusManager {
       throws Exception {
     CarbonTableIdentifier carbonTableIdentifier =
         absoluteTableIdentifier.getCarbonTableIdentifier();
-    ICarbonLock carbonMetadataLock =
-        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.METADATA_LOCK);
+    ICarbonLock carbonDeleteSegmentLock =
+        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.DELETE_SEGMENT_LOCK);
     ICarbonLock carbonTableStatusLock =
         CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.TABLE_STATUS_LOCK);
     String tableDetails =
         carbonTableIdentifier.getDatabaseName() + "." + carbonTableIdentifier.getTableName();
     List<String> invalidLoadIds = new ArrayList<String>(0);
     try {
-      if (carbonMetadataLock.lockWithRetries()) {
-        LOG.info("Metadata lock has been successfully acquired");
+      if (carbonDeleteSegmentLock.lockWithRetries()) {
+        LOG.info("Delete segment lock has been successfully acquired");
 
         CarbonTablePath carbonTablePath = CarbonStorePath
             .getCarbonTablePath(absoluteTableIdentifier.getStorePath(),
@@ -287,7 +287,8 @@ public class SegmentStatusManager {
             }
             else {
               String errorMsg = "Delete segment by id is failed for " + tableDetails
-                  + ". Not able to acquire the table status lock.";
+                  + ". Not able to acquire the table status lock due to other operation running "
+                  + "in the background.";
               LOG.audit(errorMsg);
               LOG.error(errorMsg);
               throw new Exception(errorMsg + " Please try after some time.");
@@ -304,7 +305,8 @@ public class SegmentStatusManager {
 
       } else {
         String errorMsg = "Delete segment by id is failed for " + tableDetails
-            + ". Not able to acquire the metadata lock.";
+            + ". Not able to acquire the metadata lock due to other operation running "
+            + "in the background.";
         LOG.audit(errorMsg);
         LOG.error(errorMsg);
         throw new Exception(errorMsg + " Please try after some time.");
@@ -313,7 +315,7 @@ public class SegmentStatusManager {
       LOG.error("IOException" + e.getMessage());
     } finally {
       CarbonLockUtil.fileUnlock(carbonTableStatusLock, LockUsage.TABLE_STATUS_LOCK);
-      CarbonLockUtil.fileUnlock(carbonMetadataLock, LockUsage.METADATA_LOCK);
+      CarbonLockUtil.fileUnlock(carbonDeleteSegmentLock, LockUsage.DELETE_SEGMENT_LOCK);
     }
 
     return invalidLoadIds;
@@ -330,16 +332,16 @@ public class SegmentStatusManager {
       Long loadStartTime) throws Exception {
     CarbonTableIdentifier carbonTableIdentifier =
         absoluteTableIdentifier.getCarbonTableIdentifier();
-    ICarbonLock carbonMetadataLock =
-        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.METADATA_LOCK);
+    ICarbonLock carbonDeleteSegmentLock =
+        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.DELETE_SEGMENT_LOCK);
     ICarbonLock carbonTableStatusLock =
         CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.TABLE_STATUS_LOCK);
     String tableDetails =
         carbonTableIdentifier.getDatabaseName() + "." + carbonTableIdentifier.getTableName();
     List<String> invalidLoadTimestamps = new ArrayList<String>(0);
     try {
-      if (carbonMetadataLock.lockWithRetries()) {
-        LOG.info("Metadata lock has been successfully acquired");
+      if (carbonDeleteSegmentLock.lockWithRetries()) {
+        LOG.info("Delete segment lock has been successfully acquired");
 
         CarbonTablePath carbonTablePath = CarbonStorePath
             .getCarbonTablePath(absoluteTableIdentifier.getStorePath(),
@@ -366,7 +368,8 @@ public class SegmentStatusManager {
             else {
 
               String errorMsg = "Delete segment by date is failed for " + tableDetails
-                  + ". Not able to acquire the table status lock.";
+                  + ". Not able to acquire the table status lock due to other operation running "
+                  + "in the background.";
               LOG.audit(errorMsg);
               LOG.error(errorMsg);
               throw new Exception(errorMsg + " Please try after some time.");
@@ -384,7 +387,8 @@ public class SegmentStatusManager {
 
       } else {
         String errorMsg = "Delete segment by date is failed for " + tableDetails
-            + ". Not able to acquire the metadata lock.";
+            + ". Not able to acquire the metadata lock due to other operation running "
+            + "in the background.";
         LOG.audit(errorMsg);
         LOG.error(errorMsg);
         throw new Exception(errorMsg + " Please try after some time.");
@@ -393,7 +397,7 @@ public class SegmentStatusManager {
       LOG.error("Error message: " + "IOException" + e.getMessage());
     } finally {
       CarbonLockUtil.fileUnlock(carbonTableStatusLock, LockUsage.TABLE_STATUS_LOCK);
-      CarbonLockUtil.fileUnlock(carbonMetadataLock, LockUsage.METADATA_LOCK);
+      CarbonLockUtil.fileUnlock(carbonDeleteSegmentLock, LockUsage.DELETE_SEGMENT_LOCK);
     }
 
     return invalidLoadTimestamps;

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -359,6 +359,7 @@ public class SegmentStatusManager {
               loadStartTime);
           if (invalidLoadTimestamps.isEmpty()) {
             if(carbonTableStatusLock.lockWithRetries()) {
+              LOG.info("Table status lock has been successfully acquired.");
               writeLoadDetailsIntoFile(dataLoadLocation, listOfLoadFolderDetailsArray);
             }
             else {

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -45,6 +45,7 @@ import org.apache.carbondata.lcm.fileoperations.AtomicFileOperations;
 import org.apache.carbondata.lcm.fileoperations.AtomicFileOperationsImpl;
 import org.apache.carbondata.lcm.fileoperations.FileWriteOperation;
 import org.apache.carbondata.lcm.locks.CarbonLockFactory;
+import org.apache.carbondata.lcm.locks.CarbonLockUtil;
 import org.apache.carbondata.lcm.locks.ICarbonLock;
 import org.apache.carbondata.lcm.locks.LockUsage;
 
@@ -289,7 +290,7 @@ public class SegmentStatusManager {
                   + ". Not able to acquire the table status lock.";
               LOG.audit(errorMsg);
               LOG.error(errorMsg);
-              throw new Exception(errorMsg);
+              throw new Exception(errorMsg + " Please try after some time.");
             }
 
           } else {
@@ -306,13 +307,13 @@ public class SegmentStatusManager {
             + ". Not able to acquire the metadata lock.";
         LOG.audit(errorMsg);
         LOG.error(errorMsg);
-        throw new Exception(errorMsg);
+        throw new Exception(errorMsg + " Please try after some time.");
       }
     } catch (IOException e) {
       LOG.error("IOException" + e.getMessage());
     } finally {
-      fileUnlock(carbonTableStatusLock);
-      fileUnlock(carbonMetadataLock);
+      CarbonLockUtil.fileUnlock(carbonTableStatusLock, LockUsage.TABLE_STATUS_LOCK);
+      CarbonLockUtil.fileUnlock(carbonMetadataLock, LockUsage.METADATA_LOCK);
     }
 
     return invalidLoadIds;
@@ -326,13 +327,17 @@ public class SegmentStatusManager {
    * @return
    */
   public List<String> updateDeletionStatus(String loadDate, String tableFolderPath,
-      Long loadStartTime) {
-    ICarbonLock carbonLock = CarbonLockFactory
+      Long loadStartTime, String dbName, String tableName) throws Exception {
+    ICarbonLock carbonMetadataLock = CarbonLockFactory
         .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
             LockUsage.METADATA_LOCK);
+    ICarbonLock carbonTableStatusLock = CarbonLockFactory
+        .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
+            LockUsage.TABLE_STATUS_LOCK);
+    String tableDetails = dbName + "." + tableName;
     List<String> invalidLoadTimestamps = new ArrayList<String>(0);
     try {
-      if (carbonLock.lockWithRetries()) {
+      if (carbonMetadataLock.lockWithRetries()) {
         LOG.info("Metadata lock has been successfully acquired");
 
         CarbonTablePath carbonTablePath = CarbonStorePath
@@ -353,7 +358,18 @@ public class SegmentStatusManager {
           updateDeletionStatus(loadDate, listOfLoadFolderDetailsArray, invalidLoadTimestamps,
               loadStartTime);
           if (invalidLoadTimestamps.isEmpty()) {
-            writeLoadDetailsIntoFile(dataLoadLocation, listOfLoadFolderDetailsArray);
+            if(carbonTableStatusLock.lockWithRetries()) {
+              writeLoadDetailsIntoFile(dataLoadLocation, listOfLoadFolderDetailsArray);
+            }
+            else {
+
+              String errorMsg = "Delete segment by date is failed for " + tableDetails
+                  + ". Not able to acquire the table status lock.";
+              LOG.audit(errorMsg);
+              LOG.error(errorMsg);
+              throw new Exception(errorMsg + " Please try after some time.");
+
+            }
           } else {
             return invalidLoadTimestamps;
           }
@@ -365,12 +381,17 @@ public class SegmentStatusManager {
         }
 
       } else {
-        LOG.error("Error message: " + "Unable to acquire the metadata lock");
+        String errorMsg = "Delete segment by date is failed for " + tableDetails
+            + ". Not able to acquire the metadata lock.";
+        LOG.audit(errorMsg);
+        LOG.error(errorMsg);
+        throw new Exception(errorMsg + " Please try after some time.");
       }
     } catch (IOException e) {
       LOG.error("Error message: " + "IOException" + e.getMessage());
     } finally {
-      fileUnlock(carbonLock);
+      CarbonLockUtil.fileUnlock(carbonTableStatusLock, LockUsage.TABLE_STATUS_LOCK);
+      CarbonLockUtil.fileUnlock(carbonMetadataLock, LockUsage.METADATA_LOCK);
     }
 
     return invalidLoadTimestamps;
@@ -406,9 +427,9 @@ public class SegmentStatusManager {
         brWriter.flush();
       }
       CarbonUtil.closeStreams(brWriter);
+      fileWrite.close();
     }
 
-    fileWrite.close();
   }
 
   /**
@@ -518,19 +539,6 @@ public class SegmentStatusManager {
           }
         }
       }
-    }
-  }
-
-  /**
-   * unlocks given file
-   *
-   * @param carbonLock
-   */
-  private void fileUnlock(ICarbonLock carbonLock) {
-    if (carbonLock.unlock()) {
-      LOG.info("Metadata lock has been successfully released");
-    } else {
-      LOG.error("Not able to release the metadata lock");
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -246,15 +246,22 @@ public class SegmentStatusManager {
    *
    * @param loadIds
    * @param tableFolderPath
+   * @param dbName
+   * @param tableName
    * @return
    */
-  public List<String> updateDeletionStatus(List<String> loadIds, String tableFolderPath) {
-    ICarbonLock carbonLock = CarbonLockFactory
+  public List<String> updateDeletionStatus(List<String> loadIds, String tableFolderPath,
+      String dbName, String tableName) throws Exception {
+    ICarbonLock carbonMetadataLock = CarbonLockFactory
         .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
             LockUsage.METADATA_LOCK);
+    ICarbonLock carbonTableStatusLock = CarbonLockFactory
+        .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
+            LockUsage.TABLE_STATUS_LOCK);
+    String tableDetails = dbName + "." + tableName;
     List<String> invalidLoadIds = new ArrayList<String>(0);
     try {
-      if (carbonLock.lockWithRetries()) {
+      if (carbonMetadataLock.lockWithRetries()) {
         LOG.info("Metadata lock has been successfully acquired");
 
         CarbonTablePath carbonTablePath = CarbonStorePath
@@ -272,8 +279,19 @@ public class SegmentStatusManager {
         if (listOfLoadFolderDetailsArray != null && listOfLoadFolderDetailsArray.length != 0) {
           updateDeletionStatus(loadIds, listOfLoadFolderDetailsArray, invalidLoadIds);
           if (invalidLoadIds.isEmpty()) {
-            // All or None , if anything fails then dont write
-            writeLoadDetailsIntoFile(dataLoadLocation, listOfLoadFolderDetailsArray);
+            if(carbonTableStatusLock.lockWithRetries()) {
+              LOG.info("Table status lock has been successfully acquired");
+              // All or None , if anything fails then dont write
+              writeLoadDetailsIntoFile(dataLoadLocation, listOfLoadFolderDetailsArray);
+            }
+            else {
+              String errorMsg = "Delete segment by id is failed for " + tableDetails
+                  + ". Not able to acquire the table status lock.";
+              LOG.audit(errorMsg);
+              LOG.error(errorMsg);
+              throw new Exception(errorMsg);
+            }
+
           } else {
             return invalidLoadIds;
           }
@@ -284,12 +302,17 @@ public class SegmentStatusManager {
         }
 
       } else {
-        LOG.error("Unable to acquire the metadata lock");
+        String errorMsg = "Delete segment by id is failed for " + tableDetails
+            + ". Not able to acquire the metadata lock.";
+        LOG.audit(errorMsg);
+        LOG.error(errorMsg);
+        throw new Exception(errorMsg);
       }
     } catch (IOException e) {
       LOG.error("IOException" + e.getMessage());
     } finally {
-      fileUnlock(carbonLock);
+      fileUnlock(carbonTableStatusLock);
+      fileUnlock(carbonMetadataLock);
     }
 
     return invalidLoadIds;

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -35,6 +35,7 @@ import java.util.List;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.carbon.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 import org.apache.carbondata.core.carbon.path.CarbonStorePath;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -247,19 +248,18 @@ public class SegmentStatusManager {
    *
    * @param loadIds
    * @param tableFolderPath
-   * @param dbName
-   * @param tableName
    * @return
    */
-  public List<String> updateDeletionStatus(List<String> loadIds, String tableFolderPath,
-      String dbName, String tableName) throws Exception {
-    ICarbonLock carbonMetadataLock = CarbonLockFactory
-        .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
-            LockUsage.METADATA_LOCK);
-    ICarbonLock carbonTableStatusLock = CarbonLockFactory
-        .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
-            LockUsage.TABLE_STATUS_LOCK);
-    String tableDetails = dbName + "." + tableName;
+  public List<String> updateDeletionStatus(List<String> loadIds, String tableFolderPath)
+      throws Exception {
+    CarbonTableIdentifier carbonTableIdentifier =
+        absoluteTableIdentifier.getCarbonTableIdentifier();
+    ICarbonLock carbonMetadataLock =
+        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.METADATA_LOCK);
+    ICarbonLock carbonTableStatusLock =
+        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.TABLE_STATUS_LOCK);
+    String tableDetails =
+        carbonTableIdentifier.getDatabaseName() + "." + carbonTableIdentifier.getTableName();
     List<String> invalidLoadIds = new ArrayList<String>(0);
     try {
       if (carbonMetadataLock.lockWithRetries()) {
@@ -327,14 +327,15 @@ public class SegmentStatusManager {
    * @return
    */
   public List<String> updateDeletionStatus(String loadDate, String tableFolderPath,
-      Long loadStartTime, String dbName, String tableName) throws Exception {
-    ICarbonLock carbonMetadataLock = CarbonLockFactory
-        .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
-            LockUsage.METADATA_LOCK);
-    ICarbonLock carbonTableStatusLock = CarbonLockFactory
-        .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier(),
-            LockUsage.TABLE_STATUS_LOCK);
-    String tableDetails = dbName + "." + tableName;
+      Long loadStartTime) throws Exception {
+    CarbonTableIdentifier carbonTableIdentifier =
+        absoluteTableIdentifier.getCarbonTableIdentifier();
+    ICarbonLock carbonMetadataLock =
+        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.METADATA_LOCK);
+    ICarbonLock carbonTableStatusLock =
+        CarbonLockFactory.getCarbonLockObj(carbonTableIdentifier, LockUsage.TABLE_STATUS_LOCK);
+    String tableDetails =
+        carbonTableIdentifier.getDatabaseName() + "." + carbonTableIdentifier.getTableName();
     List<String> invalidLoadTimestamps = new ArrayList<String>(0);
     try {
       if (carbonMetadataLock.lockWithRetries()) {

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -305,7 +305,7 @@ public class SegmentStatusManager {
 
       } else {
         String errorMsg = "Delete segment by id is failed for " + tableDetails
-            + ". Not able to acquire the metadata lock due to other operation running "
+            + ". Not able to acquire the delete segment lock due to other operation running "
             + "in the background.";
         LOG.audit(errorMsg);
         LOG.error(errorMsg);
@@ -387,7 +387,7 @@ public class SegmentStatusManager {
 
       } else {
         String errorMsg = "Delete segment by date is failed for " + tableDetails
-            + ". Not able to acquire the metadata lock due to other operation running "
+            + ". Not able to acquire the delete segment lock due to other operation running "
             + "in the background.";
         LOG.audit(errorMsg);
         LOG.error(errorMsg);

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -305,8 +305,8 @@ public class SegmentStatusManager {
 
       } else {
         String errorMsg = "Delete segment by id is failed for " + tableDetails
-            + ". Not able to acquire the delete segment lock due to other operation running "
-            + "in the background.";
+            + ". Not able to acquire the delete segment lock due to another delete "
+            + "operation is running in the background.";
         LOG.audit(errorMsg);
         LOG.error(errorMsg);
         throw new Exception(errorMsg + " Please try after some time.");
@@ -387,8 +387,8 @@ public class SegmentStatusManager {
 
       } else {
         String errorMsg = "Delete segment by date is failed for " + tableDetails
-            + ". Not able to acquire the delete segment lock due to other operation running "
-            + "in the background.";
+            + ". Not able to acquire the delete segment lock due to another delete "
+            + "operation is running in the background.";
         LOG.audit(errorMsg);
         LOG.error(errorMsg);
         throw new Exception(errorMsg + " Please try after some time.");


### PR DESCRIPTION
[Problem] : Load and delete segment by id queries giving inconsistent results when we execute both parallely
[Solution] : delete query will update the results in table status file so we need to do operations using locks. & throw exception if lock is not available