### PR TITLE
[CARBONDATA-290]Fix path not found when part of table name  has database Name

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
@@ -21,6 +21,7 @@ package org.apache.carbondata.core.carbon;
 import java.io.File;
 import java.io.Serializable;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
 
 /**
@@ -72,7 +73,8 @@ public class AbsoluteTableIdentifier implements Serializable {
 
     String tableName = names[names.length - 1];
     String dbName = names[names.length - 2];
-    String storePath = tablePath.substring(0, tablePath.lastIndexOf(dbName));
+    String storePath = tablePath.substring(0, tablePath.lastIndexOf(dbName +
+            CarbonCommonConstants.FILE_SEPARATOR + tableName));
 
     CarbonTableIdentifier identifier =
         new CarbonTableIdentifier(dbName, tableName, Long.toString(System.currentTimeMillis()));

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestTableNameHasDbName.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestTableNameHasDbName.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.allqueries
+
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/*
+ * Test Class for query when part of tableName has dbName
+ *
+ */
+class TestTableNameHasDbName extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("DROP TABLE IF EXISTS tabledefault")
+    sql("CREATE TABLE tabledefault (empno int, workgroupcategory string, " +
+      "deptno int, projectcode int,attendance int)" +
+      " STORED BY 'org.apache.carbondata.format'")
+    sql("LOAD DATA LOCAL INPATH './src/test/resources/data.csv' INTO TABLE tabledefault")
+  }
+
+  test("test query when part of tableName has dbName") {
+    try {
+      sql("SELECT * FROM tabledefault").collect()
+    } catch {
+      case ex: Exception =>
+        assert(false)
+    }
+  }
+
+  override def afterAll {
+    sql("DROP TABLE tabledefault")
+  }
+
+}
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CARBONDATA-290


this issue is because when part of table name has database name, then substring(0, tablePath.lastIndexOf(dbName))  can not get the correct store path, so will cause segment path not found.
regarding that table name will have no '/', so we can use this to get substring.



testcase addded, CI passed
http://136.243.101.176:8080/job/ApacheCarbonManualPRBuilder/397/


