### PR TITLE
[CARBONDATA-270] Double data type value comparison optimization

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
@@ -31,7 +31,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
-
+import org.apache.carbondata.core.util.DataTypeUtil;
 /**
  * class that implements methods specific for dictionary data look up
  */
@@ -277,8 +277,9 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
         case INT:
           return Integer.compare((Integer.parseInt(dictionaryVal)), (Integer.parseInt(memberVal)));
         case DOUBLE:
-          return Double
-              .compare((Double.parseDouble(dictionaryVal)), (Double.parseDouble(memberVal)));
+          return DataTypeUtil
+              .compareDoubleWithNan((Double.parseDouble(dictionaryVal)),
+                  (Double.parseDouble(memberVal)));
         case LONG:
           return Long.compare((Long.parseLong(dictionaryVal)), (Long.parseLong(memberVal)));
         case BOOLEAN:

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -411,4 +411,21 @@ public final class DataTypeUtil {
     }
     return null;
   }
+  /**
+   * This method will compare double values it will preserve
+   * the -0.0 and 0.0 equality as per == ,also preserve NaN equality check as per
+   * java.lang.Double.equals()
+   *
+   * @param d1 double value for equality check
+   * @param d2 double value for equality check
+   * @return boolean after comparing two double values.
+   */
+  public static int compareDoubleWithNan(Double d1, Double d2) {
+    if ((d1.doubleValue() == d2.doubleValue()) || (Double.isNaN(d1) && Double.isNaN(d2))) {
+      return 0;
+    } else if (d1 < d2) {
+      return -1;
+    }
+    return 1;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
@@ -1403,10 +1403,7 @@ public final class FilterUtil {
    * @return boolean after comparing two double values.
    */
   public static boolean nanSafeEqualsDoubles(Double d1, Double d2) {
-    Boolean xIsNan = Double.isNaN(d1);
-    Boolean yIsNan = Double.isNaN(d2);
-    if ((xIsNan && yIsNan) || (d1.doubleValue() == d2.doubleValue())) {
-
+    if ((d1.doubleValue() == d2.doubleValue()) || (Double.isNaN(d1) && Double.isNaN(d2))) {
       return true;
     }
     return false;


### PR DESCRIPTION
[Description] Double data type value comparison optimization,EqualsToExpression evaluation for double values first check for the equality of nan values and then the double value comparison happens, since nan comparison scenarios are rare we can push the comparison of nan after the double value comparison.

Already present UT testcases can verify the feature modification impact.
