### PR TITLE
[CARBONDATA-272]Fixed Test case failure on second mvn build

### DIFF
--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
@@ -36,7 +36,7 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
   override def beforeAll {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
-    sql("DROP TABLE IF EXISTS alldatatypescubeAGG")
+    sql("DROP TABLE IF EXISTS alldatatypestableAGG")
     sql(
       "CREATE TABLE alldatatypestableAGG (empno int, empname String, designation String, doj " +
       "Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, deptname " +

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
@@ -36,7 +36,7 @@ class NO_DICTIONARY_COL_TestCase extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
     //For the Hive table creation and data loading
-    sql("drop table if exists filtertestTables")
+    sql("drop table if exists filtertestTable")
     sql("drop table if exists NO_DICTIONARY_HIVE_6")
     sql("drop table if exists NO_DICTIONARY_CARBON_6")
     sql("drop table if exists NO_DICTIONARY_CARBON_7")


### PR DESCRIPTION
Currently Test case are passing only when 'clean' is used with mvn.
This is due to improper table drop in test cases AllDataTypesTestCaseAggregate and NO_DICTIONARY_COL_TestCase 

During development, running test with 'clean' will take more time to build so it is better ensure tables are dropped properly
