### PR TITLE
[CARBONDATA-256]Changed StringBuffer to StringBuilder

### DIFF
--- a/common/src/main/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppender.java
+++ b/common/src/main/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppender.java
@@ -145,7 +145,7 @@ public class ExtendedRollingFileAppender extends RollingFileAppender {
     if (maxBackupIndex > 0) {
       DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_FOR_TRANSFER);
 
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       String extension = "";
       if (fileName.contains(".")) {
         extension = fileName.substring(fileName.lastIndexOf("."));

--- a/common/src/main/java/org/apache/carbondata/common/logging/impl/StandardLogService.java
+++ b/common/src/main/java/org/apache/carbondata/common/logging/impl/StandardLogService.java
@@ -130,7 +130,7 @@ public final class StandardLogService implements LogService {
   }
 
   public static void setThreadName(String partitionID, String queryID) {
-    StringBuffer b = new StringBuffer(PARTITION_ID);
+    StringBuilder b = new StringBuilder(PARTITION_ID);
     b.append(partitionID);
     if (null != queryID) {
       b.append(";queryID:");
@@ -190,7 +190,7 @@ public final class StandardLogService implements LogService {
     if (StandardLogService.doLog) {
       try {
         //Append the partition id and query id if exist
-        StringBuffer buff = new StringBuffer(Thread.currentThread().getName());
+        StringBuilder buff = new StringBuilder(Thread.currentThread().getName());
         buff.append(" ");
         buff.append(message);
         message = buff.toString();

--- a/processing/src/main/java/org/apache/carbondata/processing/csvreaderstep/CsvInputMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/csvreaderstep/CsvInputMeta.java
@@ -202,7 +202,7 @@ public class CsvInputMeta extends BaseStepMeta
   }
 
   public String getXML() {
-    StringBuffer retval = new StringBuffer(500);
+    StringBuilder retval = new StringBuilder(500);
 
     retval.append("    ").append(XMLHandler.addTagValue(getXmlCode("FILENAME"), filename));
     retval.append("    ")

--- a/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStepMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStepMeta.java
@@ -162,7 +162,7 @@ public class MDKeyGenStepMeta extends BaseStepMeta implements StepMetaInterface 
   }
 
   public String getXML() {
-    StringBuffer retval = new StringBuffer(150);
+    StringBuilder retval = new StringBuilder(150);
 
     retval.append("    ").append(XMLHandler.addTagValue("TableName", tableName));
     retval.append("    ").append(XMLHandler.addTagValue("AggregateLevels", aggregateLevels));

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/step/CarbonSliceMergerStepMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/step/CarbonSliceMergerStepMeta.java
@@ -150,7 +150,7 @@ public class CarbonSliceMergerStepMeta extends BaseStepMeta
    * @throws KettleException in case there is a conversion or XML encoding error
    */
   public String getXML() {
-    StringBuffer retval = new StringBuffer(150);
+    StringBuilder retval = new StringBuilder(150);
     retval.append("    ").append(XMLHandler.addTagValue("TableName", tabelName));
     retval.append("    ").append(XMLHandler.addTagValue("MDKeySize", mdkeySize));
     retval.append("    ").append(XMLHandler.addTagValue("Measurecount", measureCount));

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdatastep/SortKeyStepMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdatastep/SortKeyStepMeta.java
@@ -145,7 +145,7 @@ public class SortKeyStepMeta extends BaseStepMeta implements StepMetaInterface {
    * @throws KettleException in case there is a conversion or XML encoding error
    */
   public String getXML() {
-    StringBuffer retval = new StringBuffer(150);
+    StringBuilder retval = new StringBuilder(150);
     retval.append("    ").append(XMLHandler.addTagValue("TableName", this.tabelName));
     retval.append("    ").append(XMLHandler.addTagValue("factDimLensString", factDimLensString));
     retval.append("    ").append(XMLHandler.addTagValue("outputRowSize", this.outputRowSize));

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
@@ -659,7 +659,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
   }
 
   public String getXML() throws KettleValueException {
-    StringBuffer retval = new StringBuffer(150);
+    StringBuilder retval = new StringBuilder(150);
     retval.append("    ").append(XMLHandler.addTagValue("carbonProps", carbonProps));
     retval.append("    ").append(XMLHandler.addTagValue("dim", carbondim));
     retval.append("    ").append(XMLHandler.addTagValue("msr", carbonmsr));

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonSchemaParser.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonSchemaParser.java
@@ -578,7 +578,7 @@ public final class CarbonSchemaParser {
    * @return
    */
   public static String getColumnGroups(List<CarbonDimension> dimensions) {
-    StringBuffer columnGroups = new StringBuffer();
+    StringBuilder columnGroups = new StringBuilder();
     for (int i = 0; i < dimensions.size(); i++) {
       CarbonDimension dimension = dimensions.get(i);
       //assuming complex dimensions will always be atlast
@@ -648,7 +648,7 @@ public final class CarbonSchemaParser {
 
   public static String getTableNameString(String factTableName, List<CarbonDimension> dimensions,
       CarbonDataLoadSchema carbonDataLoadSchema) {
-    StringBuffer stringBuffer = new StringBuffer();
+    StringBuilder stringBuffer = new StringBuilder();
 
     for (CarbonDimension cDimension : dimensions) {
       String tableName = extractDimensionTableName(cDimension.getColName(), carbonDataLoadSchema);
@@ -674,7 +674,7 @@ public final class CarbonSchemaParser {
    * @return
    */
   public static String getColumnIdString(List<CarbonDimension> dimensions) {
-    StringBuffer stringBuffer = new StringBuffer();
+    StringBuilder stringBuffer = new StringBuilder();
     for (CarbonDimension cDimension : dimensions) {
       if (!cDimension.hasEncoding(Encoding.DICTIONARY)) {
         continue;
@@ -741,7 +741,7 @@ public final class CarbonSchemaParser {
    */
   public static String getHeirAndKeySizeMapForFact(List<CarbonDimension> dimensions,
       CarbonDataLoadSchema carbonDataLoadSchema) {
-    StringBuffer stringBuffer = new StringBuffer();
+    StringBuilder stringBuffer = new StringBuilder();
     String heirName = null;
     int[] dims = null;
     int keySizeInBytes = 0;
@@ -895,7 +895,7 @@ public final class CarbonSchemaParser {
    */
   public static String getPrimaryKeyString(List<CarbonDimension> dimensions,
       CarbonDataLoadSchema carbonDataLoadSchema) {
-    StringBuffer primaryKeyStringbuffer = new StringBuffer();
+    StringBuilder primaryKeyStringbuffer = new StringBuilder();
     for (CarbonDimension cDimension : dimensions) {
       String dimTableName =
           extractDimensionTableName(cDimension.getColName(), carbonDataLoadSchema);


### PR DESCRIPTION
Even with local variables of Stringbuffer type, unnecessary synchronization overhead will be added in string operation.Replacing StringBuffer with StringBuilder in such cases can avoid synchronization overhead

        - Whether new unit test cases have been added or why no new tests are required? 
           >> Not added new TCs . Not modified  any new functional change




