### PR TITLE
[CARBONDATA-271]Fixed non filter data mismatch issue.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/FilterUtil.java
@@ -1019,7 +1019,11 @@ public final class FilterUtil {
     long[] dictionarySurrogateKey =
         new long[segmentProperties.getDimensions().size() - segmentProperties
             .getNumberOfNoDictionaryDimension()];
-    Arrays.fill(dictionarySurrogateKey, Long.MAX_VALUE);
+    int index = 0;
+    int[] dimColumnsCardinality = segmentProperties.getDimColumnsCardinality();
+    for (int i = 0; i < dimColumnsCardinality.length; i++) {
+      dictionarySurrogateKey[index++] = dimColumnsCardinality[i];
+    }
     IndexKey endIndexKey;
     byte[] dictionaryendMdkey =
         segmentProperties.getDimensionKeyGenerator().generateKey(dictionarySurrogateKey);


### PR DESCRIPTION
Problem: While generating the default end key we are taking LONG.MAX key and using segment key generator we are generating the end key if cardinality is less than it will give some value with in its cardinality and btree searching will fail

Solution: From segment property get the dimension cardinality as this is the max value for segment 