### PR TITLE
[CARBONDATA-251] making the auto compaction as blocking call.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -911,6 +911,7 @@ public final class CarbonCommonConstants {
   public static String majorCompactionRequiredFile = "compactionRequired_major";
 
   /**
+   * @Deprecated : This property has been deprecated.
    * Property for enabling system level compaction lock.1 compaction can run at once.
    */
   public static String ENABLE_CONCURRENT_COMPACTION =

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -920,7 +920,7 @@ public final class CarbonCommonConstants {
    * Default value of Property for enabling system level compaction lock.1 compaction can run
    * at once.
    */
-  public static String DEFAULT_ENABLE_CONCURRENT_COMPACTION = "false";
+  public static String DEFAULT_ENABLE_CONCURRENT_COMPACTION = "true";
 
   /**
    * Compaction system level lock folder.

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -623,6 +623,8 @@ object CarbonDataRDDFactory extends Logging {
           }
         }
       }
+    // calling the run method of a thread to make the call as blocking call.
+    // in the future we may make this as concurrent.
     compactionThread.run()
   }
 
@@ -1049,7 +1051,8 @@ object CarbonDataRDDFactory extends Logging {
         }
         catch {
           case e: Exception =>
-            throw new Exception("Dataload is success. Compaction is failed. Please check logs.")
+            throw new Exception(
+              "Dataload is success. Auto-Compaction has failed. Please check logs.")
         }
       }
     }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
@@ -43,6 +43,8 @@ class CompactionSystemLockFeatureTest extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists  table2")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "mm/dd/yyyy")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_CONCURRENT_COMPACTION, "false")
     sql(
       "CREATE TABLE IF NOT EXISTS table1 (country String, ID Int, date Timestamp, name " +
         "String, " +


### PR DESCRIPTION
Problem : 
the behaviour of auto compaction with spark-submit and thrift server is different.
auto compaction will not work in spark-submit as the compaction is background process.

Solution : 
Make the auto compaction feature as blocking call.
disable the system level compaction lock feature by default.

