### PR TITLE
[CARBONDATA-285] Use path parameter in Spark datasource API

### DIFF
--- a/examples/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.examples
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.examples.util.ExampleUtils
 
 // scalastyle:off println
@@ -29,8 +30,7 @@ object DataFrameAPIExample {
     // use datasource api to read
     val in = cc.read
       .format("carbondata")
-      .option("tableName", "carbon1")
-      .load()
+      .load(s"${cc.storePath}/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/carbon1")
 
     import cc.implicits._
     val count = in.where($"c3" > 500).select($"*").count()

--- a/examples/src/main/scala/org/apache/carbondata/examples/DatasourceExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/DatasourceExample.scala
@@ -17,8 +17,9 @@
 
 package org.apache.carbondata.examples
 
-import org.apache.spark.sql.{SaveMode, SQLContext}
+import org.apache.spark.sql.SQLContext
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.examples.util.ExampleUtils
 
 object DatasourceExample {
@@ -34,7 +35,7 @@ object DatasourceExample {
       s"""
         | CREATE TEMPORARY TABLE source
         | USING org.apache.spark.sql.CarbonSource
-        | OPTIONS (path '${cc.storePath}/default/table1')
+        | OPTIONS (path '${cc.storePath}/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/table1')
       """.stripMargin)
     sqlContext.sql("SELECT c1, c2, count(*) FROM source WHERE c3 > 100 GROUP BY c1, c2").show
   }

--- a/examples/src/main/scala/org/apache/carbondata/examples/HadoopFileExample.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/HadoopFileExample.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.examples
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.examples.util.ExampleUtils
 import org.apache.carbondata.hadoop.CarbonInputFormat
 
@@ -28,7 +29,8 @@ object HadoopFileExample {
     ExampleUtils.writeSampleCarbonFile(cc, "carbon1")
 
     val sc = cc.sparkContext
-    val input = sc.newAPIHadoopFile(s"${cc.storePath}/default/carbon1",
+    val input = sc.newAPIHadoopFile(
+      s"${cc.storePath}/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/carbon1",
       classOf[CarbonInputFormat[Array[Object]]],
       classOf[Void],
       classOf[Array[Object]])

--- a/examples/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
@@ -22,6 +22,7 @@ import java.io.File
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{CarbonContext, SaveMode}
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 
 // scalastyle:off println
@@ -69,10 +70,9 @@ object ExampleUtils {
     // save dataframe to carbon file
     df.write
       .format("carbondata")
-      .option("tableName", tableName)
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
-      .save()
+      .save(s"${cc.storePath}/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/$tableName")
   }
 }
 // scalastyle:on println

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -42,7 +42,7 @@ import org.apache.carbondata.core.carbon.path.{CarbonStorePath, CarbonTablePath}
 import org.apache.carbondata.hadoop.{CarbonInputFormat, CarbonInputSplit, CarbonProjection}
 import org.apache.carbondata.hadoop.util.SchemaReader
 import org.apache.carbondata.scan.expression.logical.AndExpression
-import org.apache.carbondata.spark.{CarbonFilters, CarbonOption}
+import org.apache.carbondata.spark.CarbonFilters
 import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 import org.apache.carbondata.spark.util.CarbonScalaUtil.CarbonSparkUtil
 import org.apache.carbondata.spark.util.QueryPlanUtil

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOption.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOption.scala
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.carbondata.spark
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 
@@ -23,13 +25,21 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
  * Contains all options for Spark data source
  */
 class CarbonOption(options: Map[String, String]) {
-  def tableIdentifier: String = options.getOrElse("tableName", s"$dbName.$tableName")
 
-  def dbName: String = options.getOrElse("dbName", CarbonCommonConstants.DATABASE_DEFAULT_NAME)
+  def tableIdentifier: TableIdentifier = {
+    val (dbName, tableName) = dbNameAndTableName
+    TableIdentifier(tableName, Some(dbName))
+  }
 
-  def tableName: String = options.getOrElse("tableName", "default_table")
+  def path: String = options.getOrElse("path",
+    throw new IllegalArgumentException("path must present"))
 
-  def tableId: String = options.getOrElse("tableId", "default_table_id")
+  def dbNameAndTableName: (String, String) = {
+    val tablePath = path.replace("\\", "/")
+    val pathSplits = tablePath.split('/')
+    assert(pathSplits.length > 2)
+    (pathSplits(pathSplits.length - 2), pathSplits.last)
+  }
 
   def partitionCount: String = options.getOrElse("partitionCount", "1")
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -869,9 +869,11 @@ case class CreateTable(cm: tableModel) extends RunnableCommand {
       val tablePath = catalog.createTableFromThrift(tableInfo, dbName, tbName, null)(sqlContext)
       try {
         sqlContext.sql(
-          s"""CREATE TABLE $dbName.$tbName USING carbondata""" +
-          s""" OPTIONS (tableName "$dbName.$tbName", tablePath "$tablePath") """)
-              .collect
+          s"""
+             | CREATE TABLE $dbName.$tbName
+             | USING carbondata
+             | OPTIONS (path "$tablePath")
+           """.stripMargin).collect
       } catch {
         case e: Exception =>
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
@@ -1091,10 +1091,11 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
   test("CARBONDATA-60-union-defect")({
     sql("drop table if exists carbonunion")
     import implicits._
-    val df=sc.parallelize(1 to 1000).map(x => (x+"", (x+100)+"")).toDF("c1", "c2")
+    val df = sc.parallelize(1 to 1000).map(x => (x+"", (x+100)+"")).toDF("c1", "c2")
     df.registerTempTable("sparkunion")
     import org.apache.carbondata.spark._
-    df.saveAsCarbonFile(Map("tableName" -> "carbonunion"))
+    df.saveAsCarbonFile(
+      Map("path" -> s"$storePath/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/carbonunion"))
 
     checkAnswer(
       sql("select c1,count(c1) from (select c1 as c1,c2 as c2 from carbonunion union all select c2 as c1,c1 as c2 from carbonunion)t where c1='200' group by c1"),

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
@@ -19,6 +19,7 @@
 
 package org.apache.carbondata.spark.testsuite.dataload
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.sql.common.util.CarbonHiveContext._
 import org.apache.spark.sql.common.util.QueryTest
@@ -51,11 +52,10 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
     // save dataframe to carbon file
     df.write
       .format("carbondata")
-      .option("tableName", "carbon1")
       .option("tempCSV", "true")
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
-      .save()
+      .save(s"$storePath/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/carbon1")
     checkAnswer(
       sql("select count(*) from carbon1 where c3 > 500"), Row(500)
     )
@@ -65,11 +65,10 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
     // save dataframe to carbon file
     df.write
       .format("carbondata")
-      .option("tableName", "carbon2")
       .option("tempCSV", "true")
       .option("compress", "false")
       .mode(SaveMode.Overwrite)
-      .save()
+      .save(s"$storePath/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/carbon2")
     checkAnswer(
       sql("select count(*) from carbon2 where c3 > 500"), Row(500)
     )
@@ -79,10 +78,9 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
     // save dataframe to carbon file
     df.write
       .format("carbondata")
-      .option("tableName", "carbon3")
       .option("tempCSV", "false")
       .mode(SaveMode.Overwrite)
-      .save()
+      .save(s"$storePath/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/carbon3")
     checkAnswer(
       sql("select count(*) from carbon3 where c3 > 500"), Row(500)
     )

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/hadooprelation/HadoopFSRelationTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/hadooprelation/HadoopFSRelationTestCase.scala
@@ -19,6 +19,7 @@
 
 package org.apache.carbondata.spark.testsuite.hadooprelation
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.common.util.CarbonHiveContext._
 import org.apache.spark.sql.common.util.QueryTest
@@ -48,17 +49,20 @@ class HadoopFSRelationTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("hadoopfsrelation select all test") {
-    val rdd = read.format("org.apache.spark.sql.CarbonSource")
-      .option("tableName", "hadoopfsrelation").load()
-    assert(rdd.collect().length > 0)
+    val df =
+      read.format("org.apache.spark.sql.CarbonSource")
+          .load(s"$storePath/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/hadoopfsrelation")
+    assert(df.collect().length > 0)
   }
 
   test("hadoopfsrelation filters test") {
-    val rdd: DataFrame = read.format("org.apache.spark.sql.CarbonSource")
-      .option("tableName", "hadoopfsrelation").load()
-      .select("empno", "empname", "utilization").where("empname in ('arvind','ayushi')")
+    val df: DataFrame =
+      read.format("org.apache.spark.sql.CarbonSource")
+          .load(s"$storePath/${CarbonCommonConstants.DATABASE_DEFAULT_NAME}/hadoopfsrelation")
+          .select("empno", "empname", "utilization")
+          .where("empname in ('arvind','ayushi')")
     checkAnswer(
-      rdd,
+      df,
       sql("select empno,empname,utilization from hadoopfsrelation_hive where empname in ('arvind','ayushi')"))
   }
 


### PR DESCRIPTION
Currently, when using carbon with spark datasource API, it need to give database name and table name as parameter, it is not the normal way of datasource API usage. In this PR, database name and table name is not required to give, user need to specify the `path` parameter (indicating the path to table folder) only when using datasource API

before:

```
df.write
   .format("carbondata")
   .option("tableName", tableName)
   .mode(SaveMode.Overwrite)
   .save()
```

after:

```
df.write
   .format("carbondata")
   .mode(SaveMode.Overwrite)
   .save("store_path/default/table_name")
```

The same for read interface.
