### PR TITLE
[CARBONDATA-288] In hdfs bad record logger is failing in writing the bad records in log file

### DIFF
--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -62,6 +62,7 @@ import org.apache.carbondata.lcm.fileoperations.AtomicFileOperationsImpl;
 import org.apache.carbondata.lcm.fileoperations.FileWriteOperation;
 import org.apache.carbondata.processing.api.dataloader.DataLoadModel;
 import org.apache.carbondata.processing.api.dataloader.SchemaInfo;
+import org.apache.carbondata.processing.constants.TableOptionConstant;
 import org.apache.carbondata.processing.csvload.DataGraphExecuter;
 import org.apache.carbondata.processing.dataprocessor.DataProcessTaskStatus;
 import org.apache.carbondata.processing.dataprocessor.IDataProcessStatus;
@@ -358,9 +359,12 @@ public class StoreCreator {
     schmaModel.setCommentCharacter("#");
     info.setDatabaseName(databaseName);
     info.setTableName(tableName);
-    info.setSerializationNullFormat("serialization_null_format" + "," + "\\N");
-    info.setBadRecordsLoggerEnable("bad_records_logger_enable"+","+"false");
-    info.setBadRecordsLoggerEnable("bad_records_action"+","+"force");
+    info.setSerializationNullFormat(
+        TableOptionConstant.SERIALIZATION_NULL_FORMAT.getName() + "," + "\\N");
+    info.setBadRecordsLoggerEnable(
+        TableOptionConstant.BAD_RECORDS_LOGGER_ENABLE.getName() + "," + "false");
+    info.setBadRecordsLoggerAction(
+        TableOptionConstant.BAD_RECORDS_ACTION.getName() + "," + "force");
 
     generateGraph(schmaModel, info, loadModel.getTableName(), "0", loadModel.getSchema(), null,
         loadModel.getLoadMetadataDetails());

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoadModel.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoadModel.java
@@ -117,9 +117,9 @@ public class CarbonLoadModel implements Serializable {
   private String badRecordsLoggerEnable;
 
   /**
-   * defines the option to specify the bad record log redirect to raw csv
+   * defines the option to specify the bad record logger action
    */
-  private String badRecordsLoggerRedirect;
+  private String badRecordsAction;
 
   /**
    * Max number of columns that needs to be parsed by univocity parser
@@ -348,7 +348,7 @@ public class CarbonLoadModel implements Serializable {
     copy.segmentId = segmentId;
     copy.serializationNullFormat = serializationNullFormat;
     copy.badRecordsLoggerEnable = badRecordsLoggerEnable;
-    copy.badRecordsLoggerRedirect =badRecordsLoggerRedirect;
+    copy.badRecordsAction = badRecordsAction;
     copy.escapeChar = escapeChar;
     copy.quoteChar = quoteChar;
     copy.commentChar = commentChar;
@@ -391,7 +391,7 @@ public class CarbonLoadModel implements Serializable {
     copyObj.segmentId = segmentId;
     copyObj.serializationNullFormat = serializationNullFormat;
     copyObj.badRecordsLoggerEnable = badRecordsLoggerEnable;
-    copyObj.badRecordsLoggerRedirect =badRecordsLoggerRedirect;
+    copyObj.badRecordsAction = badRecordsAction;
     copyObj.escapeChar = escapeChar;
     copyObj.quoteChar = quoteChar;
     copyObj.commentChar = commentChar;
@@ -612,19 +612,19 @@ public class CarbonLoadModel implements Serializable {
   }
 
   /**
-   *  returns option to specify the bad record log redirect to raw csv
+   *  returns option to specify the bad record logger action
    * @return
    */
-  public String getBadRecordsLoggerRedirect() {
-    return badRecordsLoggerRedirect;
+  public String getBadRecordsAction() {
+    return badRecordsAction;
   }
 
   /**
-   * set option to specify the bad record log redirect to raw csv
-   * @param badRecordsLoggerRedirect
+   * set option to specify the bad record logger action
+   * @param badRecordsAction
    */
-  public void setBadRecordsLoggerRedirect(String badRecordsLoggerRedirect) {
-    this.badRecordsLoggerRedirect = badRecordsLoggerRedirect;
+  public void setBadRecordsAction(String badRecordsAction) {
+    this.badRecordsAction = badRecordsAction;
   }
 
   public String getRddIteratorKey() {

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/load/CarbonLoaderUtil.java
@@ -198,7 +198,7 @@ public final class CarbonLoaderUtil {
     info.setComplexDelimiterLevel2(loadModel.getComplexDelimiterLevel2());
     info.setSerializationNullFormat(loadModel.getSerializationNullFormat());
     info.setBadRecordsLoggerEnable(loadModel.getBadRecordsLoggerEnable());
-    info.setBadRecordsLoggerRedirect(loadModel.getBadRecordsLoggerRedirect());
+    info.setBadRecordsLoggerAction(loadModel.getBadRecordsAction());
 
     generateGraph(schmaModel, info, loadModel, outPutLoc);
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -54,6 +54,7 @@ import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.integration.spark.merger.CompactionType
 import org.apache.carbondata.lcm.locks.{CarbonLockFactory, LockUsage}
 import org.apache.carbondata.lcm.status.SegmentStatusManager
+import org.apache.carbondata.processing.constants.TableOptionConstant
 import org.apache.carbondata.processing.etl.DataLoadingException
 import org.apache.carbondata.spark.CarbonSparkFactory
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
@@ -1135,12 +1136,15 @@ case class LoadTable(
       carbonLoadModel.setEscapeChar(escapeChar)
       carbonLoadModel.setQuoteChar(quoteChar)
       carbonLoadModel.setCommentChar(commentchar)
-      carbonLoadModel.setSerializationNullFormat("serialization_null_format" + "," +
-        serializationNullFormat)
       carbonLoadModel
-        .setBadRecordsLoggerEnable("bad_records_logger_enable" + "," + badRecordsLoggerEnable)
+        .setSerializationNullFormat(
+          TableOptionConstant.SERIALIZATION_NULL_FORMAT.getName + "," + serializationNullFormat)
       carbonLoadModel
-        .setBadRecordsLoggerRedirect("bad_records_action" + "," + badRecordsLoggerRedirect)
+        .setBadRecordsLoggerEnable(
+          TableOptionConstant.BAD_RECORDS_LOGGER_ENABLE.getName + "," + badRecordsLoggerEnable)
+      carbonLoadModel
+        .setBadRecordsAction(
+          TableOptionConstant.BAD_RECORDS_ACTION.getName + "," + badRecordsLoggerRedirect)
 
       if (delimiter.equalsIgnoreCase(complex_delimiter_level_1) ||
           complex_delimiter_level_1.equalsIgnoreCase(complex_delimiter_level_2) ||

--- a/processing/src/main/java/org/apache/carbondata/processing/api/dataloader/SchemaInfo.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/api/dataloader/SchemaInfo.java
@@ -69,9 +69,9 @@ public class SchemaInfo {
    */
   private String badRecordsLoggerEnable;
   /**
-   * defines the option to specify whether to redirect the bad record logger to raw csv or not
+   * defines the option to specify whether to bad record logger action
    */
-  private String badRecordsLoggerRedirect;
+  private String badRecordsLoggerAction;
 
 
   public String getComplexDelimiterLevel1() {
@@ -215,18 +215,18 @@ public class SchemaInfo {
   }
 
   /**
-   * returns the option to set to redirect the badrecord logger to raw csv
+   * returns the option to set bad record logger action
    * @return
    */
-  public String getBadRecordsLoggerRedirect() {
-    return badRecordsLoggerRedirect;
+  public String getBadRecordsLoggerAction() {
+    return badRecordsLoggerAction;
   }
 
   /**
-   * set the option to set to redirect the badrecord logger to raw csv
-   * @param badRecordsLoggerRedirect
+   * set the option to set set bad record logger action
+   * @param badRecordsLoggerAction
    */
-  public void setBadRecordsLoggerRedirect(String badRecordsLoggerRedirect) {
-    this.badRecordsLoggerRedirect = badRecordsLoggerRedirect;
+  public void setBadRecordsLoggerAction(String badRecordsLoggerAction) {
+    this.badRecordsLoggerAction = badRecordsLoggerAction;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/constants/TableOptionConstant.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/constants/TableOptionConstant.java
@@ -20,21 +20,24 @@
 package org.apache.carbondata.processing.constants;
 
 /**
- * enum to hold the bad record logger action
+ * enum holds the value related to the ddl option
  */
-public enum LoggerAction {
-
-  FORCE("FORCE"), // data will be converted to null
-  REDIRECT("REDIRECT"), // no null conversion moved to bad record and written to raw csv
-  IGNORE("IGNORE"); // no null conversion moved to bad record and not written to raw csv
+public enum TableOptionConstant {
+  SERIALIZATION_NULL_FORMAT("serialization_null_format"),
+  BAD_RECORDS_LOGGER_ENABLE("bad_records_logger_enable"),
+  BAD_RECORDS_ACTION("bad_records_action");
 
   private String name;
 
-  LoggerAction(String name) {
+  /**
+   * constructor to initialize the enum value
+   * @param name
+   */
+  TableOptionConstant(String name) {
     this.name = name;
   }
 
-  @Override public String toString() {
-    return this.name;
+  public String getName() {
+    return name;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
@@ -921,7 +921,7 @@ public class GraphGenerator {
     TableOptionWrapper tableOptionWrapper = TableOptionWrapper.getTableOptionWrapperInstance();
     tableOptionWrapper.setTableOption(schemaInfo.getSerializationNullFormat());
     tableOptionWrapper.setTableOption(schemaInfo.getBadRecordsLoggerEnable());
-    tableOptionWrapper.setTableOption(schemaInfo.getBadRecordsLoggerRedirect());
+    tableOptionWrapper.setTableOption(schemaInfo.getBadRecordsLoggerAction());
     return tableOptionWrapper;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -75,6 +75,10 @@ import org.apache.carbondata.processing.schema.metadata.HierarchiesInfo;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
 
+import static org.apache.carbondata.processing.constants.TableOptionConstant.BAD_RECORDS_ACTION;
+import static org.apache.carbondata.processing.constants.TableOptionConstant.BAD_RECORDS_LOGGER_ENABLE;
+import static org.apache.carbondata.processing.constants.TableOptionConstant.SERIALIZATION_NULL_FORMAT;
+
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
@@ -439,12 +443,12 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
           data.getSurrogateKeyGen()
               .setDimensionOrdinalToDimensionMapping(populateNameToCarbonDimensionMap());
         }
-        serializationNullFormat = meta.getTableOptionWrapper().get("serialization_null_format");
-        badRecordsLoggerEnable =
-            Boolean.parseBoolean(meta.getTableOptionWrapper().get("bad_records_logger_enable"));
-        badRecordConvertNullDisable = true;
+        serializationNullFormat =
+            meta.getTableOptionWrapper().get(SERIALIZATION_NULL_FORMAT.getName());
+        badRecordsLoggerEnable = Boolean
+            .parseBoolean(meta.getTableOptionWrapper().get(BAD_RECORDS_LOGGER_ENABLE.getName()));
         String bad_records_action =
-            meta.getTableOptionWrapper().get("bad_records_action");
+            meta.getTableOptionWrapper().get(BAD_RECORDS_ACTION.getName());
         if(null != bad_records_action) {
           LoggerAction loggerAction = null;
           try {
@@ -458,9 +462,11 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
               break;
             case REDIRECT:
               badRecordsLogRedirect = true;
+              badRecordConvertNullDisable = true;
               break;
             case IGNORE:
               badRecordsLogRedirect = false;
+              badRecordConvertNullDisable = true;
               break;
           }
         }


### PR DESCRIPTION
**Poblem**
For HDFS file system 
CarbonFile logFile = FileFactory.getCarbonFile(filePath, FileType.HDFS);
if filePath does not exits then
Calling CarbonFile.getPath() throws NullPointerException.
**Solution:**
If file does not exist then before accessing the file must be created first.

As part of this PR have done some code improvement related to bad record logging.