### PR TITLE
[CARBONDATA-248]Problem:Column heading TOTAL QUERY COST was missing in driver statistics table and SCAN BLOCK TIME was always zero in query statistics table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorder.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorder.java
@@ -155,7 +155,7 @@ public class DriverQueryStatisticsRecorder {
       int len1 = 8;
       int len2 = 20;
       int len3 = 21;
-      int len4 = 22;
+      int len4 = 24;
       String line = "+" + printLine("-", len1) + "+" + printLine("-", len2) + "+" +
           printLine("-", len3) + "+" + printLine("-", len4) + "+";
       String line2 = "|" + printLine(" ", len1) + "+" + printLine("-", len2) + "+" +
@@ -164,7 +164,8 @@ public class DriverQueryStatisticsRecorder {
       tableInfo.append(line).append("\n");
       tableInfo.append("|" + printLine(" ", (len1 - "Module".length())) + "Module" + "|" +
           printLine(" ", (len2 - "Operation Step".length())) + "Operation Step" + "|" +
-          printLine(" ", (len3 + len4 + 1 - "Query Cost".length())) + "Query Cost" + "|" + "\n");
+          printLine(" ", (len3 - "Total Query Cost".length())) + "Total Query Cost" + "|" +
+          printLine(" ", (len4 - "Query Cost".length())) + "Query Cost" + "|" + "\n");
       tableInfo.append(line).append("\n");
       // print sql_parse_t,load_meta_t,block_allocation_t,block_identification_t
       if (!StringUtils.isEmpty(sql_parse_time) &&

--- a/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -106,6 +106,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
   }
 
   private void intialiseInfos() {
+    totalScanTime=System.currentTimeMillis();
     for (BlockExecutionInfo blockInfo : blockExecutionInfos) {
       DataRefNodeFinder finder = new BTreeDataRefNodeFinder(blockInfo.getEachColumnValueSize());
       DataRefNode startDataBlock = finder
@@ -134,7 +135,8 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
     } else {
       if (!isStatisticsRecorded) {
         QueryStatistic statistic = new QueryStatistic();
-        statistic.addFixedTimeStatistic(QueryStatisticsConstants.SCAN_BLOCKS_TIME, totalScanTime);
+        statistic.addFixedTimeStatistic(QueryStatisticsConstants.SCAN_BLOCKS_TIME,
+            System.currentTimeMillis() - totalScanTime);
         recorder.recordStatistics(statistic);
         isStatisticsRecorded = true;
       }


### PR DESCRIPTION
problem:There was no column header for total query cost in driver statistics table and scan block time was always zero in query statistics table.

Analysis:While creating driver statistics table header was not created and the scan block time was not initialized before recording in statistics recorder.

Fix:One more line is added to print the column header in driver statistics table and the scan block time is initialized before recording the statistics.

Impact:Logs of all query