### PR TITLE
[CARBONDATA-276]add trim property for cols

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/CarbonColumn.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/CarbonColumn.java
@@ -154,6 +154,14 @@ public class CarbonColumn implements Serializable {
   public Boolean isUseInvertedIndex() {
     return columnSchema.isUseInvertedIndex();
   }
+
+  /**
+   * @return if column use trim return true, else false.
+   */
+  public Boolean isUseTrim() {
+    return columnSchema.isUseTrim();
+  }
+
   public ColumnSchema getColumnSchema() {
     return this.columnSchema;
   }

--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
@@ -80,6 +80,11 @@ public class ColumnSchema implements Serializable {
   private boolean useInvertedIndex = true;
 
   /**
+   * Whether the column should use trim
+   */
+  private boolean useTrim = false;
+
+  /**
    * The group ID for column used for row format columns,
    * where in columns in each group are chunked together.
    */
@@ -188,6 +193,20 @@ public class ColumnSchema implements Serializable {
    */
   public void setUseInvertedIndex(boolean useInvertedIndex) {
     this.useInvertedIndex = useInvertedIndex;
+  }
+
+  /**
+   * the isUseTrim
+   */
+  public boolean isUseTrim() {
+    return useTrim;
+  }
+
+  /**
+   * @param useTrim the useInvertedIndex to set
+   */
+  public void setUseTrim(boolean useTrim) {
+    this.useTrim = useTrim;
   }
 
   /**

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -78,7 +78,11 @@ case class PrimitiveParser(dimension: CarbonDimension,
 
   def parseString(input: String): Unit = {
     if (hasDictEncoding && input != null) {
-      set.add(input)
+      if (dimension.isUseTrim()) {
+        set.add(input.trim)
+      } else {
+        set.add(input)
+      }
     }
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -38,7 +38,7 @@ import org.apache.carbondata.core.cache.dictionary.Dictionary
 import org.apache.carbondata.core.carbon.{CarbonDataLoadSchema, CarbonTableIdentifier}
 import org.apache.carbondata.core.carbon.metadata.datatype.DataType
 import org.apache.carbondata.core.carbon.metadata.encoder.Encoding
-import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension
+import org.apache.carbondata.core.carbon.metadata.schema.table.column.{CarbonColumn, CarbonDimension}
 import org.apache.carbondata.core.carbon.path.CarbonStorePath
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -78,6 +78,7 @@ case class tableModel(
     simpleDimRelations: Seq[DimensionRelation],
     highcardinalitydims: Option[Seq[String]],
     noInvertedIdxCols: Option[Seq[String]],
+    trimCols: Option[Seq[String]],
     aggregation: Seq[Aggregation],
     partitioner: Option[Partitioner],
     columnGroups: Seq[String],
@@ -336,6 +337,19 @@ class TableNewProcessor(cm: tableModel, sqlContext: SQLContext) {
         column.setUseInvertedIndex(false)
       } else {
         column.setUseInvertedIndex(true)
+      }
+    }
+
+    // Setting the boolean value of useTrimCols in column schema
+    val trimCols = cm.trimCols.getOrElse(Seq())
+    for (column <- allColumns) {
+      // When the column is not measure and the specified trim column in DDL,
+      // set useTrim to true, otherwise false.
+      if (trimCols.contains(column.getColumnName) &&
+        !cm.msrCols.exists(_.column.equalsIgnoreCase(column.getColumnName))) {
+        column.setUseTrim(true)
+      } else {
+        column.setUseTrim(false)
       }
     }
 

--- a/integration/spark/src/test/resources/testDataForTrim.csv
+++ b/integration/spark/src/test/resources/testDataForTrim.csv
@@ -1,0 +1,21 @@
+ID,date,country,name,phonetype,serialname,salary
+1,2015/7/23, china , aaa1          ,phone197,ASD69643,15000
+2,2015/7/24, china , aaa2,phone756,ASD42892,15001
+3,2015/7/25, china , aaa3,phone1904,ASD37014,15002
+4,2015/7/26, china , aaa4,phone2435,ASD66902,15003
+5,2015/7/27, china , aaa5,phone2441,ASD90633,15004
+6,2015/7/28, china , aaa6,phone294,ASD59961,15005
+7,2015/7/29, china , aaa7,phone610,ASD14875,15006
+8,2015/7/30, china , aaa8,phone1848,ASD57308,15007
+9,2015/7/18, china , aaa9,phone706,ASD86717,15008
+10,2015/7/19, usa , aaa10,phone685,ASD30505,15009
+11,2015/7/18, china , aaa11,phone1554,ASD26101,15010
+12,2015/7/19, china , aaa12,phone1781,ASD85711,15011
+13,2015/7/20, china , aaa13,phone943,ASD39200,15012
+14,2015/7/21, china , aaa14,phone1954,ASD80468,15013
+15,2015/7/22, china , aaa15,phone451,ASD1954,15014
+16,2015/7/23, china , aaa16,phone390,ASD38513,15015
+17,2015/7/24, china , aaa17,phone1929,ASD86213,15016
+18,2015/7/25, usa , aaa18,phone910,ASD88812,15017
+19,2015/7/26, china , aaa19,phone2151,ASD9316,15018
+20,2015/7/27, china , aaa20,phone2625,ASD62597,15019

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestTrimProperty.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestTrimProperty.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.spark.testsuite.createtable
+
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.Row
+
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.scalatest.BeforeAndAfterAll
+
+class TestTrimProperty extends QueryTest with BeforeAndAfterAll {
+  override def beforeAll {
+    sql("DROP TABLE IF EXISTS t3")
+    sql("""
+           CREATE TABLE IF NOT EXISTS t3
+           (ID Int, date Timestamp, country String,
+           name String, phonetype String, serialname String, salary Int)
+           STORED BY 'carbondata'
+           TBLPROPERTIES("trim"="country")
+        """)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+  }
+
+  test("test load data with different timestamp format") {
+    sql(s"""
+           LOAD DATA LOCAL INPATH './src/test/resources/testDataForTrim.csv' into table t3
+           """)
+    checkAnswer(
+      sql("SELECT country FROM t3 WHERE ID = 1"),
+      Seq(Row("china"))
+    )
+    checkAnswer(
+      sql("SELECT name FROM t3 WHERE ID = 1"),
+      Seq(Row(" aaa1          "))
+    )
+  }
+
+  override def afterAll {
+    sql("DROP TABLE IF EXISTS t3")
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
@@ -583,6 +583,7 @@ public class GraphGenerator {
     seqMeta.setHeirKeySize(graphConfiguration.getHeirAndKeySizeString());
     seqMeta.setColumnSchemaDetails(graphConfiguration.getColumnSchemaDetails().toString());
     seqMeta.setTableOption(graphConfiguration.getTableOptionWrapper().toString());
+    seqMeta.setIsUseTrim(graphConfiguration.getIsUseTrim());
     String[] aggType = graphConfiguration.getAggType();
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < aggType.length; i++) {
@@ -800,6 +801,7 @@ public class GraphGenerator {
     List<CarbonDimension> dimensions = carbonDataLoadSchema.getCarbonTable()
         .getDimensionByTableName(carbonDataLoadSchema.getCarbonTable().getFactTableName());
     prepareIsUseInvertedIndex(dimensions, graphConfiguration);
+    prepareIsUseTrim(dimensions, graphConfiguration);
     graphConfiguration
         .setDimensions(CarbonSchemaParser.getTableDimensions(dimensions, carbonDataLoadSchema));
     graphConfiguration
@@ -997,5 +999,25 @@ public class GraphGenerator {
     }
     graphConfig.setIsUseInvertedIndex(
         isUseInvertedIndexList.toArray(new Boolean[isUseInvertedIndexList.size()]));
+  }
+
+  /**
+   * Preparing the boolean [] to map whether the dimension use trim or not.
+   *
+   * @param dims
+   * @param graphConfig
+   */
+  private void prepareIsUseTrim(List<CarbonDimension> dims,
+                                GraphConfigurationInfo graphConfig) {
+    List<Boolean> isUseTrimList = new ArrayList<Boolean>();
+    for (CarbonDimension dimension : dims) {
+      if (dimension.isUseTrim()) {
+        isUseTrimList.add(true);
+      } else {
+        isUseTrimList.add(false);
+      }
+    }
+    graphConfig.setIsUseTrim(
+            isUseTrimList.toArray(new Boolean[isUseTrimList.size()]));
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
@@ -192,6 +192,8 @@ public class GraphConfigurationInfo {
 
   private Boolean[] isUseInvertedIndex;
 
+  private Boolean[] isUseTrim;
+
   private String columnPropertiesString;
 
   /**
@@ -225,6 +227,17 @@ public class GraphConfigurationInfo {
    */
   public void setIsUseInvertedIndex(Boolean[] isUseInvertedIndex) {
     this.isUseInvertedIndex = isUseInvertedIndex;
+  }
+
+  public Boolean[] getIsUseTrim() {
+    return isUseTrim;
+  }
+
+  /**
+   * @param isUseTrim the bool array whether use trim to set
+   */
+  public void setIsUseTrim(Boolean[] isUseTrim) {
+    this.isUseTrim = isUseTrim;
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
@@ -386,6 +386,8 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
    */
   private String columnsDataTypeString;
 
+  private String isUseTrim = "";
+
   public CarbonCSVBasedSeqGenMeta() {
     super();
   }
@@ -655,6 +657,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     columnsDataTypeString="";
     tableOption = "";
     dateFormat = "";
+    isUseTrim = "";
   }
 
   // helper method to allocate the arrays
@@ -721,6 +724,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
         .append(XMLHandler.addTagValue("columnSchemaDetails", columnSchemaDetails));
     retval.append("    ")
         .append(XMLHandler.addTagValue("tableOption", tableOption));
+    retval.append("    ").append(XMLHandler.addTagValue("isUseTrim", isUseTrim));
     return retval.toString();
   }
 
@@ -770,6 +774,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
       taskNo = XMLHandler.getTagValue(stepnode, "taskNo");
       columnSchemaDetails = XMLHandler.getTagValue(stepnode, "columnSchemaDetails");
       tableOption = XMLHandler.getTagValue(stepnode, "tableOption");
+      isUseTrim = XMLHandler.getTagValue(stepnode, "isUseTrim");
       String batchConfig = XMLHandler.getTagValue(stepnode, "batchSize");
 
       if (batchConfig != null) {
@@ -1693,6 +1698,20 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
    */
   public TableOptionWrapper getTableOptionWrapper() {
     return tableOptionWrapper;
+  }
+
+  public String getIsUseTrim() {
+    return isUseTrim;
+  }
+
+  public void setIsUseTrim(Boolean[] isUseTrim) {
+    for (Boolean flag: isUseTrim) {
+      if (flag) {
+        this.isUseTrim += "T";
+      } else {
+        this.isUseTrim += "F";
+      }
+    }
   }
 }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -268,6 +269,8 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
 
   private DirectDictionaryGenerator[] directDictionaryGenerators;
 
+  private HashSet<String> trimDimensions = new HashSet<>();
+
   /**
    * Constructor
    *
@@ -296,8 +299,8 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
       Object[] r = getRow();  // get row, blocks when needed!
       if (first) {
         CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
-                .recordGeneratingDictionaryValuesTime(meta.getPartitionID(),
-                        System.currentTimeMillis());
+            .recordGeneratingDictionaryValuesTime(meta.getPartitionID(),
+                System.currentTimeMillis());
         first = false;
         meta.initialize();
         final Object dataProcessingLockObject = CarbonDataProcessorManager.getInstance()
@@ -475,7 +478,7 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
         HashMap<String, String> dateformatsHashMap = new HashMap<String, String>();
         if (meta.dateFormat != null) {
           String[] dateformats = meta.dateFormat.split(CarbonCommonConstants.COMMA);
-          for (String dateFormat:dateformats) {
+          for (String dateFormat : dateformats) {
             String[] dateFormatSplits = dateFormat.split(":", 2);
             dateformatsHashMap.put(dateFormatSplits[0].toLowerCase().trim(),
                 dateFormatSplits[1].trim());
@@ -501,11 +504,16 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
           }
         }
       }
+      for (int j = 0; j < meta.dimColNames.length; j++) {
+        if (meta.getIsUseTrim().charAt(j) == 'T') {
+          trimDimensions.add(meta.dimColNames[j]);
+        }
+      }
       // no more input to be expected...
       if (r == null) {
         return processWhenRowIsNull();
       }
-      // proecess the first
+      // process the first
       Object[] out = process(r);
       readCounter++;
       if (null != out) {
@@ -939,6 +947,15 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
     }
   }
 
+  private Object[] prepareForPopulate(Object[] r) {
+    for (int i = 0; i < r.length; i++) {
+      if (meta.getIsUseTrim().charAt(i) == 'T') {
+        r[i] = r.toString().trim();
+      }
+    }
+    return r;
+  }
+
   private Object[] populateOutputRow(Object[] r) throws KettleException {
 
     // Copy the dimension String values to output
@@ -983,6 +1000,9 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
           CarbonCommonConstants.MEMBER_DEFAULT_VAL :
           (String) r[j];
       // check whether the column value is the value to be  serialized as null.
+      if (trimDimensions.contains(meta.getTableName() + "_" + columnName)) {
+        tuple = tuple.trim();
+      }
       boolean isSerialized = false;
       if(tuple.equalsIgnoreCase(serializationNullFormat)) {
         tuple = CarbonCommonConstants.MEMBER_DEFAULT_VAL;


### PR DESCRIPTION
# Why raise this PR?

Add trim property for cols.
trim a col or not can be set during create table time, like,

CREATE TABLE IF NOT EXISTS t3 (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary Int)
STORED BY 'carbondata'
TBLPROPERTIES("trim"="country")

In order to delete some meaningless white space in some fields, we do this PR. It will also improve the index finding performance with shorter string.
# How to test?

Pass all the test cases.
