### PR TITLE
[CARBONDATA-261] clean files is updating the stale segment status.

### DIFF
--- a/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
@@ -28,6 +28,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -993,4 +994,24 @@ public final class CarbonLoaderUtil {
     LOGGER.info("No.Of Blocks after Blocklet distribution: " + tableBlockInfos.size());
     return tableBlockInfos;
   }
+
+  /**
+   * This will update the old table status details before clean files to the latest table status.
+   * @param oldList
+   * @param newList
+   * @return
+   */
+  public static List<LoadMetadataDetails> updateLoadMetadataFromOldToNew(
+      LoadMetadataDetails[] oldList, LoadMetadataDetails[] newList) {
+
+    List<LoadMetadataDetails> newListMetadata =
+        new ArrayList<LoadMetadataDetails>(Arrays.asList(newList));
+    for (LoadMetadataDetails oldSegment : oldList) {
+      if (oldSegment.getVisibility().equalsIgnoreCase("false")) {
+        newListMetadata.get(newListMetadata.indexOf(oldSegment)).setVisibility("false");
+      }
+    }
+    return newListMetadata;
+  }
+
 }

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
@@ -1007,7 +1007,7 @@ public final class CarbonLoaderUtil {
     List<LoadMetadataDetails> newListMetadata =
         new ArrayList<LoadMetadataDetails>(Arrays.asList(newList));
     for (LoadMetadataDetails oldSegment : oldList) {
-      if (oldSegment.getVisibility().equalsIgnoreCase("false")) {
+      if ("false".equalsIgnoreCase(oldSegment.getVisibility())) {
         newListMetadata.get(newListMetadata.indexOf(oldSegment)).setVisibility("false");
       }
     }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -1122,10 +1122,20 @@ object CarbonDataRDDFactory extends Logging {
         // Update load metadate file after cleaning deleted nodes
         if (carbonTableStatusLock.lockWithRetries()) {
           logger.info("Table status lock has been successfully acquired.")
+
+          // read latest table status again.
+          val latestMetadata = segmentStatusManager
+            .readLoadMetadata(loadMetadataFilePath)
+
+          // update the metadata details from old to new status.
+
+          val latestStatus = CarbonLoaderUtil
+            .updateLoadMetadataFromOldToNew(details, latestMetadata)
+
           CarbonLoaderUtil.writeLoadMetadata(
             carbonLoadModel.getCarbonDataLoadSchema,
             carbonLoadModel.getDatabaseName,
-            carbonLoadModel.getTableName, details.toList.asJava
+            carbonLoadModel.getTableName, latestStatus
           )
         }
         else {


### PR DESCRIPTION
PROBLEM:
in clean files it will read the table status first and it will delete the physical locations and update the table metadata  and then take the lock for writing and after that it will write the old read list to the file.
but this is wrong as in the time between the read and write the table status would have been changed.
so before writing it should read the table status again and update the changes and then write.

SOLUTION:
before writing the status read the table status again and update the changes and then write.
