### PR TITLE
[CARBONDATA-246] compaction is wrong in case if last segment is not assigned to an executor.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -36,7 +36,7 @@ import org.apache.carbondata.core.carbon.datastore.block.{Distributable, Segment
 import org.apache.carbondata.core.carbon.metadata.blocklet.DataFileFooter
 import org.apache.carbondata.core.carbon.path.CarbonTablePath
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil, CarbonUtilException}
 import org.apache.carbondata.hadoop.{CarbonInputFormat, CarbonInputSplit}
 import org.apache.carbondata.integration.spark.merger.{CarbonCompactionExecutor, CarbonCompactionUtil, RowResultMerger}
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil
@@ -102,6 +102,11 @@ class CarbonMergerRDD[K, V](
         var dataloadStatus = CarbonCommonConstants.STORE_LOADSTATUS_FAILURE
         val carbonSparkPartition = theSplit.asInstanceOf[CarbonSparkPartition]
 
+        // get destination segment properties as sent from driver which is of last segment.
+
+        val segmentProperties = new SegmentProperties(carbonMergerMapping.columnSchemaList.asJava,
+          carbonMergerMapping.colCardinality)
+
         // sorting the table block info List.
         var tableBlockInfoList = carbonSparkPartition.tableBlockInfos
 
@@ -114,19 +119,6 @@ class CarbonMergerRDD[K, V](
           CarbonCompactionUtil.createDataFileFooterMappingForSegments(tableBlockInfoList)
 
         carbonLoadModel.setStorePath(hdfsStoreLocation)
-
-        // taking the last table block info for getting the segment properties.
-        val listMetadata = dataFileMetadataSegMapping.get(tableBlockInfoList.get
-        (tableBlockInfoList.size() - 1).getSegmentId()
-        )
-
-        val colCardinality: Array[Int] = listMetadata.get(listMetadata.size() - 1).getSegmentInfo
-          .getColumnCardinality
-
-        val segmentProperties = new SegmentProperties(
-          listMetadata.get(listMetadata.size() - 1).getColumnInTable,
-          colCardinality
-        )
 
         val exec = new CarbonCompactionExecutor(segmentMapping, segmentProperties, databaseName,
           factTableName, hdfsStoreLocation, carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,
@@ -170,7 +162,7 @@ class CarbonMergerRDD[K, V](
             segmentProperties,
             tempStoreLoc,
             carbonLoadModel,
-            colCardinality
+            carbonMergerMapping.colCardinality
           )
         mergeStatus = merger.mergerSlice()
 
@@ -238,6 +230,8 @@ class CarbonMergerRDD[K, V](
 
     val taskInfoList = new util.ArrayList[Distributable]
 
+    var blocksOfLastSegment: List[TableBlockInfo] = null
+
     // for each valid segment.
     for (eachSeg <- carbonMergerMapping.validSegments) {
 
@@ -258,6 +252,9 @@ class CarbonMergerRDD[K, V](
           inputSplit.getLocations, inputSplit.getLength
         )
       )
+
+      // keep on assigning till last one is reached.
+      blocksOfLastSegment = blocksOfOneSegment.asJava
 
       // populate the task and its block mapping.
       blocksOfOneSegment.foreach(tableBlockInfo => {
@@ -280,6 +277,25 @@ class CarbonMergerRDD[K, V](
           taskInfoList.add(new TableTaskInfo(entry._1, entry._2).asInstanceOf[Distributable])
       )
     }
+
+    // prepare the details required to extract the segment properties using last segment.
+
+    val lastBlockInfo = blocksOfLastSegment.get(blocksOfLastSegment.size - 1)
+
+    var dataFileFooter: DataFileFooter = null
+
+    try {
+      dataFileFooter = CarbonUtil.readMetadatFile(lastBlockInfo.getFilePath,
+        lastBlockInfo.getBlockOffset, lastBlockInfo.getBlockLength)
+    } catch {
+      case e: CarbonUtilException =>
+        logError("Exception in preparing the data file footer for compaction " + e.getMessage)
+        throw e
+    }
+
+    carbonMergerMapping.colCardinality = dataFileFooter.getSegmentInfo.getColumnCardinality
+    carbonMergerMapping.columnSchemaList = dataFileFooter.getColumnInTable.asScala.toList
+
     // send complete list of blocks to the mapping util.
     nodeMapping = CarbonLoaderUtil.nodeBlockMapping(taskInfoList, -1)
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
@@ -70,7 +70,7 @@ object Compactor {
       factTableName,
       validSegments,
       carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId,
-      colCardinality = Array[Int](0),
+      colCardinality = null,
       columnSchemaList = null
     )
     carbonLoadModel.setStorePath(carbonMergerMapping.hdfsStoreLocation)

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
@@ -69,7 +69,9 @@ object Compactor {
       schemaName,
       factTableName,
       validSegments,
-      carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId
+      carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId,
+      colCardinality = Array[Int](0),
+      columnSchemaList = null
     )
     carbonLoadModel.setStorePath(carbonMergerMapping.hdfsStoreLocation)
     val segmentStatusManager = new SegmentStatusManager(new AbsoluteTableIdentifier

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/Compactor.scala
@@ -70,8 +70,8 @@ object Compactor {
       factTableName,
       validSegments,
       carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId,
-      colCardinality = null,
-      columnSchemaList = null
+      maxSegmentColCardinality = null,
+      maxSegmentColumnSchemaList = null
     )
     carbonLoadModel.setStorePath(carbonMergerMapping.hdfsStoreLocation)
     val segmentStatusManager = new SegmentStatusManager(new AbsoluteTableIdentifier

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -155,8 +155,10 @@ case class CarbonMergerMapping(storeLocation: String,
     factTableName: String,
     validSegments: Array[String],
     tableId: String,
-    var colCardinality: Array[Int],
-    var columnSchemaList: List[ColumnSchema])
+    // maxSegmentColCardinality is Cardinality of last segment of compaction
+    var maxSegmentColCardinality: Array[Int],
+    // maxSegmentColumnSchemaList is list of column schema of last segment of compaction
+    var maxSegmentColumnSchemaList: List[ColumnSchema])
 
 case class NodeInfo(TaskId: String, noOfBlocks: Int)
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -144,10 +144,19 @@ case class Default(key: String, value: String)
 
 case class DataLoadTableFileMapping(table: String, loadPath: String)
 
-case class CarbonMergerMapping(storeLocation: String, hdfsStoreLocation: String,
-  partitioner: Partitioner, metadataFilePath: String, mergedLoadName: String,
-  kettleHomePath: String, tableCreationTime: Long, databaseName: String,
-  factTableName: String, validSegments: Array[String], tableId: String)
+case class CarbonMergerMapping(storeLocation: String,
+    hdfsStoreLocation: String,
+    partitioner: Partitioner,
+    metadataFilePath: String,
+    mergedLoadName: String,
+    kettleHomePath: String,
+    tableCreationTime: Long,
+    databaseName: String,
+    factTableName: String,
+    validSegments: Array[String],
+    tableId: String,
+    var colCardinality: Array[Int],
+    var columnSchemaList: List[ColumnSchema])
 
 case class NodeInfo(TaskId: String, noOfBlocks: Int)
 


### PR DESCRIPTION
PROBLEM:

if during compaction of 4 loads, for any executor if only first 3 loads task is assigned then the col cardinality calculation based on the last segment info will become wrong.

in this case the cardinality will go wrong for that executor.

Solution : 

Pass the segment properties info from the driver using the last segment. 
