### PR TITLE
[CARBONDATA-257] Make CarbonData readable by SparkContext/MapReduce program

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
@@ -18,6 +18,7 @@
  */
 package org.apache.carbondata.core.carbon;
 
+import java.io.File;
 import java.io.Serializable;
 
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
@@ -76,6 +77,11 @@ public class AbsoluteTableIdentifier implements Serializable {
     CarbonTableIdentifier identifier =
         new CarbonTableIdentifier(dbName, tableName, Long.toString(System.currentTimeMillis()));
     return new AbsoluteTableIdentifier(storePath, identifier);
+  }
+
+  public String getTablePath() {
+    return getStorePath() + File.separator + getCarbonTableIdentifier().getDatabaseName() +
+        File.separator + getCarbonTableIdentifier().getTableName();
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/carbon/path/CarbonStorePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/path/CarbonStorePath.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.carbon.path;
 
 import java.io.File;
 
+import org.apache.carbondata.core.carbon.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 
 import org.apache.hadoop.fs.Path;
@@ -46,6 +47,11 @@ public class CarbonStorePath extends Path {
             + tableIdentifier.getTableName());
 
     return carbonTablePath;
+  }
+
+  public static CarbonTablePath getCarbonTablePath(AbsoluteTableIdentifier identifier) {
+    CarbonTableIdentifier id = identifier.getCarbonTableIdentifier();
+    return new CarbonTablePath(id, identifier.getTablePath());
   }
 
   /**

--- a/examples/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
@@ -18,15 +18,15 @@ package org.apache.carbondata.examples
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
-import org.apache.carbondata.examples.util.{AllDictionaryUtil, InitForExamples}
+import org.apache.carbondata.examples.util.{AllDictionaryUtil, ExampleUitls}
 
 object AllDictionaryExample {
   def main(args: Array[String]) {
-    val cc = InitForExamples.createCarbonContext("CarbonExample")
-    val testData = InitForExamples.currentPath + "/src/main/resources/data.csv"
+    val cc = ExampleUitls.createCarbonContext("CarbonExample")
+    val testData = ExampleUitls.currentPath + "/src/main/resources/data.csv"
     val csvHeader = "ID,date,country,name,phonetype,serialname,salary"
     val dictCol = "|date|country|name|phonetype|serialname|"
-    val allDictFile = InitForExamples.currentPath + "/src/main/resources/data.dictionary"
+    val allDictFile = ExampleUitls.currentPath + "/src/main/resources/data.dictionary"
     // extract all dictionary files from source data
     AllDictionaryUtil.extractDictionary(cc.sparkContext,
       testData, allDictFile, csvHeader, dictCol)

--- a/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -19,12 +19,12 @@ package org.apache.carbondata.examples
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
-import org.apache.carbondata.examples.util.InitForExamples
+import org.apache.carbondata.examples.util.ExampleUitls
 
 object CarbonExample {
   def main(args: Array[String]) {
-    val cc = InitForExamples.createCarbonContext("CarbonExample")
-    val testData = InitForExamples.currentPath + "/src/main/resources/data.csv"
+    val cc = ExampleUitls.createCarbonContext("CarbonExample")
+    val testData = ExampleUitls.currentPath + "/src/main/resources/data.csv"
 
     // Specify timestamp format based on raw data
     CarbonProperties.getInstance()

--- a/examples/src/main/scala/org/apache/carbondata/examples/ComplexTypeExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/ComplexTypeExample.scala
@@ -17,7 +17,7 @@
 
 package org.apache.carbondata.examples
 
-import org.apache.carbondata.examples.util.InitForExamples
+import org.apache.carbondata.examples.util.ExampleUitls
 
 /**
  * Carbon supports the complex types ARRAY and STRUCT.
@@ -26,8 +26,8 @@ import org.apache.carbondata.examples.util.InitForExamples
 object ComplexTypeExample {
 
   def main(args: Array[String]) {
-    val cc = InitForExamples.createCarbonContext("ComplexTypeExample")
-    val dataPath = InitForExamples.currentPath + "/src/main/resources/complexdata.csv"
+    val cc = ExampleUitls.createCarbonContext("ComplexTypeExample")
+    val dataPath = ExampleUitls.currentPath + "/src/main/resources/complexdata.csv"
     val tableName = "complexTypeTable"
 
     cc.sql(s"DROP TABLE IF EXISTS $tableName")

--- a/examples/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
@@ -19,29 +19,14 @@ package org.apache.carbondata.examples
 
 import org.apache.spark.sql.SaveMode
 
-import org.apache.carbondata.examples.util.InitForExamples
+import org.apache.carbondata.examples.util.ExampleUitls
 
 // scalastyle:off println
 object DataFrameAPIExample {
 
   def main(args: Array[String]) {
-    val cc = InitForExamples.createCarbonContext("DataFrameAPIExample")
-    val sc = cc.sc
-
-    import cc.implicits._
-
-    // create a dataframe, it can be from parquet or hive table
-    val df = sc.parallelize(1 to 1000)
-      .map(x => ("a", "b", x))
-      .toDF("c1", "c2", "c3")
-
-    // save dataframe to carbon file
-    df.write
-      .format("carbondata")
-      .option("tableName", "carbon1")
-      .option("compress", "true")
-      .mode(SaveMode.Overwrite)
-      .save()
+    val cc = ExampleUitls.createCarbonContext("DataFrameAPIExample")
+    ExampleUitls.writeSampleCarbonFile(cc, "carbon1")
 
     // use datasource api to read
     val in = cc.read
@@ -49,19 +34,13 @@ object DataFrameAPIExample {
       .option("tableName", "carbon1")
       .load()
 
+    import cc.implicits._
     val count = in.where($"c3" > 500).select($"*").count()
-    println(s"count using dataframe.read: $count")
+    println(s"count using dataframe: $count")
 
     // use SQL to read
     cc.sql("SELECT count(*) FROM carbon1 WHERE c3 > 500").show
     cc.sql("DROP TABLE IF EXISTS carbon1")
-
-    // also support a implicit function for easier access
-    import org.apache.carbondata.spark._
-    df.saveAsCarbonFile(Map("tableName" -> "carbon2", "compress" -> "true"))
-
-    cc.sql("SELECT count(*) FROM carbon2 WHERE c3 > 100").show
-    cc.sql("DROP TABLE IF EXISTS carbon2")
   }
 }
 // scalastyle:on println

--- a/examples/src/main/scala/org/apache/carbondata/examples/GenerateDictionaryExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/GenerateDictionaryExample.scala
@@ -23,7 +23,7 @@ import org.apache.carbondata.core.cache.dictionary.DictionaryColumnUniqueIdentif
 import org.apache.carbondata.core.carbon.{CarbonTableIdentifier, ColumnIdentifier}
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension
 import org.apache.carbondata.core.carbon.path.CarbonStorePath
-import org.apache.carbondata.examples.util.InitForExamples
+import org.apache.carbondata.examples.util.ExampleUitls
 import org.apache.carbondata.spark.load.CarbonLoaderUtil
 
 /**
@@ -34,9 +34,9 @@ import org.apache.carbondata.spark.load.CarbonLoaderUtil
 object GenerateDictionaryExample {
 
   def main(args: Array[String]) {
-    val cc = InitForExamples.createCarbonContext("GenerateDictionaryExample")
-    val factFilePath = InitForExamples.currentPath + "/src/main/resources/factSample.csv"
-    val carbonTablePath = CarbonStorePath.getCarbonTablePath(InitForExamples.storeLocation,
+    val cc = ExampleUitls.createCarbonContext("GenerateDictionaryExample")
+    val factFilePath = ExampleUitls.currentPath + "/src/main/resources/factSample.csv"
+    val carbonTablePath = CarbonStorePath.getCarbonTablePath(ExampleUitls.storeLocation,
       new CarbonTableIdentifier("default", "dictSample", "1"))
     val dictFolderPath = carbonTablePath.getMetadataDirectoryPath
 

--- a/examples/src/main/scala/org/apache/carbondata/examples/HadoopFileExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/HadoopFileExample.scala
@@ -17,25 +17,24 @@
 
 package org.apache.carbondata.examples
 
-import org.apache.spark.sql.{SaveMode, SQLContext}
-
 import org.apache.carbondata.examples.util.ExampleUitls
+import org.apache.carbondata.hadoop.CarbonInputFormat
 
-object DatasourceExample {
+// scalastyle:off println
+object HadoopFileExample {
 
-  def main(args: Array[String]) {
-    // use CarbonContext to write CarbonData files
-    val cc = ExampleUitls.createCarbonContext("DatasourceExample")
-    ExampleUitls.writeSampleCarbonFile(cc, "table1")
+  def main(args: Array[String]): Unit = {
+    val cc = ExampleUitls.createCarbonContext("DataFrameAPIExample")
+    ExampleUitls.writeSampleCarbonFile(cc, "carbon1")
 
-    // Use SQLContext to read CarbonData files
-    val sqlContext = new SQLContext(cc.sparkContext)
-    sqlContext.sql(
-      s"""
-        | CREATE TEMPORARY TABLE source
-        | USING org.apache.spark.sql.CarbonSource
-        | OPTIONS (path '${cc.storePath}/default/table1')
-      """.stripMargin)
-    sqlContext.sql("SELECT c1, c2, count(*) FROM source WHERE c3 > 100 GROUP BY c1, c2").show
+    val sc = cc.sparkContext
+    val input = sc.newAPIHadoopFile(s"${cc.storePath}/default/carbon1",
+      classOf[CarbonInputFormat[Array[Object]]],
+      classOf[Void],
+      classOf[Array[Object]])
+    val result = input.map(x => x._2.toList).collect
+    result.foreach(x => println(x.mkString(", ")))
   }
 }
+// scalastyle:on println
+

--- a/examples/src/main/scala/org/apache/carbondata/examples/PerfTest.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/PerfTest.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.{CarbonContext, DataFrame, Row, SaveMode, SQLContext
 import org.apache.spark.sql.types.{DataTypes, StructType}
 
 import org.apache.carbondata.examples.PerfTest._
-import org.apache.carbondata.examples.util.InitForExamples
+import org.apache.carbondata.examples.util.ExampleUitls
 
 // scalastyle:off println
 
@@ -268,7 +268,7 @@ object PerfTest {
   )
 
   def main(args: Array[String]) {
-    val cc = InitForExamples.createCarbonContext("PerfTest")
+    val cc = ExampleUitls.createCarbonContext("PerfTest")
 
     // prepare performance queries
     var workload = Seq[Query]()
@@ -318,7 +318,7 @@ object PerfTest {
   }
 
   def savePath(datasource: String): String =
-      s"${InitForExamples.currentPath}/target/perftest/${datasource}"
+      s"${ExampleUitls.currentPath}/target/perftest/${datasource}"
 
   def withTime(body: => Unit): Long = {
     val start = System.nanoTime()

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/DictionaryDecodedReadSupportImpl.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/DictionaryDecodedReadSupportImpl.java
@@ -25,6 +25,7 @@ public class DictionaryDecodedReadSupportImpl
     extends AbstractDictionaryDecodedReadSupport<Object[]> {
 
   @Override public Object[] readRow(Object[] data) {
+    assert(data.length == dictionaries.length);
     for (int i = 0; i < dictionaries.length; i++) {
       if (dictionaries[i] != null) {
         data[i] = dictionaries[i].getDictionaryValueForKey((int) data[i]);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/SchemaReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/SchemaReader.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.core.carbon.metadata.converter.SchemaConverter;
 import org.apache.carbondata.core.carbon.metadata.converter.ThriftWrapperSchemaConverterImpl;
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.carbon.metadata.schema.table.TableInfo;
+import org.apache.carbondata.core.carbon.path.CarbonStorePath;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
 import org.apache.carbondata.core.reader.ThriftReader;
@@ -37,8 +38,9 @@ import org.apache.thrift.TBase;
  */
 public class SchemaReader {
 
-  public static CarbonTable readCarbonTableFromStore(CarbonTablePath carbonTablePath,
-      AbsoluteTableIdentifier identifier) throws IOException {
+  public static CarbonTable readCarbonTableFromStore(AbsoluteTableIdentifier identifier)
+      throws IOException {
+    CarbonTablePath carbonTablePath = CarbonStorePath.getCarbonTablePath(identifier);
     String schemaFilePath = carbonTablePath.getSchemaFilePath();
     if (FileFactory.isFileExist(schemaFilePath, FileFactory.FileType.LOCAL) ||
         FileFactory.isFileExist(schemaFilePath, FileFactory.FileType.HDFS) ||

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputFormat_FT.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputFormat_FT.java
@@ -52,9 +52,7 @@ public class CarbonInputFormat_FT extends TestCase {
     CarbonInputFormat carbonInputFormat = new CarbonInputFormat();
     JobConf jobConf = new JobConf(new Configuration());
     Job job = new Job(jobConf);
-    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("db", "table1", UUID.randomUUID().toString());
-    FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/"));
-    carbonInputFormat.setTableToAccess(job.getConfiguration(), tableIdentifier);
+    FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/db/table1"));
     job.getConfiguration().set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, "1,2");
     List splits = carbonInputFormat.getSplits(job);
 
@@ -66,9 +64,7 @@ public class CarbonInputFormat_FT extends TestCase {
     CarbonInputFormat carbonInputFormat = new CarbonInputFormat();
     JobConf jobConf = new JobConf(new Configuration());
     Job job = new Job(jobConf);
-    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("db", "table1", UUID.randomUUID().toString());
-    FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/"));
-    carbonInputFormat.setTableToAccess(job.getConfiguration(), tableIdentifier);
+    FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/db/table1"));
     job.getConfiguration().set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, "1,2");
     Expression expression = new EqualToExpression(new ColumnExpression("c1", DataType.STRING),
         new LiteralExpression("a", DataType.STRING));

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputMapperTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputMapperTest.java
@@ -170,14 +170,13 @@ public class CarbonInputMapperTest extends TestCase {
     job.setInputFormatClass(CarbonInputFormat.class);
     job.setOutputFormatClass(TextOutputFormat.class);
     AbsoluteTableIdentifier abs = StoreCreator.getAbsoluteTableIdentifier();
-    CarbonInputFormat.setTableToAccess(job.getConfiguration(), abs.getCarbonTableIdentifier());
     if (projection != null) {
       CarbonInputFormat.setColumnProjection(projection, job.getConfiguration());
     }
     if (filter != null) {
       CarbonInputFormat.setFilterPredicates(job.getConfiguration(), filter);
     }
-    FileInputFormat.addInputPath(job, new Path(abs.getStorePath()));
+    FileInputFormat.addInputPath(job, new Path(abs.getTablePath()));
     CarbonUtil.deleteFoldersAndFiles(new File(outPath + "1"));
     FileOutputFormat.setOutputPath(job, new Path(outPath + "1"));
     job.getConfiguration().set("outpath", outPath);

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/QueryPlanUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/QueryPlanUtil.scala
@@ -42,9 +42,7 @@ object QueryPlanUtil {
     val carbonInputFormat = new CarbonInputFormat[Array[Object]]()
     val jobConf: JobConf = new JobConf(new Configuration)
     val job: Job = new Job(jobConf)
-    FileInputFormat.addInputPath(job, new Path(absoluteTableIdentifier.getStorePath))
-    CarbonInputFormat.setTableToAccess(job.getConfiguration,
-      absoluteTableIdentifier.getCarbonTableIdentifier)
+    FileInputFormat.addInputPath(job, new Path(absoluteTableIdentifier.getTablePath))
     (carbonInputFormat, job)
   }
 
@@ -52,8 +50,7 @@ object QueryPlanUtil {
       conf: Configuration) : CarbonInputFormat[V] = {
     val carbonInputFormat = new CarbonInputFormat[V]()
     val job: Job = new Job(conf)
-    FileInputFormat.addInputPath(job, new Path(absoluteTableIdentifier.getStorePath))
-    CarbonInputFormat.setTableToAccess(conf, absoluteTableIdentifier.getCarbonTableIdentifier)
+    FileInputFormat.addInputPath(job, new Path(absoluteTableIdentifier.getTablePath))
     carbonInputFormat
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1212,8 +1212,7 @@ private[sql] case class DropTableCommand(ifExistsSet: Boolean, databaseNameOp: O
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
     val dbName = getDB.getDatabaseName(databaseNameOp, sqlContext)
     val identifier = TableIdentifier(tableName, Option(dbName))
-    val tmpTable = org.apache.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
-      .getCarbonTable(dbName + "_" + tableName)
+    val tmpTable = CarbonMetadata.getInstance.getCarbonTable(dbName + "_" + tableName)
     if (null == tmpTable) {
       if (!ifExistsSet) {
         LOGGER


### PR DESCRIPTION
User should be able to use SparkContext.newAPIHadoopFile to read CarbonData files
For example:
```
    val input = sc.newAPIHadoopFile(s"${cc.storePath}/default/carbon1",
      classOf[CarbonInputFormat[Array[Object]]],
      classOf[Void],
      classOf[Array[Object]])
    val result = input.map(x => x._2.toList).collect
    result.foreach(x => println(x.mkString(", ")))
```

In this PR, the INPUT_DIR in CarbonInputFormat job configuration is changed to table path instead of store path, since sc.newAPIHadoopFile will set it to the first input parameter (`path` indicating the table path)