### PR TITLE
[WIP] Add a tool to print out schema of CarbonData

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.carbon.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 import org.apache.carbondata.core.carbon.metadata.encoder.Encoding;
+import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.ColumnSchema;
@@ -438,4 +439,32 @@ public class CarbonTable implements Serializable {
     this.blocksize = blocksize;
   }
 
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+
+    // table info
+    oneLine(builder.append("======= table information ======="));
+    oneLine(builder.append("path of this table: ").append(absoluteTableIdentifier.getTablePath()));
+    oneLine(builder.append("last updated time: ").append(getTableLastUpdatedTime()));
+    oneLine(builder.append("partition count: ").append(getPartitionCount()));
+    oneLine(builder.append("block size: ").append(getBlocksize()));
+
+    // schema info
+    oneLine(builder.append("======= schema information ======="));
+    List<CarbonDimension> dims = getDimensionByTableName(getFactTableName());
+    for (CarbonDimension dim : dims) {
+      oneLine(builder.append(dim));
+    }
+
+    List<CarbonMeasure> msrs = getMeasureByTableName(getFactTableName());
+    for (CarbonMeasure msr : msrs) {
+      oneLine(builder.append(msr));
+    }
+
+    return builder.toString();
+  }
+
+  private void oneLine(StringBuilder builder) {
+    builder.append("\n");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/CarbonColumn.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/CarbonColumn.java
@@ -171,4 +171,19 @@ public class CarbonColumn implements Serializable {
   public ColumnIdentifier getColumnIdentifier() {
     return this.columnIdentifier;
   }
+
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(isDimesion() ? "dimension column: {" : "measure column: {");
+    builder.append("name: ").append(getColName());
+    builder.append(", data type: ").append(getDataType());
+    builder.append(", columnar: ").append(isColumnar());
+    builder.append(", encoding: ").append(getEncoder());
+    builder.append(", inverted index: ").append(isUseInvertedIndnex());
+    builder.append(", ordinal: ").append(getOrdinal());
+    builder.append(", id: ").append(getColumnId());
+    builder.append(", default value: ").append(defaultValue);
+    builder.append("}");
+    return builder.toString();
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <module>integration/spark</module>
     <module>assembly</module>
     <module>examples</module>
+    <module>tools</module>
   </modules>
 
   <properties>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.carbondata</groupId>
+    <artifactId>carbondata-parent</artifactId>
+    <version>0.2.0-incubating-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>carbon-tools</artifactId>
+  <name>Apache CarbonData :: Tools</name>
+
+  <properties>
+    <dev.path>${basedir}/../dev</dev.path>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-spark</artifactId>
+      <version>0.2.0-incubating-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-hadoop</artifactId>
+      <version>0.2.0-incubating-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-examples</artifactId>
+      <version>0.2.0-incubating-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/java</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tools/src/main/java/org/apache/carbondata/tools/SchemaTool.java
+++ b/tools/src/main/java/org/apache/carbondata/tools/SchemaTool.java
@@ -1,0 +1,47 @@
+package org.apache.carbondata.tools;
+
+import java.io.IOException;
+
+import org.apache.carbondata.core.carbon.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.hadoop.util.SchemaReader;
+
+/**
+ * This tool prints out schema information of the CarbonData files (by giving args[0] as table path)
+ */
+public class SchemaTool {
+
+  public static void main(String[] args) {
+
+    if (args.length < 1) {
+      printUsage();
+      return;
+    }
+
+    String tablePath = args[args.length - 1];
+
+    AbsoluteTableIdentifier identifier = AbsoluteTableIdentifier.fromTablePath(tablePath);
+
+    try {
+      CarbonTable table = SchemaReader.readCarbonTableFromStore(identifier);
+      if (table != null) {
+        System.out.println(table);
+      } else {
+        System.out.println("it is not a valid table path: " + tablePath);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static void printUsage() {
+    String usage =
+        "command line tool to print carbondata files, it prints out schema by default \n" +
+        "usage: carbon-ls path\n" +
+        "arguments:\n" +
+        "\tpath: path to carbondatat files\n";
+
+    System.out.println(usage);
+  }
+
+}


### PR DESCRIPTION
Add a tool to print out schema information, taking carbondata table folder as input parameter

```
usage: carbon-ls path
arguments:
    path: path to carbondatat files
```

For example, for the table generated using `ExampleUtils.writeSampleCarbonFile`, it will print following information:

```
======= table information =======
path of this table: /Users/jackylk/code/incubator-carbondata/tools/target/store/default/t1
last updated time: 1475755645305
partition count: 1
block size: 1024
======= schema information =======
dimension column: {name: c1, data type: STRING, columnar: true, encoding: [DICTIONARY], inverted index: true, ordinal: 0, id: d5345f2e-ce2c-40f0-99e8-39ee07f356da, default value: null}
dimension column: {name: c2, data type: STRING, columnar: true, encoding: [DICTIONARY], inverted index: true, ordinal: 1, id: 0ddb30d9-7d9f-4c2c-b253-9a5a4bdebbfb, default value: null}
measure column: {name: c3, data type: INT, columnar: true, encoding: [], inverted index: false, ordinal: 0, id: 5c9010de-0006-46dd-918a-72e7a2f0a2c8, default value: null}
```

I will create JIRA later
