### PR TITLE
[CARBONDATA-262]Fixed limit query issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/executor/QueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/QueryExecutor.java
@@ -37,4 +37,11 @@ public interface QueryExecutor<E> {
    * @throws QueryExecutionException if any failure while executing the query
    */
   CarbonIterator<E> execute(QueryModel queryModel) throws QueryExecutionException;
+
+  /**
+   * Below method will be used for cleanup
+   *
+   * @throws QueryExecutionException
+   */
+  void finish() throws QueryExecutionException;
 }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/QueryExecutorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/QueryExecutorFactory.java
@@ -19,7 +19,6 @@
 package org.apache.carbondata.scan.executor;
 
 import org.apache.carbondata.scan.executor.impl.DetailQueryExecutor;
-import org.apache.carbondata.scan.model.QueryModel;
 
 /**
  * Factory class to get the query executor from RDD
@@ -27,7 +26,7 @@ import org.apache.carbondata.scan.model.QueryModel;
  */
 public class QueryExecutorFactory {
 
-  public static QueryExecutor getQueryExecutor(QueryModel queryModel) {
+  public static QueryExecutor getQueryExecutor() {
     return new DetailQueryExecutor();
   }
 }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.carbondata.scan.executor.impl;
 
 import java.util.*;
+import java.util.concurrent.Executors;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -85,6 +86,8 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         queryModel.getQueryId());
     LOGGER.info("Query will be executed on table: " + queryModel.getAbsoluteTableIdentifier()
         .getCarbonTableIdentifier().getTableName());
+    // add executor service for query execution
+    queryProperties.executorService = Executors.newFixedThreadPool(1);
     // Initializing statistics list to record the query statistics
     // creating copy on write to handle concurrent scenario
     queryProperties.queryStatisticsRecorder = new QueryStatisticsRecorder(queryModel.getQueryId());
@@ -424,6 +427,17 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     }
     return ArrayUtils
         .toPrimitive(parentBlockIndexList.toArray(new Integer[parentBlockIndexList.size()]));
+  }
+
+  /**
+   * Below method will be used to finish the execution
+   *
+   * @throws QueryExecutionException
+   */
+  @Override public void finish() throws QueryExecutionException {
+    if (null != queryProperties.executorService) {
+      queryProperties.executorService.shutdownNow();
+    }
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
@@ -36,7 +36,8 @@ public class DetailQueryExecutor extends AbstractQueryExecutor {
   @Override public CarbonIterator<Object[]> execute(QueryModel queryModel)
       throws QueryExecutionException {
     List<BlockExecutionInfo> blockExecutionInfoList = getBlockExecutionInfos(queryModel);
-    return new DetailQueryResultIterator(blockExecutionInfoList, queryModel);
+    return new DetailQueryResultIterator(blockExecutionInfoList, queryModel,
+        queryProperties.executorService);
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/QueryExecutorProperties.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/QueryExecutorProperties.java
@@ -21,6 +21,7 @@ package org.apache.carbondata.scan.executor.impl;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
 import org.apache.carbondata.core.carbon.datastore.block.AbstractIndex;
@@ -82,6 +83,10 @@ public class QueryExecutorProperties {
    * to record the query execution details phase wise
    */
   public QueryStatisticsRecorder queryStatisticsRecorder;
+  /**
+   * executor service to execute the query
+   */
+  public ExecutorService executorService;
   /**
    * list of blocks in which query will be executed
    */

--- a/core/src/main/java/org/apache/carbondata/scan/model/QueryModel.java
+++ b/core/src/main/java/org/apache/carbondata/scan/model/QueryModel.java
@@ -199,8 +199,8 @@ public class QueryModel implements Serializable {
 
   }
 
-  public static void processFilterExpression(
-      Expression filterExpression, List<CarbonDimension> dimensions, List<CarbonMeasure> measures) {
+  public static void processFilterExpression(Expression filterExpression,
+      List<CarbonDimension> dimensions, List<CarbonMeasure> measures) {
     if (null != filterExpression) {
       if (null != filterExpression.getChildren() && filterExpression.getChildren().size() == 0) {
         if (filterExpression instanceof ConditionalExpression) {


### PR DESCRIPTION
Problem: In case of limit query if limit value is 100 so after consuming 100 records executor service is not getting shutdown, and it may cause memory issue 

Solution: Add executor service in query model need to shutdown the executor after query execution in carbonscan rdd