### PR TITLE
[CARBONDATA-208] Add configuration enbale query statistics on-off

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderDummy.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderDummy.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.core.carbon.querystatistics;
+
+/**
+ * Class will be used to record and log the query statistics
+ */
+public class DriverQueryStatisticsRecorderDummy implements QueryStatisticsRecorder{
+
+  private DriverQueryStatisticsRecorderDummy() {
+
+  }
+
+  private static DriverQueryStatisticsRecorderDummy carbonLoadStatisticsImplInstance =
+      new DriverQueryStatisticsRecorderDummy();
+
+  public static DriverQueryStatisticsRecorderDummy getInstance() {
+    return carbonLoadStatisticsImplInstance;
+  }
+
+  public void recordStatistics(QueryStatistic statistic) {
+
+  }
+
+  public void logStatistics() {
+
+  }
+
+  public void logStatisticsAsTableExecutor() {
+
+  }
+
+  /**
+   * Below method will be used to add the statistics
+   *
+   * @param statistic
+   */
+  public synchronized void recordStatisticsForDriver(QueryStatistic statistic, String queryId) {
+
+  }
+
+  /**
+   * Below method will be used to show statistic log as table
+   */
+  public void logStatisticsAsTableDriver() {
+
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
@@ -135,6 +135,7 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
     String block_identification_time = "";
     long driver_part_time_tmp = 0L;
     long driver_part_time_tmp2 = 0L;
+    long load_blocks_time_tmp = 0L;
     String splitChar = " ";
     try {
       // get statistic time from the QueryStatistic
@@ -149,7 +150,8 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
             driver_part_time_tmp += statistic.getTimeTaken();
             break;
           case QueryStatisticsConstants.LOAD_BLOCKS_DRIVER:
-            load_blocks_time += statistic.getTimeTaken() + splitChar;
+            // multi segments will generate multi load_blocks_time
+            load_blocks_time_tmp += statistic.getTimeTaken();
             driver_part_time_tmp += statistic.getTimeTaken();
             driver_part_time_tmp2 += statistic.getTimeTaken();
             break;
@@ -167,6 +169,7 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
             break;
         }
       }
+      load_blocks_time = load_blocks_time_tmp + splitChar;
       String driver_part_time = driver_part_time_tmp + splitChar;
       // structure the query statistics info table
       StringBuilder tableInfo = new StringBuilder();

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
@@ -130,6 +130,7 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
   public String collectDriverStatistics(List<QueryStatistic> statisticsList, String queryId) {
     String sql_parse_time = "";
     String load_meta_time = "";
+    String load_blocks_time = "";
     String block_allocation_time = "";
     String block_identification_time = "";
     long driver_part_time_tmp = 0L;
@@ -146,6 +147,11 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
           case QueryStatisticsConstants.LOAD_META:
             load_meta_time += statistic.getTimeTaken() + splitChar;
             driver_part_time_tmp += statistic.getTimeTaken();
+            break;
+          case QueryStatisticsConstants.LOAD_BLOCKS_DRIVER:
+            load_blocks_time += statistic.getTimeTaken() + splitChar;
+            driver_part_time_tmp += statistic.getTimeTaken();
+            driver_part_time_tmp2 += statistic.getTimeTaken();
             break;
           case QueryStatisticsConstants.BLOCK_ALLOCATION:
             block_allocation_time += statistic.getTimeTaken() + splitChar;
@@ -196,6 +202,12 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
             load_meta_time + "|" + "\n");
         tableInfo.append(line2).append("\n");
         tableInfo.append("|" + printLine(" ", (len1 - "Part".length())) + "Part" + "|" +
+                printLine(" ", (len2 - "Load blocks driver".length())) + "Load blocks driver" + "|" +
+                printLine(" ", len3) + "|" +
+                printLine(" ", (len4 - load_blocks_time.length())) +
+                load_blocks_time + "|" + "\n");
+        tableInfo.append(line2).append("\n");
+        tableInfo.append("|" + printLine(" ", len1 ) + "|" +
             printLine(" ", (len2 - "Block allocation".length())) + "Block allocation" + "|" +
             printLine(" ", len3) + "|" +
             printLine(" ", (len4 - block_allocation_time.length())) +
@@ -217,13 +229,19 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
         // when we can't get sql parse time, we only print the last two
         driver_part_time = driver_part_time_tmp2 + splitChar;
         tableInfo.append("|" + printLine(" ", (len1 - "Driver".length())) + "Driver" + "|" +
+                printLine(" ", (len2 - "Load blocks driver".length())) + "Load blocks driver" + "|" +
+                printLine(" ", len3) + "|" +
+                printLine(" ", (len4 - load_blocks_time.length())) +
+                load_blocks_time + "|" + "\n");
+        tableInfo.append(line2).append("\n");
+        tableInfo.append("|" + printLine(" ", (len1 - "Part".length())) + "Part" + "|" +
             printLine(" ", (len2 - "Block allocation".length())) + "Block allocation" + "|" +
             printLine(" ", (len3 - driver_part_time.length())) + driver_part_time + "|" +
             printLine(" ", (len4 - block_allocation_time.length())) +
             block_allocation_time + "|" + "\n");
         tableInfo.append(line2).append("\n");
         tableInfo.append("|" +
-            printLine(" ", (len1 - "Part".length())) + "Part" + "|" +
+            printLine(" ", len1) + "|" +
             printLine(" ", (len2 - "Block identification".length())) +
             "Block identification" + "|" +
             printLine(" ", len3) + "|" +

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
@@ -202,7 +202,8 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
             load_meta_time + "|" + "\n");
         tableInfo.append(line2).append("\n");
         tableInfo.append("|" + printLine(" ", (len1 - "Part".length())) + "Part" + "|" +
-                printLine(" ", (len2 - "Load blocks driver".length())) + "Load blocks driver" + "|" +
+                printLine(" ", (len2 - "Load blocks driver".length())) +
+                "Load blocks driver" + "|" +
                 printLine(" ", len3) + "|" +
                 printLine(" ", (len4 - load_blocks_time.length())) +
                 load_blocks_time + "|" + "\n");
@@ -229,7 +230,8 @@ public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorde
         // when we can't get sql parse time, we only print the last two
         driver_part_time = driver_part_time_tmp2 + splitChar;
         tableInfo.append("|" + printLine(" ", (len1 - "Driver".length())) + "Driver" + "|" +
-                printLine(" ", (len2 - "Load blocks driver".length())) + "Load blocks driver" + "|" +
+                printLine(" ", (len2 - "Load blocks driver".length())) +
+                "Load blocks driver" + "|" +
                 printLine(" ", len3) + "|" +
                 printLine(" ", (len4 - load_blocks_time.length())) +
                 load_blocks_time + "|" + "\n");

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/DriverQueryStatisticsRecorderImpl.java
@@ -34,10 +34,10 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Class will be used to record and log the query statistics
  */
-public class DriverQueryStatisticsRecorder {
+public class DriverQueryStatisticsRecorderImpl implements QueryStatisticsRecorder{
 
   private static final LogService LOGGER =
-      LogServiceFactory.getLogService(DriverQueryStatisticsRecorder.class.getName());
+      LogServiceFactory.getLogService(DriverQueryStatisticsRecorderImpl.class.getName());
 
   /**
    * singleton QueryStatisticsRecorder for driver
@@ -49,16 +49,28 @@ public class DriverQueryStatisticsRecorder {
    */
   private static final Object lock = new Object();
 
-  private DriverQueryStatisticsRecorder() {
+  private DriverQueryStatisticsRecorderImpl() {
     // use ConcurrentHashMap, it is thread-safe
     queryStatisticsMap = new ConcurrentHashMap<String, List<QueryStatistic>>();
   }
 
-  private static DriverQueryStatisticsRecorder carbonLoadStatisticsImplInstance =
-      new DriverQueryStatisticsRecorder();
+  private static DriverQueryStatisticsRecorderImpl carbonLoadStatisticsImplInstance =
+      new DriverQueryStatisticsRecorderImpl();
 
-  public static DriverQueryStatisticsRecorder getInstance() {
+  public static DriverQueryStatisticsRecorderImpl getInstance() {
     return carbonLoadStatisticsImplInstance;
+  }
+
+  public void recordStatistics(QueryStatistic statistic) {
+
+  }
+
+  public void logStatistics() {
+
+  }
+
+  public void logStatisticsAsTableExecutor() {
+
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorder.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorder.java
@@ -18,147 +18,19 @@
  */
 package org.apache.carbondata.core.carbon.querystatistics;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.carbondata.common.logging.LogService;
-import org.apache.carbondata.common.logging.LogServiceFactory;
-
-import static org.apache.carbondata.core.util.CarbonUtil.printLine;
-
 /**
- * Class will be used to record and log the query statistics
+ * interface will be used to record and log the query statistics
  */
-public class QueryStatisticsRecorder implements Serializable {
+public interface QueryStatisticsRecorder {
 
-  private static final LogService LOGGER =
-      LogServiceFactory.getLogService(QueryStatisticsRecorder.class.getName());
+  void recordStatistics(QueryStatistic statistic);
 
-  /**
-   * serialization version
-   */
-  private static final long serialVersionUID = -5719752001674467864L;
+  void logStatistics();
 
-  /**
-   * list for statistics to record time taken
-   * by each phase of the query for example aggregation
-   * scanning,block loading time etc.
-   */
-  private List<QueryStatistic> queryStatistics;
+  void logStatisticsAsTableExecutor();
 
-  /**
-   * query with taskd
-   */
-  private String queryIWthTask;
+  void recordStatisticsForDriver(QueryStatistic statistic, String queryId);
 
-  /**
-   * lock for log statistics table
-   */
-  private static final Object lock = new Object();
-
-  public QueryStatisticsRecorder(String queryId) {
-    queryStatistics = new ArrayList<QueryStatistic>();
-    this.queryIWthTask = queryId;
-  }
-
-  /**
-   * Below method will be used to add the statistics
-   *
-   * @param statistic
-   */
-  public synchronized void recordStatistics(QueryStatistic statistic) {
-    queryStatistics.add(statistic);
-  }
-
-  /**
-   * Below method will be used to log the statistic
-   */
-  public void logStatistics() {
-    for (QueryStatistic statistic : queryStatistics) {
-      LOGGER.statistic(statistic.getStatistics(queryIWthTask));
-    }
-  }
-
-  /**
-   * Below method will be used to show statistic log as table
-   */
-  public void logStatisticsAsTableExecutor() {
-    synchronized (lock) {
-      String tableInfo = collectExecutorStatistics();
-      if (null != tableInfo) {
-        LOGGER.statistic(tableInfo);
-      }
-    }
-  }
-
-  /**
-   * Below method will parse queryStatisticsMap and put time into table
-   */
-  public String collectExecutorStatistics() {
-    String load_blocks_time = "";
-    String scan_blocks_time = "";
-    String scan_blocks_num = "";
-    String load_dictionary_time = "";
-    String result_size = "";
-    String total_executor_time = "";
-    String splitChar = " ";
-    try {
-      for (QueryStatistic statistic : queryStatistics) {
-        switch (statistic.getMessage()) {
-          case QueryStatisticsConstants.LOAD_BLOCKS_EXECUTOR:
-            load_blocks_time += statistic.getTimeTaken() + splitChar;
-            break;
-          case QueryStatisticsConstants.SCAN_BLOCKS_TIME:
-            scan_blocks_time += statistic.getTimeTaken() + splitChar;
-            break;
-          case QueryStatisticsConstants.SCAN_BLOCKS_NUM:
-            scan_blocks_num += statistic.getCount() + splitChar;
-            break;
-          case QueryStatisticsConstants.LOAD_DICTIONARY:
-            load_dictionary_time += statistic.getTimeTaken() + splitChar;
-            break;
-          case QueryStatisticsConstants.RESULT_SIZE:
-            result_size += statistic.getCount() + " ";
-            break;
-          case QueryStatisticsConstants.EXECUTOR_PART:
-            total_executor_time += statistic.getTimeTaken() + splitChar;
-            break;
-          default:
-            break;
-        }
-      }
-      String headers = "task_id,load_blocks_time,load_dictionary_time,scan_blocks_time," +
-          "scan_blocks_num,result_size,total_executor_time";
-      List<String> values = new ArrayList<String>();
-      values.add(queryIWthTask);
-      values.add(load_blocks_time);
-      values.add(load_dictionary_time);
-      values.add(scan_blocks_time);
-      values.add(scan_blocks_num);
-      values.add(result_size);
-      values.add(total_executor_time);
-      StringBuilder tableInfo = new StringBuilder();
-      String[] columns = headers.split(",");
-      String line = "";
-      String hearLine = "";
-      String valueLine = "";
-      for (int i = 0; i < columns.length; i++) {
-        int len = Math.max(columns[i].length(), values.get(i).length());
-        line += "+" + printLine("-", len);
-        hearLine += "|" + printLine(" ", len - columns[i].length()) + columns[i];
-        valueLine += "|" + printLine(" ", len - values.get(i).length()) + values.get(i);
-      }
-      // struct table info
-      tableInfo.append(line + "+").append("\n");
-      tableInfo.append(hearLine + "|").append("\n");
-      tableInfo.append(line + "+").append("\n");
-      tableInfo.append(valueLine + "|").append("\n");
-      tableInfo.append(line + "+").append("\n");
-      return "Print query statistic for each task id:" + "\n" + tableInfo.toString();
-    } catch (Exception ex) {
-      return "Put statistics into table failed, catch exception: " + ex.getMessage();
-    }
-  }
+  void logStatisticsAsTableDriver();
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorderDummy.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorderDummy.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.core.carbon.querystatistics;
+
+import java.io.Serializable;
+
+/**
+ * Class will be used to record and log the query statistics
+ */
+public class QueryStatisticsRecorderDummy implements QueryStatisticsRecorder,Serializable {
+
+  /**
+   * serialization version
+   */
+  private static final long serialVersionUID = -5719752001674467864L;
+
+  public QueryStatisticsRecorderDummy(String queryId) {
+
+  }
+
+  /**
+   * Below method will be used to add the statistics
+   *
+   * @param statistic
+   */
+  public synchronized void recordStatistics(QueryStatistic statistic) {
+
+  }
+
+  /**
+   * Below method will be used to log the statistic
+   */
+  public void logStatistics() {
+
+  }
+
+  /**
+   * Below method will be used to show statistic log as table
+   */
+  public void logStatisticsAsTableExecutor() {
+
+  }
+
+  public void recordStatisticsForDriver(QueryStatistic statistic, String queryId) {
+
+  }
+
+  public void logStatisticsAsTableDriver() {
+
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorderImpl.java
@@ -52,11 +52,6 @@ public class QueryStatisticsRecorderImpl implements QueryStatisticsRecorder,Seri
    */
   private String queryIWthTask;
 
-  /**
-   * lock for log statistics table
-   */
-  private static final Object lock = new Object();
-
   public QueryStatisticsRecorderImpl(String queryId) {
     queryStatistics = new ArrayList<QueryStatistic>();
     this.queryIWthTask = queryId;
@@ -84,11 +79,9 @@ public class QueryStatisticsRecorderImpl implements QueryStatisticsRecorder,Seri
    * Below method will be used to show statistic log as table
    */
   public void logStatisticsAsTableExecutor() {
-    synchronized (lock) {
-      String tableInfo = collectExecutorStatistics();
-      if (null != tableInfo) {
-        LOGGER.statistic(tableInfo);
-      }
+    String tableInfo = collectExecutorStatistics();
+    if (null != tableInfo) {
+      LOGGER.statistic(tableInfo);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatisticsRecorderImpl.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.core.carbon.querystatistics;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+
+import static org.apache.carbondata.core.util.CarbonUtil.printLine;
+
+/**
+ * Class will be used to record and log the query statistics
+ */
+public class QueryStatisticsRecorderImpl implements QueryStatisticsRecorder,Serializable {
+
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(QueryStatisticsRecorderImpl.class.getName());
+
+  /**
+   * serialization version
+   */
+  private static final long serialVersionUID = -5719752001674467864L;
+
+  /**
+   * list for statistics to record time taken
+   * by each phase of the query for example aggregation
+   * scanning,block loading time etc.
+   */
+  private List<QueryStatistic> queryStatistics;
+
+  /**
+   * query with taskd
+   */
+  private String queryIWthTask;
+
+  /**
+   * lock for log statistics table
+   */
+  private static final Object lock = new Object();
+
+  public QueryStatisticsRecorderImpl(String queryId) {
+    queryStatistics = new ArrayList<QueryStatistic>();
+    this.queryIWthTask = queryId;
+  }
+
+  /**
+   * Below method will be used to add the statistics
+   *
+   * @param statistic
+   */
+  public synchronized void recordStatistics(QueryStatistic statistic) {
+    queryStatistics.add(statistic);
+  }
+
+  /**
+   * Below method will be used to log the statistic
+   */
+  public void logStatistics() {
+    for (QueryStatistic statistic : queryStatistics) {
+      LOGGER.statistic(statistic.getStatistics(queryIWthTask));
+    }
+  }
+
+  /**
+   * Below method will be used to show statistic log as table
+   */
+  public void logStatisticsAsTableExecutor() {
+    synchronized (lock) {
+      String tableInfo = collectExecutorStatistics();
+      if (null != tableInfo) {
+        LOGGER.statistic(tableInfo);
+      }
+    }
+  }
+
+  /**
+   * Below method will parse queryStatisticsMap and put time into table
+   */
+  public String collectExecutorStatistics() {
+    String load_blocks_time = "";
+    String scan_blocks_time = "";
+    String scan_blocks_num = "";
+    String load_dictionary_time = "";
+    String result_size = "";
+    String total_executor_time = "";
+    String splitChar = " ";
+    try {
+      for (QueryStatistic statistic : queryStatistics) {
+        switch (statistic.getMessage()) {
+          case QueryStatisticsConstants.LOAD_BLOCKS_EXECUTOR:
+            load_blocks_time += statistic.getTimeTaken() + splitChar;
+            break;
+          case QueryStatisticsConstants.SCAN_BLOCKS_TIME:
+            scan_blocks_time += statistic.getTimeTaken() + splitChar;
+            break;
+          case QueryStatisticsConstants.SCAN_BLOCKS_NUM:
+            scan_blocks_num += statistic.getCount() + splitChar;
+            break;
+          case QueryStatisticsConstants.LOAD_DICTIONARY:
+            load_dictionary_time += statistic.getTimeTaken() + splitChar;
+            break;
+          case QueryStatisticsConstants.RESULT_SIZE:
+            result_size += statistic.getCount() + " ";
+            break;
+          case QueryStatisticsConstants.EXECUTOR_PART:
+            total_executor_time += statistic.getTimeTaken() + splitChar;
+            break;
+          default:
+            break;
+        }
+      }
+      String headers = "task_id,load_blocks_time,load_dictionary_time,scan_blocks_time," +
+          "scan_blocks_num,result_size,total_executor_time";
+      List<String> values = new ArrayList<String>();
+      values.add(queryIWthTask);
+      values.add(load_blocks_time);
+      values.add(load_dictionary_time);
+      values.add(scan_blocks_time);
+      values.add(scan_blocks_num);
+      values.add(result_size);
+      values.add(total_executor_time);
+      StringBuilder tableInfo = new StringBuilder();
+      String[] columns = headers.split(",");
+      String line = "";
+      String hearLine = "";
+      String valueLine = "";
+      for (int i = 0; i < columns.length; i++) {
+        int len = Math.max(columns[i].length(), values.get(i).length());
+        line += "+" + printLine("-", len);
+        hearLine += "|" + printLine(" ", len - columns[i].length()) + columns[i];
+        valueLine += "|" + printLine(" ", len - values.get(i).length()) + values.get(i);
+      }
+      // struct table info
+      tableInfo.append(line + "+").append("\n");
+      tableInfo.append(hearLine + "|").append("\n");
+      tableInfo.append(line + "+").append("\n");
+      tableInfo.append(valueLine + "|").append("\n");
+      tableInfo.append(line + "+").append("\n");
+      return "Print query statistic for each task id:" + "\n" + tableInfo.toString();
+    } catch (Exception ex) {
+      return "Put statistics into table failed, catch exception: " + ex.getMessage();
+    }
+  }
+
+  public void recordStatisticsForDriver(QueryStatistic statistic, String queryId) {
+
+  }
+
+  public void logStatisticsAsTableDriver() {
+
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -395,6 +395,14 @@ public final class CarbonCommonConstants {
    */
   public static final String AGGREAGATE_COLUMNAR_KEY_BLOCK_DEFAULTVALUE = "true";
   /**
+   * ENABLE_QUERY_STATISTICS
+   */
+  public static final String ENABLE_QUERY_STATISTICS = "enable.query.statistics";
+  /**
+   * ENABLE_QUERY_STATISTICS_DEFAULT
+   */
+  public static final String ENABLE_QUERY_STATISTICS_DEFAULT = "false";
+  /**
    * TIME_STAT_UTIL_TYPE
    */
   public static final String ENABLE_DATA_LOADING_STATISTICS = "enable.data.loading.statistics";

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
@@ -21,28 +21,28 @@ import org.apache.carbondata.core.carbon.querystatistics.*;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
 public class CarbonTimeStatisticsFactory {
-  private static String LoadStatisticsInstanceType;
-  private static LoadStatistics LoadStatisticsInstance;
-  private static String queryStatisticsRecorderInstanceType;
-  private static QueryStatisticsRecorder QueryStatisticsRecorderInstance;
+  private static String loadStatisticsInstanceType;
+  private static LoadStatistics loadStatisticsInstance;
+  private static String driverRecorderType;
+  private static QueryStatisticsRecorder driverRecorder;
 
   static {
     CarbonTimeStatisticsFactory.updateTimeStatisticsUtilStatus();
-    LoadStatisticsInstance = genLoadStatisticsInstance();
-    QueryStatisticsRecorderInstance = genQueryStatisticsRecorderInstance();
+    loadStatisticsInstance = genLoadStatisticsInstance();
+    driverRecorder = genDriverRecorder();
   }
 
   private static void updateTimeStatisticsUtilStatus() {
-    LoadStatisticsInstanceType = CarbonProperties.getInstance()
+    loadStatisticsInstanceType = CarbonProperties.getInstance()
         .getProperty(CarbonCommonConstants.ENABLE_DATA_LOADING_STATISTICS,
             CarbonCommonConstants.ENABLE_DATA_LOADING_STATISTICS_DEFAULT);
-    queryStatisticsRecorderInstanceType = CarbonProperties.getInstance()
+    driverRecorderType = CarbonProperties.getInstance()
             .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
                     CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);
   }
 
   private static LoadStatistics genLoadStatisticsInstance() {
-    if (LoadStatisticsInstanceType.equalsIgnoreCase("true")) {
+    if (loadStatisticsInstanceType.equalsIgnoreCase("true")) {
       return CarbonLoadStatisticsImpl.getInstance();
     } else {
       return CarbonLoadStatisticsDummy.getInstance();
@@ -50,11 +50,11 @@ public class CarbonTimeStatisticsFactory {
   }
 
   public static LoadStatistics getLoadStatisticsInstance() {
-    return LoadStatisticsInstance;
+    return loadStatisticsInstance;
   }
 
-  private static QueryStatisticsRecorder genQueryStatisticsRecorderInstance() {
-    if (queryStatisticsRecorderInstanceType.equalsIgnoreCase("true")) {
+  private static QueryStatisticsRecorder genDriverRecorder() {
+    if (driverRecorderType.equalsIgnoreCase("true")) {
       return DriverQueryStatisticsRecorderImpl.getInstance();
     } else {
       return DriverQueryStatisticsRecorderDummy.getInstance();
@@ -62,10 +62,10 @@ public class CarbonTimeStatisticsFactory {
   }
 
   public static QueryStatisticsRecorder createDriverRecorder() {
-    return QueryStatisticsRecorderInstance;
+    return driverRecorder;
   }
 
-  public static QueryStatisticsRecorder createRecorder(String queryId) {
+  public static QueryStatisticsRecorder createExecutorRecorder(String queryId) {
     String queryStatisticsRecorderType = CarbonProperties.getInstance()
             .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
                     CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
@@ -17,13 +17,16 @@
 
 package org.apache.carbondata.core.util;
 
-import org.apache.carbondata.core.carbon.querystatistics.DriverQueryStatisticsRecorder;
+import org.apache.carbondata.core.carbon.querystatistics.DriverQueryStatisticsRecorderDummy;
+import org.apache.carbondata.core.carbon.querystatistics.DriverQueryStatisticsRecorderImpl;
+import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
 public class CarbonTimeStatisticsFactory {
   private static String LoadStatisticsInstanceType;
   private static LoadStatistics LoadStatisticsInstance;
-  private static DriverQueryStatisticsRecorder QueryStatisticsRecorderInstance;
+  private static String queryStatisticsRecorderInstanceType;
+  private static QueryStatisticsRecorder QueryStatisticsRecorderInstance;
 
   static {
     CarbonTimeStatisticsFactory.updateTimeStatisticsUtilStatus();
@@ -35,6 +38,9 @@ public class CarbonTimeStatisticsFactory {
     LoadStatisticsInstanceType = CarbonProperties.getInstance()
         .getProperty(CarbonCommonConstants.ENABLE_DATA_LOADING_STATISTICS,
             CarbonCommonConstants.ENABLE_DATA_LOADING_STATISTICS_DEFAULT);
+    queryStatisticsRecorderInstanceType = CarbonProperties.getInstance()
+            .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
+                    CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);
   }
 
   private static LoadStatistics genLoadStatisticsInstance() {
@@ -52,11 +58,18 @@ public class CarbonTimeStatisticsFactory {
     return LoadStatisticsInstance;
   }
 
-  private static DriverQueryStatisticsRecorder genQueryStatisticsRecorderInstance() {
-    return DriverQueryStatisticsRecorder.getInstance();
+  private static QueryStatisticsRecorder genQueryStatisticsRecorderInstance() {
+    switch (queryStatisticsRecorderInstanceType.toLowerCase()) {
+      case "false":
+        return DriverQueryStatisticsRecorderDummy.getInstance();
+      case "true":
+        return DriverQueryStatisticsRecorderImpl.getInstance();
+      default:
+        return DriverQueryStatisticsRecorderDummy.getInstance();
+    }
   }
 
-  public static DriverQueryStatisticsRecorder getQueryStatisticsRecorderInstance() {
+  public static QueryStatisticsRecorder getQueryStatisticsRecorderInstance() {
     return QueryStatisticsRecorderInstance;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
@@ -68,7 +68,7 @@ public class CarbonTimeStatisticsFactory {
     return QueryStatisticsRecorderInstance;
   }
 
-  public static QueryStatisticsRecorder getQueryStatisticsRecorder(String queryId) {
+  public static QueryStatisticsRecorder createRecorder(String queryId) {
     String queryStatisticsRecorderType = CarbonProperties.getInstance()
             .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
                     CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
@@ -42,13 +42,10 @@ public class CarbonTimeStatisticsFactory {
   }
 
   private static LoadStatistics genLoadStatisticsInstance() {
-    switch (LoadStatisticsInstanceType.toLowerCase()) {
-      case "false":
-        return CarbonLoadStatisticsDummy.getInstance();
-      case "true":
-        return CarbonLoadStatisticsImpl.getInstance();
-      default:
-        return CarbonLoadStatisticsDummy.getInstance();
+    if (LoadStatisticsInstanceType.equalsIgnoreCase("true")) {
+      return CarbonLoadStatisticsImpl.getInstance();
+    } else {
+      return CarbonLoadStatisticsDummy.getInstance();
     }
   }
 
@@ -64,7 +61,7 @@ public class CarbonTimeStatisticsFactory {
     }
   }
 
-  public static QueryStatisticsRecorder getQueryStatisticsRecorderInstance() {
+  public static QueryStatisticsRecorder createDriverRecorder() {
     return QueryStatisticsRecorderInstance;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonTimeStatisticsFactory.java
@@ -17,9 +17,7 @@
 
 package org.apache.carbondata.core.util;
 
-import org.apache.carbondata.core.carbon.querystatistics.DriverQueryStatisticsRecorderDummy;
-import org.apache.carbondata.core.carbon.querystatistics.DriverQueryStatisticsRecorderImpl;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
+import org.apache.carbondata.core.carbon.querystatistics.*;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
 public class CarbonTimeStatisticsFactory {
@@ -59,18 +57,26 @@ public class CarbonTimeStatisticsFactory {
   }
 
   private static QueryStatisticsRecorder genQueryStatisticsRecorderInstance() {
-    switch (queryStatisticsRecorderInstanceType.toLowerCase()) {
-      case "false":
-        return DriverQueryStatisticsRecorderDummy.getInstance();
-      case "true":
-        return DriverQueryStatisticsRecorderImpl.getInstance();
-      default:
-        return DriverQueryStatisticsRecorderDummy.getInstance();
+    if (queryStatisticsRecorderInstanceType.equalsIgnoreCase("true")) {
+      return DriverQueryStatisticsRecorderImpl.getInstance();
+    } else {
+      return DriverQueryStatisticsRecorderDummy.getInstance();
     }
   }
 
   public static QueryStatisticsRecorder getQueryStatisticsRecorderInstance() {
     return QueryStatisticsRecorderInstance;
+  }
+
+  public static QueryStatisticsRecorder getQueryStatisticsRecorder(String queryId) {
+    String queryStatisticsRecorderType = CarbonProperties.getInstance()
+            .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
+                    CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);
+    if (queryStatisticsRecorderType.equalsIgnoreCase("true")) {
+      return new QueryStatisticsRecorderImpl(queryId);
+    } else {
+      return new QueryStatisticsRecorderDummy(queryId);
+    }
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -38,7 +38,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.keygenerator.KeyGenerator;
-import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.scan.executor.QueryExecutor;
 import org.apache.carbondata.scan.executor.exception.QueryExecutionException;
@@ -89,16 +89,8 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     queryProperties.executorService = Executors.newFixedThreadPool(1);
     // Initializing statistics list to record the query statistics
     // creating copy on write to handle concurrent scenario
-    String queryStatisticsRecorderInstanceType = CarbonProperties.getInstance()
-            .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
-                    CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);
-    if (queryStatisticsRecorderInstanceType.equalsIgnoreCase("true")) {
-      queryProperties.queryStatisticsRecorder =
-              new QueryStatisticsRecorderImpl(queryModel.getQueryId());
-    } else {
-      queryProperties.queryStatisticsRecorder =
-              new QueryStatisticsRecorderDummy(queryModel.getQueryId());
-    }
+    queryProperties.queryStatisticsRecorder =
+            CarbonTimeStatisticsFactory.getQueryStatisticsRecorder(queryModel.getQueryId());
     queryModel.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
     QueryUtil.resolveQueryModel(queryModel);
     QueryStatistic queryStatistic = new QueryStatistic();

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -90,7 +90,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     // Initializing statistics list to record the query statistics
     // creating copy on write to handle concurrent scenario
     queryProperties.queryStatisticsRecorder =
-            CarbonTimeStatisticsFactory.getQueryStatisticsRecorder(queryModel.getQueryId());
+            CarbonTimeStatisticsFactory.createRecorder(queryModel.getQueryId());
     queryModel.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
     QueryUtil.resolveQueryModel(queryModel);
     QueryStatistic queryStatistic = new QueryStatistic();

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -33,13 +33,12 @@ import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatistic;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsConstants;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
+import org.apache.carbondata.core.carbon.querystatistics.*;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.keygenerator.KeyGenerator;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.scan.executor.QueryExecutor;
 import org.apache.carbondata.scan.executor.exception.QueryExecutionException;
@@ -90,7 +89,16 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     queryProperties.executorService = Executors.newFixedThreadPool(1);
     // Initializing statistics list to record the query statistics
     // creating copy on write to handle concurrent scenario
-    queryProperties.queryStatisticsRecorder = new QueryStatisticsRecorder(queryModel.getQueryId());
+    String queryStatisticsRecorderInstanceType = CarbonProperties.getInstance()
+            .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
+                    CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);
+    if (queryStatisticsRecorderInstanceType.equalsIgnoreCase("true")) {
+      queryProperties.queryStatisticsRecorder =
+              new QueryStatisticsRecorderImpl(queryModel.getQueryId());
+    } else {
+      queryProperties.queryStatisticsRecorder =
+              new QueryStatisticsRecorderDummy(queryModel.getQueryId());
+    }
     queryModel.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
     QueryUtil.resolveQueryModel(queryModel);
     QueryStatistic queryStatistic = new QueryStatistic();

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -90,7 +90,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     // Initializing statistics list to record the query statistics
     // creating copy on write to handle concurrent scenario
     queryProperties.queryStatisticsRecorder =
-            CarbonTimeStatisticsFactory.createRecorder(queryModel.getQueryId());
+            CarbonTimeStatisticsFactory.createExecutorRecorder(queryModel.getQueryId());
     queryModel.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
     QueryUtil.resolveQueryModel(queryModel);
     QueryStatistic queryStatistic = new QueryStatistic();

--- a/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -30,9 +30,6 @@ object CarbonExample {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/mm/dd")
 
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS, "true")
-
     cc.sql("DROP TABLE IF EXISTS t3")
 
     cc.sql("""

--- a/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -30,6 +30,9 @@ object CarbonExample {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/mm/dd")
 
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS, "true")
+
     cc.sql("DROP TABLE IF EXISTS t3")
 
     cc.sql("""

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
@@ -52,6 +52,7 @@ import org.apache.carbondata.core.carbon.querystatistics.*;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.hadoop.readsupport.CarbonReadSupport;
 import org.apache.carbondata.hadoop.readsupport.impl.DictionaryDecodedReadSupportImpl;
@@ -459,15 +460,7 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       FilterExpressionProcessor filterExpressionProcessor,
       AbsoluteTableIdentifier absoluteTableIdentifier, FilterResolverIntf resolver,
       String segmentId) throws IndexBuilderException, IOException {
-    String queryStatisticsRecorderInstanceType = CarbonProperties.getInstance()
-            .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
-                    CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);
-    QueryStatisticsRecorder recorder = null;
-    if (queryStatisticsRecorderInstanceType.equalsIgnoreCase("true")) {
-      recorder = new QueryStatisticsRecorderImpl("");
-    } else {
-      recorder = new QueryStatisticsRecorderDummy("");
-    }
+    QueryStatisticsRecorder recorder = CarbonTimeStatisticsFactory.getQueryStatisticsRecorder("");
     QueryStatistic statistic = new QueryStatistic();
     Map<String, AbstractIndex> segmentIndexMap =
         getSegmentAbstractIndexs(job, absoluteTableIdentifier, segmentId);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
@@ -460,7 +460,8 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       FilterExpressionProcessor filterExpressionProcessor,
       AbsoluteTableIdentifier absoluteTableIdentifier, FilterResolverIntf resolver,
       String segmentId) throws IndexBuilderException, IOException {
-    QueryStatisticsRecorder recorder = CarbonTimeStatisticsFactory.getQueryStatisticsRecorder("");
+    QueryStatisticsRecorder recorder =
+            CarbonTimeStatisticsFactory.getQueryStatisticsRecorderInstance();
     QueryStatistic statistic = new QueryStatistic();
     Map<String, AbstractIndex> segmentIndexMap =
         getSegmentAbstractIndexs(job, absoluteTableIdentifier, segmentId);
@@ -488,8 +489,7 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     }
     statistic.addStatistics(QueryStatisticsConstants.LOAD_BLOCKS_DRIVER,
         System.currentTimeMillis());
-    recorder.recordStatistics(statistic);
-    recorder.logStatistics();
+    recorder.recordStatisticsForDriver(statistic, job.getConfiguration().get("query.id"));
     return resultFilterredBlocks;
   }
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
@@ -461,7 +461,7 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       AbsoluteTableIdentifier absoluteTableIdentifier, FilterResolverIntf resolver,
       String segmentId) throws IndexBuilderException, IOException {
     QueryStatisticsRecorder recorder =
-            CarbonTimeStatisticsFactory.getQueryStatisticsRecorderInstance();
+            CarbonTimeStatisticsFactory.createDriverRecorder();
     QueryStatistic statistic = new QueryStatistic();
     Map<String, AbstractIndex> segmentIndexMap =
         getSegmentAbstractIndexs(job, absoluteTableIdentifier, segmentId);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
@@ -48,9 +48,7 @@ import org.apache.carbondata.core.carbon.datastore.impl.btree.BlockBTreeLeafNode
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.carbon.path.CarbonStorePath;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatistic;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsConstants;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
+import org.apache.carbondata.core.carbon.querystatistics.*;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.util.CarbonProperties;
@@ -461,8 +459,15 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       FilterExpressionProcessor filterExpressionProcessor,
       AbsoluteTableIdentifier absoluteTableIdentifier, FilterResolverIntf resolver,
       String segmentId) throws IndexBuilderException, IOException {
-
-    QueryStatisticsRecorder recorder = new QueryStatisticsRecorder("");
+    String queryStatisticsRecorderInstanceType = CarbonProperties.getInstance()
+            .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
+                    CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT);
+    QueryStatisticsRecorder recorder = null;
+    if (queryStatisticsRecorderInstanceType.equalsIgnoreCase("true")) {
+      recorder = new QueryStatisticsRecorderImpl("");
+    } else {
+      recorder = new QueryStatisticsRecorderDummy("");
+    }
     QueryStatistic statistic = new QueryStatistic();
     Map<String, AbstractIndex> segmentIndexMap =
         getSegmentAbstractIndexs(job, absoluteTableIdentifier, segmentId);

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -86,6 +86,9 @@ class CarbonScanRDD[V: ClassTag](
     val (carbonInputFormat: CarbonInputFormat[Array[Object]], job: Job) =
       QueryPlanUtil.createCarbonInputFormat(queryModel.getAbsoluteTableIdentifier)
 
+    // initialise query_id for job
+    job.getConfiguration.set("query.id", queryModel.getQueryId)
+
     val result = new util.ArrayList[Partition](defaultParallelism)
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
     val validAndInvalidSegments = new SegmentStatusManager(queryModel.getAbsoluteTableIdentifier)

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -82,7 +82,7 @@ class CarbonScanRDD[V: ClassTag](
 
   override def getPartitions: Array[Partition] = {
     var defaultParallelism = sparkContext.defaultParallelism
-    val statisticRecorder = CarbonTimeStatisticsFactory.getQueryStatisticsRecorderInstance()
+    val statisticRecorder = CarbonTimeStatisticsFactory.createDriverRecorder()
     val (carbonInputFormat: CarbonInputFormat[Array[Object]], job: Job) =
       QueryPlanUtil.createCarbonInputFormat(queryModel.getAbsoluteTableIdentifier)
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -129,7 +129,7 @@ class CarbonContext(
     CarbonContext.updateCarbonPorpertiesPath(this)
     val sqlString = sql.toUpperCase
     LOGGER.info(s"Query [$sqlString]")
-    val recorder = CarbonTimeStatisticsFactory.getQueryStatisticsRecorderInstance()
+    val recorder = CarbonTimeStatisticsFactory.createDriverRecorder()
     val statistic = new QueryStatistic()
     val logicPlan: LogicalPlan = parseSql(sql)
     statistic.addStatistics(QueryStatisticsConstants.SQL_PARSE, System.currentTimeMillis())

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -33,8 +33,7 @@ import org.apache.carbondata.core.carbon.metadata.datatype.DataType
 import org.apache.carbondata.core.carbon.metadata.encoder.Encoding
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension
 import org.apache.carbondata.core.carbon.querystatistics._
-import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.{CarbonProperties, DataTypeUtil}
+import org.apache.carbondata.core.util.{CarbonTimeStatisticsFactory, DataTypeUtil}
 
 /**
  * It decodes the data.
@@ -159,16 +158,8 @@ case class CarbonDictionaryDecoder(
         val carbonTable = relation.carbonRelation.carbonRelation.metaData.carbonTable
         (carbonTable.getFactTableName, carbonTable.getAbsoluteTableIdentifier)
       }.toMap
-      val queryStatisticsRecorderInstanceType = CarbonProperties.getInstance()
-        .getProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS,
-          CarbonCommonConstants.ENABLE_QUERY_STATISTICS_DEFAULT)
-      var recorder: QueryStatisticsRecorder = null
-      if (queryStatisticsRecorderInstanceType.equalsIgnoreCase("true")) {
-        recorder = new QueryStatisticsRecorderImpl(queryId)
-      } else {
-        recorder = new QueryStatisticsRecorderDummy(queryId)
-      }
 
+      val recorder = CarbonTimeStatisticsFactory.getQueryStatisticsRecorder(queryId);
       if (isRequiredToDecode) {
         val dataTypes = child.output.map { attr => attr.dataType }
         child.execute().mapPartitions { iter =>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -159,7 +159,7 @@ case class CarbonDictionaryDecoder(
         (carbonTable.getFactTableName, carbonTable.getAbsoluteTableIdentifier)
       }.toMap
 
-      val recorder = CarbonTimeStatisticsFactory.createRecorder(queryId);
+      val recorder = CarbonTimeStatisticsFactory.createExecutorRecorder(queryId);
       if (isRequiredToDecode) {
         val dataTypes = child.output.map { attr => attr.dataType }
         child.execute().mapPartitions { iter =>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -159,7 +159,7 @@ case class CarbonDictionaryDecoder(
         (carbonTable.getFactTableName, carbonTable.getAbsoluteTableIdentifier)
       }.toMap
 
-      val recorder = CarbonTimeStatisticsFactory.getQueryStatisticsRecorder(queryId);
+      val recorder = CarbonTimeStatisticsFactory.createRecorder(queryId);
       if (isRequiredToDecode) {
         val dataTypes = child.output.map { attr => attr.dataType }
         child.execute().mapPartitions { iter =>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -40,7 +40,7 @@ import org.apache.carbondata.core.carbon.metadata.CarbonMetadata
 import org.apache.carbondata.core.carbon.metadata.converter.ThriftWrapperSchemaConverterImpl
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.carbon.path.{CarbonStorePath, CarbonTablePath}
-import org.apache.carbondata.core.carbon.querystatistics.{QueryStatistic, QueryStatisticsConstants, QueryStatisticsRecorder}
+import org.apache.carbondata.core.carbon.querystatistics.{QueryStatistic, QueryStatisticsConstants}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastorage.store.filesystem.CarbonFile
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -152,7 +152,7 @@ class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
   }
 
   def loadMetadata(metadataPath: String): MetaData = {
-    val recorder = CarbonTimeStatisticsFactory.getQueryStatisticsRecorderInstance()
+    val recorder = CarbonTimeStatisticsFactory.createDriverRecorder()
     val statistic = new QueryStatistic()
     // creating zookeeper instance once.
     // if zookeeper is configured as carbon lock type.


### PR DESCRIPTION
# Why raise this pr?
Currently there are many STATISTIC log for performance tuning purpose, but it should be configurable by the user.
# How to solve it?
Add configuration to carbon.properties, "enable.query.statistics" (default value is "false")
User can enable query statistics by setting it as true.

