### PR TITLE
[CARBONDATA-280]Fix the bug that when table properties is repeated it only set the last one

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -365,7 +365,7 @@ class CarbonSqlParser()
               }
             case Token("TOK_TABLEPROPERTIES", list :: Nil) =>
               val propertySeq: Seq[(String, String)] = getProperties(list)
-              val repeatedProperties = propertySeq.groupBy(_._1).filter(_._2.nonEmpty).keySet
+              val repeatedProperties = propertySeq.groupBy(_._1).filter(_._2.size > 1).keySet
               if (repeatedProperties.nonEmpty) {
                 val repeatedPropStr: String = repeatedProperties.mkString(",")
                 throw new MalformedCarbonCommandException("Table properties is repeated: " +

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -365,9 +365,8 @@ class CarbonSqlParser()
               }
             case Token("TOK_TABLEPROPERTIES", list :: Nil) =>
               val propertySeq: Seq[(String, String)] = getProperties(list)
-              val repeatedProperties = propertySeq.groupBy(x => x._1)
-                .filter(y => y._2.size > 1).keySet
-              if (repeatedProperties.size > 0) {
+              val repeatedProperties = propertySeq.groupBy(_._1).filter(_._2.nonEmpty).keySet
+              if (repeatedProperties.nonEmpty) {
                 val repeatedPropStr: String = repeatedProperties.mkString(",")
                 throw new MalformedCarbonCommandException("Table properties is repeated: " +
                   repeatedPropStr)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -364,7 +364,15 @@ class CarbonSqlParser()
                 }
               }
             case Token("TOK_TABLEPROPERTIES", list :: Nil) =>
-              tableProperties ++= getProperties(list)
+              val propertySeq: Seq[(String, String)] = getProperties(list)
+              val repeatedProperties = propertySeq.groupBy(x => x._1)
+                .filter(y => y._2.size > 1).keySet
+              if (repeatedProperties.size > 0) {
+                val repeatedPropStr: String = repeatedProperties.mkString(",")
+                throw new MalformedCarbonCommandException("Table properties is repeated: " +
+                  repeatedPropStr)
+              }
+              tableProperties ++= propertySeq
 
             case Token("TOK_LIKETABLE", child :: Nil) =>
               likeTableName = child.getChild(0).getText()

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
@@ -162,6 +162,26 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
       }
     }
   }
+
+  test("create carbon table with repeated table properties") {
+    try {
+      sql(
+        """
+          CREATE TABLE IF NOT EXISTS carbontable
+          (ID Int, date Timestamp, country String,
+          name String, phonetype String, serialname String, salary Int)
+          STORED BY 'carbondata'
+          TBLPROPERTIES('DICTIONARY_EXCLUDE'='country','DICTIONARY_INCLUDE'='ID',
+          'DICTIONARY_EXCLUDE'='phonetype', 'DICTIONARY_INCLUDE'='salary')
+        """)
+      assert(false)
+    } catch {
+      case e : MalformedCarbonCommandException => {
+        assert(e.getMessage.equals("Table properties is repeated: dictionary_include,dictionary_exclude"))
+      }
+    }
+  }
+
   override def afterAll {
     sql("drop table if exists carbontable")
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -97,7 +97,7 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
       "CREATE table CaseInsensitiveTable (ID int, date String, country String, name " +
       "String," +
       "phonetype String, serialname String, salary int) stored by 'org.apache.carbondata.format'" +
-      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID,salary')"
+      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID, salary')"
     )
     // table should drop wihout any error
     sql("drop table caseInsensitiveTable")
@@ -107,7 +107,7 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
       "CREATE table CaseInsensitiveTable (ID int, date String, country String, name " +
       "String," +
       "phonetype String, serialname String, salary int) stored by 'org.apache.carbondata.format'" +
-      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID,salary')"
+      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID, salary')"
     )
 
   }
@@ -118,7 +118,7 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
       "CREATE table default.table3 (ID int, date String, country String, name " +
       "String," +
       "phonetype String, serialname String, salary int) stored by 'org.apache.carbondata.format'" +
-      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID,salary')"
+      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID, salary')"
     )
     // table should drop without any error
     sql("drop table default.table3")

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -97,7 +97,7 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
       "CREATE table CaseInsensitiveTable (ID int, date String, country String, name " +
       "String," +
       "phonetype String, serialname String, salary int) stored by 'org.apache.carbondata.format'" +
-      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID', 'DICTIONARY_INCLUDE'='salary')"
+      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID,salary')"
     )
     // table should drop wihout any error
     sql("drop table caseInsensitiveTable")
@@ -107,7 +107,7 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
       "CREATE table CaseInsensitiveTable (ID int, date String, country String, name " +
       "String," +
       "phonetype String, serialname String, salary int) stored by 'org.apache.carbondata.format'" +
-      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID', 'DICTIONARY_INCLUDE'='salary')"
+      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID,salary')"
     )
 
   }
@@ -118,7 +118,7 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
       "CREATE table default.table3 (ID int, date String, country String, name " +
       "String," +
       "phonetype String, serialname String, salary int) stored by 'org.apache.carbondata.format'" +
-      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID', 'DICTIONARY_INCLUDE'='salary')"
+      "TBLPROPERTIES('DICTIONARY_INCLUDE'='ID,salary')"
     )
     // table should drop without any error
     sql("drop table default.table3")


### PR DESCRIPTION
## Why raise this pr?
When table properties is repeated it only set the last one, for example,
```
CREATE TABLE IF NOT EXISTS carbontable
(ID Int, date Timestamp, country String,
name String, phonetype String, serialname String, salary Int)
STORED BY 'carbondata'
TBLPROPERTIES('DICTIONARY_EXCLUDE'='country','DICTIONARY_INCLUDE'='ID',
'DICTIONARY_EXCLUDE'='phonetype', 'DICTIONARY_INCLUDE'='salary')
```
As we use map to store the properties, only salary is set to DICTIONARY_INCLUDE and only phonetype is set to DICTIONARY_EXCLUDE.

## How to solve?
**We should do restrict syntax check that 'DICTIONARY_EXCLUDE'='country,phonetype' , 'DICTIONARY_INCLUDE'='ID,salary**' and if table properties is repeated, throw an  MalformedCarbonCommandException to tell the user that Table properties is repeated, so that the user would not perform error operation.

## How to test?
Pass the exist test cases and the new test case for this bug.
## Test Result
CI has passed:
http://136.243.101.176:8080/job/ApacheCarbonManualPRBuilder/354/testReport/