### PR TITLE
[CARBONDATA-241]Fixed out of memory issue during query execution

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/datastore/SegmentTaskIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/datastore/SegmentTaskIndexStore.java
@@ -141,8 +141,8 @@ public class SegmentTaskIndexStore {
           synchronized (segmentLoderLockObject) {
             taskIdToSegmentIndexMap = tableSegmentMapTemp.get(segmentId);
             if (null == taskIdToSegmentIndexMap) {
-              // creating a map of take if to table segment
-              taskIdToSegmentIndexMap = new HashMap<String, AbstractIndex>();
+              // creating a map of task id to table segment
+              taskIdToSegmentIndexMap = new ConcurrentHashMap<String, AbstractIndex>();
               Iterator<Entry<String, List<TableBlockInfo>>> iterator =
                   taskIdToTableBlockInfoMap.entrySet().iterator();
               while (iterator.hasNext()) {
@@ -256,7 +256,7 @@ public class SegmentTaskIndexStore {
   private Map<String, List<TableBlockInfo>> mappedAndGetTaskIdToTableBlockInfo(
       Map<String, List<TableBlockInfo>> segmentToTableBlocksInfos) {
     Map<String, List<TableBlockInfo>> taskIdToTableBlockInfoMap =
-        new HashMap<String, List<TableBlockInfo>>();
+        new ConcurrentHashMap<String, List<TableBlockInfo>>();
     Iterator<Entry<String, List<TableBlockInfo>>> iterator =
         segmentToTableBlocksInfos.entrySet().iterator();
     while (iterator.hasNext()) {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1431,5 +1431,26 @@ public final class CarbonUtil {
     return builder.toString();
   }
 
+  /**
+   * Below method will be used to get the list of segment in
+   * comma separated string format
+   *
+   * @param segmentList
+   * @return comma separated segment string
+   */
+  public static String getSegmentString(List<String> segmentList) {
+    if (segmentList.isEmpty()) {
+      return "";
+    }
+    StringBuilder segmentStringbuilder = new StringBuilder();
+    for (int i = 0; i < segmentList.size() - 1; i++) {
+      String segmentNo = segmentList.get(i);
+      segmentStringbuilder.append(segmentNo);
+      segmentStringbuilder.append(",");
+    }
+    segmentStringbuilder.append(segmentList.get(segmentList.size() - 1));
+    return segmentStringbuilder.toString();
+  }
+
 }
 

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -18,12 +18,7 @@
  */
 package org.apache.carbondata.scan.executor.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -101,8 +96,12 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     // query execution
     Collections.sort(queryModel.getTableBlockInfos());
     // get the table blocks
+    BlockIndexStore blockLoaderInstance = BlockIndexStore.getInstance();
+    // remove the invalid table blocks, block which is deleted or compacted
+    blockLoaderInstance.removeTableBlocks(queryModel.getInvalidTableBlocks(),
+        queryModel.getAbsoluteTableIdentifier());
     try {
-      queryProperties.dataBlocks = BlockIndexStore.getInstance()
+      queryProperties.dataBlocks = blockLoaderInstance
           .loadAndGetBlocks(queryModel.getTableBlockInfos(),
               queryModel.getAbsoluteTableIdentifier());
     } catch (IndexBuilderException e) {

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -98,7 +98,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     // get the table blocks
     BlockIndexStore blockLoaderInstance = BlockIndexStore.getInstance();
     // remove the invalid table blocks, block which is deleted or compacted
-    blockLoaderInstance.removeTableBlocks(queryModel.getInvalidTableBlocks(),
+    blockLoaderInstance.removeTableBlocks(queryModel.getInvalidSegmentIds(),
         queryModel.getAbsoluteTableIdentifier());
     try {
       queryProperties.dataBlocks = blockLoaderInstance

--- a/core/src/main/java/org/apache/carbondata/scan/model/QueryModel.java
+++ b/core/src/main/java/org/apache/carbondata/scan/model/QueryModel.java
@@ -132,6 +132,13 @@ public class QueryModel implements Serializable {
 
   private QueryStatisticsRecorder statisticsRecorder;
 
+  /**
+   * Invalid table blocks, which need to be removed from
+   * memory, invalid blocks can be segment which are deleted
+   * or compacted
+   */
+  private List<TableBlockInfo> invalidTableBlocks;
+
   public QueryModel() {
     tableBlockInfos = new ArrayList<TableBlockInfo>();
     queryDimension = new ArrayList<QueryDimension>();
@@ -139,6 +146,7 @@ public class QueryModel implements Serializable {
     sortDimension = new ArrayList<QueryDimension>();
     sortOrder = new byte[0];
     paritionColumns = new ArrayList<String>();
+    invalidTableBlocks = new ArrayList<>();
   }
 
   public static QueryModel createModel(AbsoluteTableIdentifier absoluteTableIdentifier,
@@ -503,5 +511,13 @@ public class QueryModel implements Serializable {
 
   public void setStatisticsRecorder(QueryStatisticsRecorder statisticsRecorder) {
     this.statisticsRecorder = statisticsRecorder;
+  }
+
+  public List<TableBlockInfo> getInvalidTableBlocks() {
+    return invalidTableBlocks;
+  }
+
+  public void setInvalidTableBlocks(List<TableBlockInfo> invalidTableBlocks) {
+    this.invalidTableBlocks = invalidTableBlocks;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/scan/model/QueryModel.java
+++ b/core/src/main/java/org/apache/carbondata/scan/model/QueryModel.java
@@ -137,7 +137,7 @@ public class QueryModel implements Serializable {
    * memory, invalid blocks can be segment which are deleted
    * or compacted
    */
-  private List<TableBlockInfo> invalidTableBlocks;
+  private List<String> invalidSegmentIds;
 
   public QueryModel() {
     tableBlockInfos = new ArrayList<TableBlockInfo>();
@@ -146,7 +146,7 @@ public class QueryModel implements Serializable {
     sortDimension = new ArrayList<QueryDimension>();
     sortOrder = new byte[0];
     paritionColumns = new ArrayList<String>();
-    invalidTableBlocks = new ArrayList<>();
+    invalidSegmentIds = new ArrayList<>();
   }
 
   public static QueryModel createModel(AbsoluteTableIdentifier absoluteTableIdentifier,
@@ -513,11 +513,11 @@ public class QueryModel implements Serializable {
     this.statisticsRecorder = statisticsRecorder;
   }
 
-  public List<TableBlockInfo> getInvalidTableBlocks() {
-    return invalidTableBlocks;
+  public List<String> getInvalidSegmentIds() {
+    return invalidSegmentIds;
   }
 
-  public void setInvalidTableBlocks(List<TableBlockInfo> invalidTableBlocks) {
-    this.invalidTableBlocks = invalidTableBlocks;
+  public void setInvalidSegmentIds(List<String> invalidSegmentIds) {
+    this.invalidSegmentIds = invalidSegmentIds;
   }
 }

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputMapperTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputMapperTest.java
@@ -25,18 +25,18 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import junit.framework.TestCase;
 import org.apache.carbondata.core.carbon.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.hadoop.CarbonInputFormat;
 import org.apache.carbondata.hadoop.CarbonProjection;
 import org.apache.carbondata.hadoop.test.util.StoreCreator;
+import org.apache.carbondata.lcm.status.SegmentStatusManager;
 import org.apache.carbondata.scan.expression.ColumnExpression;
 import org.apache.carbondata.scan.expression.Expression;
 import org.apache.carbondata.scan.expression.LiteralExpression;
 import org.apache.carbondata.scan.expression.conditional.EqualToExpression;
-
-import junit.framework.TestCase;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IntWritable;
@@ -47,7 +47,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class CarbonInputMapperTest extends TestCase {
@@ -55,6 +54,10 @@ public class CarbonInputMapperTest extends TestCase {
   // changed setUp to static init block to avoid un wanted multiple time store creation
   static {
     StoreCreator.createCarbonStore();
+  }
+
+  public static void main(String[] args) throws Exception {
+    new CarbonInputMapperTest().runJob("target/output", null, null);
   }
 
   @Test public void testInputFormatMapperReadAllRowsAndColumns() throws Exception {
@@ -129,6 +132,38 @@ public class CarbonInputMapperTest extends TestCase {
     return 0;
   }
 
+  private void runJob(String outPath, CarbonProjection projection, Expression filter)
+      throws Exception {
+
+    Job job = Job.getInstance(new Configuration());
+    job.setJarByClass(CarbonInputMapperTest.class);
+    job.setOutputKeyClass(Text.class);
+    job.setOutputValueClass(IntWritable.class);
+    job.setMapperClass(Map.class);
+    //    job.setReducerClass(WordCountReducer.class);
+    job.setInputFormatClass(CarbonInputFormat.class);
+    job.setOutputFormatClass(TextOutputFormat.class);
+    AbsoluteTableIdentifier abs = StoreCreator.getAbsoluteTableIdentifier();
+    CarbonInputFormat.setTableToAccess(job.getConfiguration(), abs.getCarbonTableIdentifier());
+    if (projection != null) {
+      CarbonInputFormat.setColumnProjection(projection, job.getConfiguration());
+    }
+    if (filter != null) {
+      CarbonInputFormat.setFilterPredicates(job.getConfiguration(), filter);
+    }
+    FileInputFormat.addInputPath(job, new Path(abs.getStorePath()));
+    CarbonUtil.deleteFoldersAndFiles(new File(outPath + "1"));
+    FileOutputFormat.setOutputPath(job, new Path(outPath + "1"));
+    SegmentStatusManager.ValidAndInvalidSegmentsInfo validAndInvalidSegments =
+        new SegmentStatusManager(abs).getValidAndInvalidSegments();
+    CarbonInputFormat
+        .setSegmentsToAccess(job.getConfiguration(), validAndInvalidSegments.getValidSegments(),
+            validAndInvalidSegments.getInvalidSegments());
+    job.getConfiguration().set("outpath", outPath);
+
+    boolean status = job.waitForCompletion(true);
+  }
+
   public static class Map extends Mapper<Void, Object[], Void, Text> {
 
     private BufferedWriter fileWriter;
@@ -156,35 +191,5 @@ public class CarbonInputMapperTest extends TestCase {
       super.cleanup(context);
       fileWriter.close();
     }
-  }
-
-  private void runJob(String outPath, CarbonProjection projection, Expression filter)
-      throws Exception {
-
-    Job job = Job.getInstance(new Configuration());
-    job.setJarByClass(CarbonInputMapperTest.class);
-    job.setOutputKeyClass(Text.class);
-    job.setOutputValueClass(IntWritable.class);
-    job.setMapperClass(Map.class);
-    //    job.setReducerClass(WordCountReducer.class);
-    job.setInputFormatClass(CarbonInputFormat.class);
-    job.setOutputFormatClass(TextOutputFormat.class);
-    AbsoluteTableIdentifier abs = StoreCreator.getAbsoluteTableIdentifier();
-    CarbonInputFormat.setTableToAccess(job.getConfiguration(), abs.getCarbonTableIdentifier());
-    if (projection != null) {
-      CarbonInputFormat.setColumnProjection(projection, job.getConfiguration());
-    }
-    if (filter != null) {
-      CarbonInputFormat.setFilterPredicates(job.getConfiguration(), filter);
-    }
-    FileInputFormat.addInputPath(job, new Path(abs.getStorePath()));
-    CarbonUtil.deleteFoldersAndFiles(new File(outPath + "1"));
-    FileOutputFormat.setOutputPath(job, new Path(outPath + "1"));
-    job.getConfiguration().set("outpath", outPath);
-    boolean status = job.waitForCompletion(true);
-  }
-
-  public static void main(String[] args) throws Exception {
-    new CarbonInputMapperTest().runJob("target/output", null, null);
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -102,7 +102,7 @@ class CarbonScanRDD[V: ClassTag](
     val splits = carbonInputFormat.getSplits(job)
     if (!splits.isEmpty) {
       val carbonInputSplits = splits.asScala.map(_.asInstanceOf[CarbonInputSplit])
-
+      queryModel.setInvalidTableBlocks(carbonInputFormat.getInvalidSplits(job))
       val blockListTemp = carbonInputSplits.map(inputSplit =>
         new TableBlockInfo(inputSplit.getPath.toString,
           inputSplit.getStart, inputSplit.getSegmentId,

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
@@ -118,7 +118,7 @@ class CompactionSystemLockFeatureTest extends QueryTest with BeforeAndAfterAll {
         )
     )
     // merged segment should not be there
-    val segments = segmentStatusManager.getValidSegments.listOfValidSegments.asScala.toList
+    val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
     assert(segments.contains("0.1"))
     assert(!segments.contains("0"))
     assert(!segments.contains("1"))
@@ -130,7 +130,7 @@ class CompactionSystemLockFeatureTest extends QueryTest with BeforeAndAfterAll {
         )
     )
     // merged segment should not be there
-    val segments2 = segmentStatusManager2.getValidSegments.listOfValidSegments.asScala.toList
+    val segments2 = segmentStatusManager2.getValidAndInvalidSegments.getValidSegments.asScala.toList
     assert(segments2.contains("0.1"))
     assert(!segments2.contains("0"))
     assert(!segments2.contains("1"))

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionCardinalityBoundryTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionCardinalityBoundryTest.scala
@@ -92,7 +92,7 @@ class DataCompactionCardinalityBoundryTest extends QueryTest with BeforeAndAfter
             new CarbonTableIdentifier("default", "cardinalityTest", "1")
           )
       )
-      val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+      val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 
       if (!segments.contains("0.1")) {
         // wait for 2 seconds for compaction to complete.

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionLockTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionLockTest.scala
@@ -108,7 +108,7 @@ class DataCompactionLockTest extends QueryTest with BeforeAndAfterAll {
       val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(
         absoluteTableIdentifier
       )
-      val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+      val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 
       if (!segments.contains("0.1")) {
         assert(true)

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -44,7 +44,7 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
           new CarbonTableIdentifier(databaseName, tableName.toLowerCase , tableId)
         )
     )
-    val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+    val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
     segments
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -90,7 +90,7 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
             new CarbonTableIdentifier("default", "normalcompaction", "1")
           )
       )
-      val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+      val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 
       if (!segments.contains("0.1")) {
         // wait for 2 seconds for compaction to complete.
@@ -138,7 +138,7 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
         )
     )
     // merged segment should not be there
-    val segments   = segmentStatusManager.getValidSegments.listOfValidSegments.asScala.toList
+    val segments   = segmentStatusManager.getValidAndInvalidSegments().getValidSegments.asScala.toList
     assert(!segments.contains("0"))
     assert(!segments.contains("1"))
     assert(!segments.contains("2"))

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
@@ -103,7 +103,7 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
             new CarbonTableIdentifier("default", "ignoremajor", noOfRetries + "")
           )
       )
-      val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+      val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
       segments.foreach(seg =>
         System.out.println( "valid segment is =" + seg)
       )
@@ -135,7 +135,7 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
         )
     )
     // merged segment should not be there
-    val segments = segmentStatusManager.getValidSegments.listOfValidSegments.asScala.toList
+    val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
     assert(segments.contains("0.1"))
     assert(segments.contains("2.1"))
     assert(!segments.contains("2"))

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionStopsAfterCompaction.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionStopsAfterCompaction.scala
@@ -93,7 +93,7 @@ class MajorCompactionStopsAfterCompaction extends QueryTest with BeforeAndAfterA
             new CarbonTableIdentifier("default", "stopmajor", noOfRetries + "")
           )
       )
-      val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+      val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
       segments.foreach(seg =>
         System.out.println( "valid segment is =" + seg)
       )
@@ -125,7 +125,7 @@ class MajorCompactionStopsAfterCompaction extends QueryTest with BeforeAndAfterA
         )
     )
     // merged segment should not be there
-    val segments = segmentStatusManager.getValidSegments.listOfValidSegments.asScala.toList
+    val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
     assert(segments.contains("0.1"))
     assert(!segments.contains("0.2"))
     assert(!segments.contains("0"))

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -49,6 +49,7 @@ import org.apache.carbondata.lcm.locks.ICarbonLock;
 import org.apache.carbondata.lcm.locks.LockUsage;
 
 import com.google.gson.Gson;
+
 /**
  * Manages Load/Segment status
  */
@@ -120,14 +121,14 @@ public class SegmentStatusManager {
         List<LoadMetadataDetails> loadFolderDetails = Arrays.asList(loadFolderDetailsArray);
 
         for (LoadMetadataDetails loadMetadataDetails : loadFolderDetails) {
-          if (CarbonCommonConstants.STORE_LOADSTATUS_FAILURE
+          if ((CarbonCommonConstants.STORE_LOADSTATUS_FAILURE
               .equalsIgnoreCase(loadMetadataDetails.getLoadStatus())
               || CarbonCommonConstants.SEGMENT_COMPACTED
               .equalsIgnoreCase(loadMetadataDetails.getLoadStatus())
               || CarbonCommonConstants.MARKED_FOR_DELETE
-              .equalsIgnoreCase(loadMetadataDetails.getLoadStatus())) {
+              .equalsIgnoreCase(loadMetadataDetails.getLoadStatus())) && "true"
+              .equalsIgnoreCase(loadMetadataDetails.getVisibility())) {
             listOfInvalidSegments.add(loadMetadataDetails.getLoadName());
-
           }
         }
       }

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -152,8 +152,7 @@ public class SegmentStatusManager {
               || CarbonCommonConstants.SEGMENT_COMPACTED
               .equalsIgnoreCase(loadMetadataDetails.getLoadStatus())
               || CarbonCommonConstants.MARKED_FOR_DELETE
-              .equalsIgnoreCase(loadMetadataDetails.getLoadStatus())) && "true"
-              .equalsIgnoreCase(loadMetadataDetails.getVisibility())) {
+              .equalsIgnoreCase(loadMetadataDetails.getLoadStatus()))) {
             listOfInvalidSegments.add(loadMetadataDetails.getLoadName());
           }
 


### PR DESCRIPTION
**Problem:** During long run query execution is taking more time and it is throwing out of memory issue.
**Reason**: In compaction we are compacting segments and each segment metadata is loaded in memory. So after compaction compacted segments are invalid but its meta data is not removed from memory because of this duplicate metadata is pile up and it is taking more memory and after few days query execution is throwing OOM
**Solution**: Need to remove invalid blocks from memory

 
