### PR TITLE
[CARBONDATA-274]Use exist method in CarbonMetastoreCatalog to read/write thrift TableInfo and move Carbon table path builder string to CarbonCommonContants

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/path/CarbonTablePath.java
@@ -35,20 +35,6 @@ import org.apache.hadoop.fs.Path;
  */
 public class CarbonTablePath extends Path {
 
-  protected static final String METADATA_DIR = "Metadata";
-  protected static final String DICTIONARY_EXT = ".dict";
-  protected static final String DICTIONARY_META_EXT = ".dictmeta";
-  protected static final String SORT_INDEX_EXT = ".sortindex";
-  protected static final String SCHEMA_FILE = "schema";
-  protected static final String TABLE_STATUS_FILE = "tablestatus";
-  protected static final String FACT_DIR = "Fact";
-  protected static final String AGGREGATE_TABLE_PREFIX = "Agg";
-  protected static final String SEGMENT_PREFIX = "Segment_";
-  protected static final String PARTITION_PREFIX = "Part";
-  protected static final String CARBON_DATA_EXT = ".carbondata";
-  protected static final String DATA_PART_PREFIX = "part";
-  protected static final String INDEX_FILE_EXT = ".carbonindex";
-
   protected String tablePath;
   protected CarbonTableIdentifier carbonTableIdentifier;
 
@@ -77,7 +63,7 @@ public class CarbonTablePath extends Path {
    * @return name of dictionary file
    */
   public static String getDictionaryFileName(String columnId) {
-    return columnId + DICTIONARY_EXT;
+    return columnId + CarbonCommonConstants.DICTIONARY_EXT;
   }
 
   /**
@@ -87,7 +73,8 @@ public class CarbonTablePath extends Path {
    * @return
    */
   public static Boolean isDictionaryFile(CarbonFile carbonFile) {
-    return (!carbonFile.isDirectory()) && (carbonFile.getName().endsWith(DICTIONARY_EXT));
+    return (!carbonFile.isDirectory()) &&
+        (carbonFile.getName().endsWith(CarbonCommonConstants.DICTIONARY_EXT));
   }
 
   /**
@@ -99,7 +86,7 @@ public class CarbonTablePath extends Path {
   public static boolean isCarbonDataFile(String fileNameWithPath) {
     int pos = fileNameWithPath.lastIndexOf('.');
     if (pos != -1) {
-      return fileNameWithPath.substring(pos).startsWith(CARBON_DATA_EXT);
+      return fileNameWithPath.substring(pos).startsWith(CarbonCommonConstants.CARBON_DATA_EXT);
     }
     return false;
   }
@@ -113,7 +100,7 @@ public class CarbonTablePath extends Path {
   public static boolean isCarbonIndexFile(String fileNameWithPath) {
     int pos = fileNameWithPath.lastIndexOf('.');
     if (pos != -1) {
-      return fileNameWithPath.substring(pos).startsWith(INDEX_FILE_EXT);
+      return fileNameWithPath.substring(pos).startsWith(CarbonCommonConstants.INDEX_FILE_EXT);
     }
     return false;
   }
@@ -155,7 +142,7 @@ public class CarbonTablePath extends Path {
    * @return absolute path of dictionary meta file
    */
   public String getDictionaryMetaFilePath(String columnId) {
-    return getMetaDataDir() + File.separator + columnId + DICTIONARY_META_EXT;
+    return getMetaDataDir() + File.separator + columnId + CarbonCommonConstants.DICTIONARY_META_EXT;
   }
 
   /**
@@ -163,7 +150,7 @@ public class CarbonTablePath extends Path {
    * @return absolute path of sort index file
    */
   public String getSortIndexFilePath(String columnId) {
-    return getMetaDataDir() + File.separator + columnId + SORT_INDEX_EXT;
+    return getMetaDataDir() + File.separator + columnId + CarbonCommonConstants.SORT_INDEX_EXT;
   }
 
   /**
@@ -173,14 +160,15 @@ public class CarbonTablePath extends Path {
    * @return absolute path of sortindex with appeneded dictionary offset
    */
   public String getSortIndexFilePath(String columnId, long dictOffset) {
-    return getMetaDataDir() + File.separator + columnId + "_" + dictOffset + SORT_INDEX_EXT;
+    return getMetaDataDir() + File.separator + columnId + "_" + dictOffset +
+        CarbonCommonConstants.SORT_INDEX_EXT;
   }
 
   /**
    * @return absolute path of schema file
    */
   public String getSchemaFilePath() {
-    return getMetaDataDir() + File.separator + SCHEMA_FILE;
+    return getMetaDataDir() + File.separator + CarbonCommonConstants.SCHEMA_FILE;
   }
 
   /**
@@ -189,14 +177,15 @@ public class CarbonTablePath extends Path {
    * @return schema file path
    */
   public static String getSchemaFilePath(String tablePath) {
-    return tablePath + File.separator + METADATA_DIR + File.separator + SCHEMA_FILE;
+    return tablePath + File.separator + CarbonCommonConstants.METADATA_DIR +
+        File.separator + CarbonCommonConstants.SCHEMA_FILE;
   }
 
   /**
    * @return absolute path of table status file
    */
   public String getTableStatusFilePath() {
-    return getMetaDataDir() + File.separator + TABLE_STATUS_FILE;
+    return getMetaDataDir() + File.separator + CarbonCommonConstants.TABLE_STATUS_FILE;
   }
 
   /**
@@ -231,7 +220,8 @@ public class CarbonTablePath extends Path {
 
     CarbonFile[] files = carbonFile.listFiles(new CarbonFileFilter() {
       @Override public boolean accept(CarbonFile file) {
-        return file.getName().startsWith(taskId) && file.getName().endsWith(INDEX_FILE_EXT);
+        return file.getName().startsWith(taskId) &&
+            file.getName().endsWith(CarbonCommonConstants.INDEX_FILE_EXT);
       }
     });
     return files[0].getAbsolutePath();
@@ -274,8 +264,8 @@ public class CarbonTablePath extends Path {
    */
   public String getCarbonDataFileName(Integer filePartNo, Integer taskNo,
       String factUpdateTimeStamp) {
-    return DATA_PART_PREFIX + "-" + filePartNo + "-" + taskNo + "-" + factUpdateTimeStamp
-        + CARBON_DATA_EXT;
+    return CarbonCommonConstants.DATA_PART_PREFIX + "-" + filePartNo + "-" + taskNo + "-" +
+        factUpdateTimeStamp + CarbonCommonConstants.CARBON_DATA_EXT;
   }
 
   /**
@@ -286,36 +276,38 @@ public class CarbonTablePath extends Path {
    * @return filename
    */
   public String getCarbonIndexFileName(int taskNo, String factUpdatedTimeStamp) {
-    return taskNo + "-" + factUpdatedTimeStamp + INDEX_FILE_EXT;
+    return taskNo + "-" + factUpdatedTimeStamp + CarbonCommonConstants.INDEX_FILE_EXT;
   }
 
   private String getSegmentDir(String partitionId, String segmentId) {
-    return getPartitionDir(partitionId) + File.separator + SEGMENT_PREFIX + segmentId;
+    return getPartitionDir(partitionId) + File.separator +
+        CarbonCommonConstants.SEGMENT_PREFIX + segmentId;
   }
 
   public String getPartitionDir(String partitionId) {
-    return getFactDir() + File.separator + PARTITION_PREFIX + partitionId;
+    return getFactDir() + File.separator + CarbonCommonConstants.PARTITION_PREFIX + partitionId;
   }
 
   private String getAggSegmentDir(String aggTableID, String partitionId, String segmentId) {
-    return getAggPartitionDir(aggTableID, partitionId) + File.separator + SEGMENT_PREFIX
-        + segmentId;
+    return getAggPartitionDir(aggTableID, partitionId) + File.separator +
+        CarbonCommonConstants.SEGMENT_PREFIX + segmentId;
   }
 
   private String getAggPartitionDir(String aggTableID, String partitionId) {
-    return getAggregateTableDir(aggTableID) + File.separator + PARTITION_PREFIX + partitionId;
+    return getAggregateTableDir(aggTableID) + File.separator +
+        CarbonCommonConstants.PARTITION_PREFIX + partitionId;
   }
 
   private String getMetaDataDir() {
-    return tablePath + File.separator + METADATA_DIR;
+    return tablePath + File.separator + CarbonCommonConstants.METADATA_DIR;
   }
 
   public String getFactDir() {
-    return tablePath + File.separator + FACT_DIR;
+    return tablePath + File.separator + CarbonCommonConstants.FACT_DIR;
   }
 
   private String getAggregateTableDir(String aggTableId) {
-    return tablePath + File.separator + AGGREGATE_TABLE_PREFIX + aggTableId;
+    return tablePath + File.separator + CarbonCommonConstants.AGGREGATE_TABLE_PREFIX + aggTableId;
   }
 
   @Override public boolean equals(Object o) {
@@ -425,7 +417,8 @@ public class CarbonTablePath extends Path {
   public CarbonFile[] getSortIndexFiles(CarbonFile sortIndexDir, final String columnUniqueId) {
     CarbonFile[] files = sortIndexDir.listFiles(new CarbonFileFilter() {
       @Override public boolean accept(CarbonFile file) {
-        return file.getName().startsWith(columnUniqueId) && file.getName().endsWith(SORT_INDEX_EXT);
+        return file.getName().startsWith(columnUniqueId) &&
+            file.getName().endsWith(CarbonCommonConstants.SORT_INDEX_EXT);
       }
     });
     return files;

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -517,9 +517,21 @@ public final class CarbonCommonConstants {
    */
   public static final int DEFAULT_MAX_QUERY_EXECUTION_TIME = 60;
   /**
-   * LOADMETADATA_FILENAME
+   * Carbon table path
    */
-  public static final String LOADMETADATA_FILENAME = "tablestatus";
+  public static final String METADATA_DIR = "Metadata";
+  public static final String DICTIONARY_EXT = ".dict";
+  public static final String DICTIONARY_META_EXT = ".dictmeta";
+  public static final String SORT_INDEX_EXT = ".sortindex";
+  public static final String SCHEMA_FILE = "schema";
+  public static final String TABLE_STATUS_FILE = "tablestatus";
+  public static final String FACT_DIR = "Fact";
+  public static final String AGGREGATE_TABLE_PREFIX = "Agg";
+  public static final String SEGMENT_PREFIX = "Segment_";
+  public static final String PARTITION_PREFIX = "Part";
+  public static final String CARBON_DATA_EXT = ".carbondata";
+  public static final String DATA_PART_PREFIX = "part";
+  public static final String INDEX_FILE_EXT = ".carbonindex";
   /**
    * INMEMORY_REOCRD_SIZE
    */

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -406,7 +406,7 @@ public class StoreCreator {
     listOfLoadFolderDetails.add(loadMetadataDetails);
 
     String dataLoadLocation = schema.getCarbonTable().getMetaDataFilepath() + File.separator
-        + CarbonCommonConstants.LOADMETADATA_FILENAME;
+        + CarbonCommonConstants.TABLE_STATUS_FILE;
 
     DataOutputStream dataOutputStream;
     Gson gsonObjectToWrite = new Gson();

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -208,17 +208,8 @@ class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
                 if (FileFactory.isFileExist(tableMetadataFile, fileType)) {
                   val tableName = tableFolder.getName
                   val tableUniqueName = databaseFolder.getName + "_" + tableFolder.getName
-
-
-                  val createTBase = new ThriftReader.TBaseCreator() {
-                    override def create(): org.apache.thrift.TBase[TableInfo, TableInfo._Fields] = {
-                      new TableInfo()
-                    }
-                  }
-                  val thriftReader = new ThriftReader(tableMetadataFile, createTBase)
-                  thriftReader.open()
-                  val tableInfo: TableInfo = thriftReader.read().asInstanceOf[TableInfo]
-                  thriftReader.close()
+                  val tableInfo: TableInfo = CarbonMetastoreCatalog
+                    .readSchemaFileToThriftTable(tableMetadataFile)
 
                   val schemaConverter = new ThriftWrapperSchemaConverterImpl
                   val wrapperTableInfo = schemaConverter
@@ -304,11 +295,7 @@ class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
     if (!FileFactory.isFileExist(schemaMetadataPath, fileType)) {
       FileFactory.mkdirs(schemaMetadataPath, fileType)
     }
-
-    val thriftWriter = new ThriftWriter(schemaFilePath, false)
-    thriftWriter.open()
-    thriftWriter.write(thriftTableInfo)
-    thriftWriter.close()
+    CarbonMetastoreCatalog.writeThriftTableToSchemaFile(schemaFilePath, thriftTableInfo)
 
     metadata.tablesMeta += tableMeta
     logInfo(s"Table $tableName for Database $dbName created successfully.")

--- a/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
+++ b/processing/src/main/java/org/apache/carbondata/lcm/status/SegmentStatusManager.java
@@ -192,7 +192,7 @@ public class SegmentStatusManager {
     BufferedReader buffReader = null;
     InputStreamReader inStream = null;
     String metadataFileName = tableFolderPath + CarbonCommonConstants.FILE_SEPARATOR
-        + CarbonCommonConstants.LOADMETADATA_FILENAME;
+        + CarbonCommonConstants.TABLE_STATUS_FILE;
     LoadMetadataDetails[] listOfLoadFolderDetailsArray;
 
     AtomicFileOperations fileOperation =

--- a/processing/src/test/java/org/apache/carbondata/test/util/StoreCreator.java
+++ b/processing/src/test/java/org/apache/carbondata/test/util/StoreCreator.java
@@ -417,7 +417,7 @@ public class StoreCreator {
     listOfLoadFolderDetails.add(loadMetadataDetails);
 
     String dataLoadLocation = schema.getCarbonTable().getMetaDataFilepath() + File.separator
-        + CarbonCommonConstants.LOADMETADATA_FILENAME;
+        + CarbonCommonConstants.TABLE_STATUS_FILE;
 
     DataOutputStream dataOutputStream;
     Gson gsonObjectToWrite = new Gson();


### PR DESCRIPTION
## Why raise this pr?
1. Use exist method in CarbonMetastoreCatalog to reand/write thrift TableInfo
2. Move carbon table path builder string to CarbonCommonContants, so that we can aquire these common string in other places conveniently.

## How to test?
Pass all the test cases