### PR TITLE
[CARBONDATA-278] IS NULL and IS NOT NULL shall be push down to carbon

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/expression/conditional/BinaryConditionalExpression.java
+++ b/core/src/main/java/org/apache/carbondata/scan/expression/conditional/BinaryConditionalExpression.java
@@ -29,7 +29,7 @@ public abstract class BinaryConditionalExpression extends BinaryLogicalExpressio
    *
    */
   private static final long serialVersionUID = 1L;
-
+  public boolean isNull;
   public BinaryConditionalExpression(Expression left, Expression right) {
     super(left, right);
   }

--- a/core/src/main/java/org/apache/carbondata/scan/expression/conditional/EqualToExpression.java
+++ b/core/src/main/java/org/apache/carbondata/scan/expression/conditional/EqualToExpression.java
@@ -31,7 +31,6 @@ import org.apache.carbondata.scan.filter.intf.RowIntf;
 public class EqualToExpression extends BinaryConditionalExpression {
 
   private static final long serialVersionUID = 1L;
-  private boolean isNull;
 
   public EqualToExpression(Expression left, Expression right) {
     super(left, right);

--- a/core/src/main/java/org/apache/carbondata/scan/filter/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/FilterExpressionProcessor.java
@@ -232,7 +232,8 @@ public class FilterExpressionProcessor implements FilterProcessor {
                 currentExpression), currentExpression);
       case EQUALS:
       case IN:
-        return getFilterResolverBasedOnExpressionType(ExpressionType.EQUALS, false, expressionTree,
+        return getFilterResolverBasedOnExpressionType(ExpressionType.EQUALS,
+            ((BinaryConditionalExpression) expressionTree).isNull, expressionTree,
             tableIdentifier, expressionTree);
       case GREATERTHAN:
       case GREATERTHAN_EQUALTO:

--- a/core/src/main/java/org/apache/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/resolver/ConditionalFilterResolverImpl.java
@@ -132,7 +132,8 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
       metadata.setColumnExpression(columnList.get(0));
       metadata.setExpression(exp);
       metadata.setIncludeFilter(isIncludeFilter);
-      if (!columnList.get(0).getDimension().hasEncoding(Encoding.DICTIONARY)) {
+      if (!columnList.get(0).getDimension().hasEncoding(Encoding.DICTIONARY)
+              || columnList.get(0).getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
         dimColResolvedFilterInfo.populateFilterInfoBasedOnColumnType(
             FilterInfoTypeVisitorFactory.getResolvedFilterInfoVisitor(columnList.get(0)), metadata);
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonFilters.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonFilters.scala
@@ -153,7 +153,8 @@ object CarbonFilters {
             Some(sources.Not(sources.EqualTo(a.name, v)))
         case Not(EqualTo(Literal(v, t), Cast(a: Attribute, _))) => new
             Some(sources.Not(sources.EqualTo(a.name, v)))
-
+        case IsNotNull(a: Attribute) => Some(sources.IsNotNull(a.name))
+        case IsNull(a: Attribute) => Some(sources.IsNull(a.name))
         case Not(In(a: Attribute, list)) if !list.exists(!_.isInstanceOf[Literal]) =>
           val hSet = list.map(e => e.eval(EmptyRow))
           Some(sources.Not(sources.In(a.name, hSet.toArray)))
@@ -257,7 +258,12 @@ object CarbonFilters {
             Some(new NotEqualsExpression(transformExpression(a).get, transformExpression(l).get))
         case Not(EqualTo(l@Literal(v, t), Cast(a: Attribute, _))) => new
             Some(new NotEqualsExpression(transformExpression(a).get, transformExpression(l).get))
-
+        case IsNotNull(child) =>
+            Some(new NotEqualsExpression(transformExpression(child).get,
+             transformExpression(Literal(null)).get, true))
+        case IsNull(child) =>
+            Some(new EqualToExpression(transformExpression(child).get,
+             transformExpression(Literal(null)).get, true))
         case Not(In(a: Attribute, list))
          if !list.exists(!_.isInstanceOf[Literal]) =>
          if (list.exists(x => (isNullLiteral(x.asInstanceOf[Literal])))) {


### PR DESCRIPTION
**Current design** : As per the current design IS NULL and IS NOT NULL filter is been handled by spark layer
**Drawback** :  Block/Blocklet level pruning will not be possible if the filter is been processed by spark layer
**Proposed Improvement**:  IS NULL and IS NOT NULL shall be push down to carbon layer since carbon layer can process these filters faster using block/block-let pruning , also while processing filters in executers  carbon is applying binary search for applying filter values.

**UT/FT Testcases** : Existing testcases can verify the impact of this PR change since its not new usecase/scenario.