### PR TITLE
[CARBONDATA-266]Add a new feature that support delete all carbon tables under one database.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -60,6 +60,7 @@ class CarbonSqlParser()
   protected val BY = carbonKeyWord("BY")
   protected val CARDINALITY = carbonKeyWord("CARDINALITY")
   protected val CASCADE = carbonKeyWord("CASCADE")
+  protected val CARBON = carbonKeyWord("CARBON")
   protected val CLASS = carbonKeyWord("CLASS")
   protected val CLEAN = carbonKeyWord("CLEAN")
   protected val COLS = carbonKeyWord("COLS")
@@ -194,7 +195,7 @@ class CarbonSqlParser()
   private def carbonKeyWord(keys: String) =
     ("(?i)" + keys).r
 
-  override protected lazy val start: Parser[LogicalPlan] = explainPlan | startCommand
+  override protected lazy val start: Parser[LogicalPlan] = explainPlan | startCommand | dropAllCarbonTables
 
   protected lazy val startCommand: Parser[LogicalPlan] =
     dropDatabaseCascade | loadManagement | describeTable | showLoads | alterTable | createTable
@@ -1172,6 +1173,11 @@ class CarbonSqlParser()
       opt(";") ^^ {
       case databaseName ~ tableName ~ limit =>
         ShowLoadsCommand(databaseName, tableName.toLowerCase(), limit)
+    }
+
+  protected lazy val dropAllCarbonTables: Parser[LogicalPlan] =
+    DROP ~> ALL ~> CARBON ~> TABLES ~> IN ~> ident <~ opt(";") ^^ {
+      case dbName => DropAllCarbonTables(dbName)
     }
 
   protected lazy val segmentId: Parser[String] =

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -195,10 +195,11 @@ class CarbonSqlParser()
   private def carbonKeyWord(keys: String) =
     ("(?i)" + keys).r
 
-  override protected lazy val start: Parser[LogicalPlan] = explainPlan | startCommand | dropAllCarbonTables
+  override protected lazy val start: Parser[LogicalPlan] = explainPlan | startCommand
 
   protected lazy val startCommand: Parser[LogicalPlan] =
-    dropDatabaseCascade | loadManagement | describeTable | showLoads | alterTable | createTable
+    dropAllCarbonTables | dropDatabaseCascade | loadManagement | describeTable | showLoads |
+      alterTable | createTable
 
   protected lazy val loadManagement: Parser[LogicalPlan] = deleteLoadsByID | deleteLoadsByLoadDate |
     cleanFiles | loadDataNew

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1583,3 +1583,22 @@ private[sql] case class CleanFiles(
     Seq.empty
   }
 }
+
+private[sql] case class DropAllCarbonTables(dbName: String) extends RunnableCommand {
+
+  val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+
+  def run(sqlContext: SQLContext): Seq[Row] = {
+    LOGGER.audit(s"Drop all carbon tables request has been received for $dbName")
+    val carbonTablesInDB = CarbonEnv.getInstance(sqlContext).carbonCatalog
+      .getTables(Some(dbName))(sqlContext).map(x => x._1)
+    carbonTablesInDB.foreach{carbonTableName =>
+      sqlContext.sql(
+        s"""DROP TABLE IF EXISTS $carbonTableName""")
+        .collect
+    }
+    LOGGER.audit(s"Carbon tables under database $dbName had been dropped.")
+    Seq.empty
+  }
+
+}

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.deleteTable
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestDeleteAllCarbonTablesInDB extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("create database if not exists testDB")
+    sql("use testDB")
+    sql("drop table if exists carbonTB1")
+    sql("drop table if exists carbonTB2")
+    sql("drop table if exists hiveTB")
+    sql("CREATE TABLE if not exists carbonTB1 (name string, age int) STORED BY 'org.apache.carbondata.format'")
+    sql("CREATE TABLE if not exists carbonTB2 (name string, age int) STORED BY 'org.apache.carbondata.format'")
+    sql("CREATE TABLE if not exists hiveTB (name string, age int)")
+  }
+
+  test("Drop all carbon tables in one database") {
+    sql("DROP ALL CARBON TABLES IN testDB")
+    checkAnswer(
+      sql("show tables in testDB"), Seq(Row("hivetb", false))
+    )
+  }
+
+  override def afterAll {
+    sql("drop table if exists carbonTB1")
+    sql("drop table if exists carbonTB2")
+    sql("drop table if exists hiveTB")
+    sql("drop database testDB")
+    sql("use default")
+  }
+}

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
@@ -27,8 +27,8 @@ import org.scalatest.BeforeAndAfterAll
 class TestDeleteAllCarbonTablesInDB extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
-    sql("create database if not exists testDB")
-    sql("use testDB")
+    sql("create database if not exists testDB_deleteall")
+    sql("use testDB_deleteall")
     sql("drop table if exists carbonTB1")
     sql("drop table if exists carbonTB2")
     sql("drop table if exists hiveTB")
@@ -38,9 +38,9 @@ class TestDeleteAllCarbonTablesInDB extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Drop all carbon tables in one database") {
-    sql("DROP ALL CARBON TABLES IN testDB")
+    sql("DROP ALL CARBON TABLES IN testDB_deleteall")
     checkAnswer(
-      sql("show tables in testDB"), Seq(Row("hivetb", false))
+      sql("show tables in testDB_deleteall"), Seq(Row("hivetb", false))
     )
   }
 
@@ -48,7 +48,7 @@ class TestDeleteAllCarbonTablesInDB extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbonTB1")
     sql("drop table if exists carbonTB2")
     sql("drop table if exists hiveTB")
-    sql("drop database testDB")
+    sql("drop database testDB_deleteall")
     sql("use default")
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
@@ -43,7 +43,7 @@ class TestDeleteAllCarbonTablesInDB extends QueryTest with BeforeAndAfterAll {
     assert(
       allTables.contains(Row("hivetb", false)) &&
       !allTables.contains(Row("carbonTB1", false)) &&
-      !allTables.contains(Row("carbonTB1", false))
+      !allTables.contains(Row("carbonTB2", false))
     )
 
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteAllCarbonTablesInDB.scala
@@ -39,9 +39,13 @@ class TestDeleteAllCarbonTablesInDB extends QueryTest with BeforeAndAfterAll {
 
   test("Drop all carbon tables in one database") {
     sql("DROP ALL CARBON TABLES IN testDB_deleteall")
-    checkAnswer(
-      sql("show tables in testDB_deleteall"), Seq(Row("hivetb", false))
+    val allTables = sql("show tables in testDB_deleteall").collectAsList()
+    assert(
+      allTables.contains(Row("hivetb", false)) &&
+      !allTables.contains(Row("carbonTB1", false)) &&
+      !allTables.contains(Row("carbonTB1", false))
     )
+
   }
 
   override def afterAll {


### PR DESCRIPTION
## Why rasie this pr?
Add a new feature that support delete all carbon tables under one database.
**Only delete all carbon tables, do not has effect on other tables.**

## How to test?
Pass all the testcases including the new test case.
