### PR TITLE
[CARBONDATA-253]OOM issue if distribution is based on blocklet duing query execution

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/datastore/block/BlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/datastore/block/BlockInfo.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.core.carbon.datastore.block;
+
+/**
+ * Below class will be used to store table block info
+ * As in blocklet distribution we are dividing the same block
+ * in parts but in case of block loading blocklets belongs to same
+ * block will be loaded together. This class will be used to store table block info
+ * and equals and hash code method is used to identify blocklet belongs to same block
+ */
+public class BlockInfo {
+
+  /**
+   * table block info, stores all the details
+   * about the block
+   */
+  private TableBlockInfo info;
+
+  /**
+   * Constructor
+   *
+   * @param info
+   */
+  public BlockInfo(TableBlockInfo info) {
+    this.info = info;
+  }
+
+  /**
+   * @return table Block info
+   */
+  public TableBlockInfo getTableBlockInfo() {
+    return info;
+  }
+
+  /**
+   * To set the table block info
+   *
+   * @param info
+   */
+  public void setTableBlockInfo(TableBlockInfo info) {
+    this.info = info;
+  }
+
+  /**
+   * method to get the hash code
+   */
+  @Override public int hashCode() {
+    int result = info.getFilePath().hashCode();
+    result = 31 * result + (int) (info.getBlockOffset() ^ (info.getBlockOffset() >>> 32));
+    result = 31 * result + (int) (info.getBlockLength() ^ (info.getBlockLength() >>> 32));
+    result = 31 * result + info.getSegmentId().hashCode();
+    return result;
+  }
+
+  /**
+   * To check the equality
+   *
+   * @param obj
+   */
+  @Override public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (!(obj instanceof BlockInfo)) {
+      return false;
+    }
+    BlockInfo other = (BlockInfo) obj;
+    if (!info.getSegmentId().equals(other.info.getSegmentId())) {
+      return false;
+    }
+    if (info.getBlockOffset() != other.info.getBlockOffset()) {
+      return false;
+    }
+    if (info.getBlockLength() != info.getBlockLength()) {
+      return false;
+    }
+
+    if (info.getFilePath() == null && other.info.getFilePath() != null) {
+      return false;
+    } else if (info.getFilePath() != null && other.info.getFilePath() == null) {
+      return false;
+    } else if (!info.getFilePath().equals(other.info.getFilePath())) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/carbon/datastore/block/TableBlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/datastore/block/TableBlockInfo.java
@@ -19,7 +19,6 @@
 package org.apache.carbondata.core.carbon.datastore.block;
 
 import java.io.Serializable;
-import java.util.Arrays;
 
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath.DataFileUtil;
@@ -74,6 +73,7 @@ public class TableBlockInfo extends Distributable
 
   /**
    * constructor to initialize the TbaleBlockInfo with BlockletInfos
+   *
    * @param filePath
    * @param blockOffset
    * @param segmentId
@@ -104,7 +104,6 @@ public class TableBlockInfo extends Distributable
   public long getBlockOffset() {
     return blockOffset;
   }
-
 
   /**
    * @return the segmentId
@@ -145,12 +144,14 @@ public class TableBlockInfo extends Distributable
     if (blockLength != other.blockLength) {
       return false;
     }
-
-    if (filePath == null) {
-      if (other.filePath != null) {
-        return false;
-      }
+    if (filePath == null && other.filePath != null) {
+      return false;
+    } else if (filePath != null && other.filePath == null) {
+      return false;
     } else if (!filePath.equals(other.filePath)) {
+      return false;
+    }
+    if (blockletInfos.getStartBlockletNumber() != other.blockletInfos.getStartBlockletNumber()) {
       return false;
     }
     return true;
@@ -225,7 +226,6 @@ public class TableBlockInfo extends Distributable
     result = 31 * result + (int) (blockOffset ^ (blockOffset >>> 32));
     result = 31 * result + (int) (blockLength ^ (blockLength >>> 32));
     result = 31 * result + segmentId.hashCode();
-    result = 31 * result + Arrays.hashCode(locations);
     result = 31 * result + blockletInfos.getStartBlockletNumber();
     return result;
   }
@@ -236,6 +236,7 @@ public class TableBlockInfo extends Distributable
 
   /**
    * returns BlockletInfos
+   *
    * @return
    */
   public BlockletInfos getBlockletInfos() {
@@ -244,6 +245,7 @@ public class TableBlockInfo extends Distributable
 
   /**
    * set the blocklestinfos
+   *
    * @param blockletInfos
    */
   public void setBlockletInfos(BlockletInfos blockletInfos) {

--- a/core/src/main/java/org/apache/carbondata/core/carbon/datastore/impl/btree/BlockBTreeLeafNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/datastore/impl/btree/BlockBTreeLeafNode.java
@@ -19,6 +19,7 @@
 package org.apache.carbondata.core.carbon.datastore.impl.btree;
 
 import org.apache.carbondata.core.carbon.datastore.BTreeBuilderInfo;
+import org.apache.carbondata.core.carbon.datastore.block.BlockInfo;
 import org.apache.carbondata.core.carbon.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.carbon.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.carbon.metadata.blocklet.index.BlockletMinMaxIndex;
@@ -30,7 +31,7 @@ import org.apache.carbondata.core.carbon.metadata.blocklet.index.BlockletMinMaxI
  */
 public class BlockBTreeLeafNode extends AbstractBTreeLeafNode {
 
-  private TableBlockInfo blockInfo;
+  private BlockInfo blockInfo;
 
   /**
    * Create a leaf node
@@ -47,7 +48,7 @@ public class BlockBTreeLeafNode extends AbstractBTreeLeafNode {
     minKeyOfColumns = minMaxIndex.getMinValues();
     numberOfKeys = 1;
     this.nodeNumber = nodeNumber;
-    this.blockInfo = footer.getTableBlockInfo();
+    this.blockInfo = footer.getBlockInfo();
   }
 
   /**
@@ -58,7 +59,7 @@ public class BlockBTreeLeafNode extends AbstractBTreeLeafNode {
    * @return TableBlockInfo
    */
   public TableBlockInfo getTableBlockInfo() {
-    return blockInfo;
+    return blockInfo.getTableBlockInfo();
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/carbon/datastore/impl/btree/BlockletBTreeLeafNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/datastore/impl/btree/BlockletBTreeLeafNode.java
@@ -70,7 +70,7 @@ public class BlockletBTreeLeafNode extends AbstractBTreeLeafNode {
     dimensionChunksReader = new CompressedDimensionChunkFileBasedReader(
         builderInfos.getFooterList().get(0).getBlockletList().get(leafIndex)
             .getDimensionColumnChunk(), builderInfos.getDimensionColumnValueSize(),
-        builderInfos.getFooterList().get(0).getTableBlockInfo().getFilePath());
+        builderInfos.getFooterList().get(0).getBlockInfo().getTableBlockInfo().getFilePath());
     // get the value compression model which was used to compress the measure values
     ValueCompressionModel valueCompressionModel = CarbonUtil.getValueCompressionModel(
         builderInfos.getFooterList().get(0).getBlockletList().get(leafIndex)
@@ -79,7 +79,7 @@ public class BlockletBTreeLeafNode extends AbstractBTreeLeafNode {
     measureColumnChunkReader = new CompressedMeasureChunkFileBasedReader(
         builderInfos.getFooterList().get(0).getBlockletList().get(leafIndex)
             .getMeasureColumnChunk(), valueCompressionModel,
-            builderInfos.getFooterList().get(0).getTableBlockInfo().getFilePath());
+            builderInfos.getFooterList().get(0).getBlockInfo().getTableBlockInfo().getFilePath());
     this.nodeNumber = nodeNumber;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/blocklet/DataFileFooter.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/blocklet/DataFileFooter.java
@@ -21,7 +21,7 @@ package org.apache.carbondata.core.carbon.metadata.blocklet;
 import java.io.Serializable;
 import java.util.List;
 
-import org.apache.carbondata.core.carbon.datastore.block.TableBlockInfo;
+import org.apache.carbondata.core.carbon.datastore.block.BlockInfo;
 import org.apache.carbondata.core.carbon.metadata.blocklet.index.BlockletIndex;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.ColumnSchema;
 
@@ -68,7 +68,7 @@ public class DataFileFooter implements Serializable {
   /**
    * to store the block info detail like file name block index and locations
    */
-  private TableBlockInfo tableBlockInfo;
+  private BlockInfo blockInfo;
 
   /**
    * @return the versionId
@@ -157,14 +157,14 @@ public class DataFileFooter implements Serializable {
   /**
    * @return the tableBlockInfo
    */
-  public TableBlockInfo getTableBlockInfo() {
-    return tableBlockInfo;
+  public BlockInfo getBlockInfo() {
+    return blockInfo;
   }
 
   /**
    * @param tableBlockInfo the tableBlockInfo to set
    */
-  public void setTableBlockInfo(TableBlockInfo tableBlockInfo) {
-    this.tableBlockInfo = tableBlockInfo;
+  public void setBlockInfo(BlockInfo tableBlockInfo) {
+    this.blockInfo = tableBlockInfo;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.carbon.datastore.block.BlockInfo;
 import org.apache.carbondata.core.carbon.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.carbon.metadata.blocklet.BlockletInfo;
 import org.apache.carbondata.core.carbon.metadata.blocklet.DataFileFooter;
@@ -101,7 +102,7 @@ public class DataFileFooterConverter {
         dataFileFooter.setBlockletIndex(blockletIndex);
         dataFileFooter.setColumnInTable(columnSchemaList);
         dataFileFooter.setNumberOfRows(readBlockIndexInfo.getNum_rows());
-        dataFileFooter.setTableBlockInfo(tableBlockInfo);
+        dataFileFooter.setBlockInfo(new BlockInfo(tableBlockInfo));
         dataFileFooter.setSegmentInfo(segmentInfo);
         dataFileFooters.add(dataFileFooter);
       }


### PR DESCRIPTION
Problem:In case of query execution when distribution is based on blocklet same blocks are getting loaded multiple times this is because hash code and equals method contract is not same, this is can cause OOM issue if distribution is based on blocklet
Solution: As same class will be used to identify unique blocks while distribution and while loading so creating a wrapper class and implementing hash code and equals method based on filepath, offset and length, this will remove duplicate blocks and only one block's metadata will be loaded in memory 