### PR TITLE
[CARBONDATA-265] Improve Dataframe write to CarbonData file from CSV file

### DIFF
--- a/examples/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
@@ -39,6 +39,7 @@ object DataFrameAPIExample {
     df.write
       .format("carbondata")
       .option("tableName", "carbon1")
+      .option("compress", "true")
       .mode(SaveMode.Overwrite)
       .save()
 


### PR DESCRIPTION
Currently during dataframe write to CarbonData file, all files need to be renamed to add CSV extension name. In this PR, only delete the SUCCESS file instead