### PR TITLE
[CARBONDATA-245] Actual Exception is getting lost in case of data dictionary file generation.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
@@ -198,11 +198,9 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
    * @throws IOException if an I/O error occurs
    */
   @Override public void close() throws IOException {
-    if (null != dictionaryThriftWriter) {
+    if (null != dictionaryThriftWriter && dictionaryThriftWriter.isOpen()) {
       // if stream is open then only need to write dictionary file.
-      if(dictionaryThriftWriter.isOpen()){
         writeDictionaryFile();
-      }
       // close the thrift writer for dictionary file
       closeThriftWriter();
     }

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
@@ -200,7 +200,7 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
   @Override public void close() throws IOException {
     if (null != dictionaryThriftWriter && dictionaryThriftWriter.isOpen()) {
       // if stream is open then only need to write dictionary file.
-        writeDictionaryFile();
+      writeDictionaryFile();
       // close the thrift writer for dictionary file
       closeThriftWriter();
     }

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
@@ -199,7 +199,10 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
    */
   @Override public void close() throws IOException {
     if (null != dictionaryThriftWriter) {
-      writeDictionaryFile();
+      // if stream is open then only need to write dictionary file.
+      if(dictionaryThriftWriter.isOpen()){
+        writeDictionaryFile();
+      }
       // close the thrift writer for dictionary file
       closeThriftWriter();
     }
@@ -404,7 +407,7 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
   }
 
   @Override public void commit() throws IOException {
-    if (null != dictionaryThriftWriter) {
+    if (null != dictionaryThriftWriter && dictionaryThriftWriter.isOpen()) {
       this.chunk_end_offset = CarbonUtil.getFileSize(this.dictionaryFilePath);
       writeDictionaryMetadataFile();
     }

--- a/core/src/main/java/org/apache/carbondata/core/writer/ThriftWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/ThriftWriter.java
@@ -80,6 +80,17 @@ public class ThriftWriter {
   }
 
   /**
+   * This will check whether stream and binary out is open or not.
+   * @return
+   */
+  public boolean isOpen() {
+    if (null != binaryOut && null != dataOutputStream) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Write the object to disk.
    */
   public void write(TBase t) throws IOException {


### PR DESCRIPTION
PROBLEM : 
during data load if any exception comes when the dictionary file is getting generated.
then in the finally block trying to write the meta file but as the stream is null, it will throw null pointer.
  
solution : 
in the finally added a check whether the stream is null or not. then only writing data to the stream.
