### PR TITLE
[CARBONDATA-268]Improve carbonoptimizer Performance

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
@@ -134,7 +134,7 @@ private[sql] case class CarbonDatasourceRelation(
     (@transient context: SQLContext)
     extends BaseRelation with Serializable with Logging {
 
-  def carbonRelation: CarbonRelation = {
+  lazy val carbonRelation: CarbonRelation = {
     CarbonEnv.getInstance(context)
         .carbonCatalog.lookupRelation1(tableIdentifier, None)(sqlContext)
         .asInstanceOf[CarbonRelation]

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -99,7 +99,6 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
     plan match {
       case l: LogicalRelation if l.relation.isInstanceOf[CarbonDatasourceRelation] =>
         val extraNodeInfo = ExtraNodeInfo(true)
-        extraNodeInfos.put(plan, extraNodeInfo)
         extraNodeInfo
       case others =>
         val extraNodeInfo = ExtraNodeInfo(false)
@@ -109,7 +108,10 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
             extraNodeInfo.hasCarbonRelation = true
           }
         }
-        extraNodeInfos.put(plan, extraNodeInfo)
+        // only put no carbon realtion plan
+        if (!extraNodeInfo.hasCarbonRelation) {
+          extraNodeInfos.put(plan, extraNodeInfo)
+        }
         extraNodeInfo
     }
   }
@@ -135,7 +137,12 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
     collectInformationOnAttributes(plan, aliasMap)
 
     def hasCarbonRelation(currentPlan: LogicalPlan): Boolean = {
-      mapOfNodes.containsKey(currentPlan)
+      val extraNodeInfo = mapOfNodes.get(currentPlan)
+      if (extraNodeInfo == null) {
+        true
+      } else {
+        extraNodeInfo.hasCarbonRelation
+      }
     }
 
     val attrMap = new util.HashMap[AttributeReferenceWrapper, CarbonDecoderRelation]()

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -76,7 +76,8 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
       LOGGER.info("Starting to optimize plan")
       val startTime = System.currentTimeMillis
       val result = transformCarbonPlan(plan, relations)
-      LOGGER.info("Time taken to optimize plan: " + ( System.currentTimeMillis - startTime))
+      LOGGER.statistic("Time taken for Carbon Optimizer to optimize: " +
+        ( System.currentTimeMillis - startTime))
       result
     } else {
       LOGGER.info("Skip CarbonOptimizer")
@@ -130,14 +131,14 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
       return plan
     }
     var decoder = false
-    val mapOfNodes = new java.util.HashMap[LogicalPlan, ExtraNodeInfo]
-    fillNodeInfo(plan, mapOfNodes)
+    val mapOfNonCarbonPlanNodes = new java.util.HashMap[LogicalPlan, ExtraNodeInfo]
+    fillNodeInfo(plan, mapOfNonCarbonPlanNodes)
     val aliasMap = CarbonAliasDecoderRelation()
     // collect alias information before hand.
     collectInformationOnAttributes(plan, aliasMap)
 
     def hasCarbonRelation(currentPlan: LogicalPlan): Boolean = {
-      val extraNodeInfo = mapOfNodes.get(currentPlan)
+      val extraNodeInfo = mapOfNonCarbonPlanNodes.get(currentPlan)
       if (extraNodeInfo == null) {
         true
       } else {
@@ -454,7 +455,6 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
 
     }
 
-    val tStartTime = System.currentTimeMillis
     val transFormedPlan =
       plan transformDown {
         case cd: CarbonDictionaryTempDecoder if cd.isOuter =>


### PR DESCRIPTION
1. fix bug for carbon table union/join hive table

    No need to add dictionary decoder for hive table

2. just lookup relation from catalog once for each carbonrelation

3. use map for searching, instead of list
