### PR TITLE
[CARBONDATA-242] Filter result was not compatible with hive result when a null filter member is present in 'NOT IN' filter model

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/expression/logical/FalseExpression.java
+++ b/core/src/main/java/org/apache/carbondata/scan/expression/logical/FalseExpression.java
@@ -1,0 +1,51 @@
+package org.apache.carbondata.scan.expression.logical;
+
+import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
+import org.apache.carbondata.scan.expression.Expression;
+import org.apache.carbondata.scan.expression.ExpressionResult;
+import org.apache.carbondata.scan.expression.LiteralExpression;
+import org.apache.carbondata.scan.expression.conditional.BinaryConditionalExpression;
+import org.apache.carbondata.scan.expression.exception.FilterIllegalMemberException;
+import org.apache.carbondata.scan.expression.exception.FilterUnsupportedException;
+import org.apache.carbondata.scan.filter.intf.ExpressionType;
+import org.apache.carbondata.scan.filter.intf.RowIntf;
+
+
+
+/**
+ * This class will form an expression whose evaluation will be always false.
+ */
+public class FalseExpression  extends BinaryConditionalExpression {
+
+
+  private static final long serialVersionUID = -8390184061336799370L;
+
+  public FalseExpression(Expression child1) {
+    super(child1, new LiteralExpression(null,null));
+  }
+
+  /**
+   * This method will always return false, mainly used in the filter expressions
+   * which are illogical.
+   * eg: columnName NOT IN('Java',NULL)
+   * @param value
+   * @return
+   * @throws FilterUnsupportedException
+   * @throws FilterIllegalMemberException
+   */
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
+    return new ExpressionResult(DataType.BOOLEAN,false);
+  }
+
+  /**
+   * This method will return the expression types
+   * @return
+   */
+  @Override public ExpressionType getFilterExpressionType() {
+    return ExpressionType.FALSE;
+  }
+  @Override public String getString() {
+    return null;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/scan/filter/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/FilterExpressionProcessor.java
@@ -245,7 +245,9 @@ public class FilterExpressionProcessor implements FilterProcessor {
       case NOT_IN:
         return getFilterResolverBasedOnExpressionType(ExpressionType.NOT_EQUALS, false,
             expressionTree, tableIdentifier, expressionTree);
-
+      case FALSE:
+        return getFilterResolverBasedOnExpressionType(ExpressionType.FALSE, false,
+            expressionTree, tableIdentifier, expressionTree);
       default:
         return getFilterResolverBasedOnExpressionType(ExpressionType.UNKNOWN, false, expressionTree,
             tableIdentifier, expressionTree);
@@ -262,6 +264,8 @@ public class FilterExpressionProcessor implements FilterProcessor {
     BinaryConditionalExpression currentCondExpression = null;
     ConditionalExpression condExpression = null;
     switch (filterExpressionType) {
+      case FALSE:
+        return new RowLevelFilterResolverImpl(expression, false, false, tableIdentifier);
       case EQUALS:
         currentCondExpression = (BinaryConditionalExpression) expression;
         if (currentCondExpression.isSingleDimension()

--- a/core/src/main/java/org/apache/carbondata/scan/filter/intf/ExpressionType.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/intf/ExpressionType.java
@@ -39,6 +39,7 @@ public enum ExpressionType {
   NOT_IN,
   UNKNOWN,
   LITERAL,
-  RANGE
+  RANGE,
+  FALSE
 
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/GrtLtFilterProcessorTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/GrtLtFilterProcessorTestCase.scala
@@ -136,6 +136,12 @@ class GrtLtFilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
       Seq(Row(0))
     )
   }
+      test("In condition With improper format query regarding Null filter") {
+    checkAnswer(
+      sql("select empid from a12_allnull " + "where empid not in ('china',NULL)"),
+      Seq()
+    )
+      }
 
   //no null test cases
 


### PR DESCRIPTION
[**Problem**] 
Filter result was not compatible with hive result when a null filter member is present in not in
 filter model, as per hive no result shall be return if a NOT IN filter model has null object for comparison.
eg: select country from t3 where country not in (null,'china','france') group by country
[**Description**] 
When user provides Null member inside NOT IN filter condition the resultset is not compatible with hive result.