### PR TITLE
[CARBONDATA-291] All STATISTIC log shouble be configurable

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatistic.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/querystatistics/QueryStatistic.java
@@ -20,6 +20,8 @@ package org.apache.carbondata.core.carbon.querystatistics;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Wrapper class to maintain the query statistics for each phase of the query
  */
@@ -91,6 +93,9 @@ public class QueryStatistic implements Serializable {
    * @return statistic message
    */
   public String getStatistics(String queryWithTaskId) {
+    if (StringUtils.isEmpty(queryWithTaskId)) {
+      return message + timeTaken;
+    }
     return message + " for the taskid : " + queryWithTaskId + " Is : " + timeTaken;
   }
 


### PR DESCRIPTION
# Why raise this pr?
There are Some STATISTIC logs still present even though disable STATISTIC

# How to solve?
Using QueryStatisticRecorder for STATISTIC log, so we can configurate it to print or not  uniformly,