### PR TITLE
[CARBONDATA-221] Fix the bug of inverted index that store inverted index in metadata by using Encoding.INVERTED_INDEX.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
@@ -75,11 +75,6 @@ public class ColumnSchema implements Serializable {
   private boolean isDimensionColumn;
 
   /**
-   * Whether the column should use inverted index
-   */
-  private boolean useInvertedIndex = true;
-
-  /**
    * The group ID for column used for row format columns,
    * where in columns in each group are chunked together.
    */
@@ -181,14 +176,22 @@ public class ColumnSchema implements Serializable {
    * the isUseInvertedIndex
    */
   public boolean isUseInvertedIndex() {
-    return useInvertedIndex;
+    return this.hasEncoding(Encoding.INVERTED_INDEX);
   }
 
   /**
    * @param useInvertedIndex the useInvertedIndex to set
    */
   public void setUseInvertedIndex(boolean useInvertedIndex) {
-    this.useInvertedIndex = useInvertedIndex;
+    if (useInvertedIndex) {
+      if (!hasEncoding(Encoding.INVERTED_INDEX)) {
+        this.getEncodingList().add(Encoding.INVERTED_INDEX);
+      }
+    } else {
+      if (hasEncoding(Encoding.INVERTED_INDEX)) {
+        this.getEncodingList().remove(Encoding.INVERTED_INDEX);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -719,6 +719,7 @@ public final class CarbonCommonConstants {
   public static final String COLUMN_PROPERTIES = "columnproperties";
   // table block size in MB
   public static final String TABLE_BLOCKSIZE = "table_blocksize";
+  public static final String NO_INVERTED_INDEX = "no_inverted_index";
 
   /**
    * this variable is to enable/disable identify high cardinality during first data loading

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -240,7 +240,9 @@ public class CarbonMetadataUtil {
       if (!isSortedKeyColumn[i]) {
         dataChunk.setRowid_page_offset(blockletInfoColumnar.getKeyBlockIndexOffSets()[j]);
         dataChunk.setRowid_page_length(blockletInfoColumnar.getKeyBlockIndexLength()[j]);
-        encodings.add(Encoding.INVERTED_INDEX);
+        if (!encodings.contains(Encoding.INVERTED_INDEX)) {
+          encodings.add(Encoding.INVERTED_INDEX);
+        }
         j++;
       }
 

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -39,7 +39,6 @@ object CarbonExample {
            (ID Int, date Timestamp, country String,
            name String, phonetype String, serialname String, salary Int)
            STORED BY 'carbondata'
-           TBLPROPERTIES('NO_INVERTED_INDEX'='country,name,phonetype')
            """)
 
     // Currently there are two data loading flows in CarbonData, one uses Kettle as ETL tool

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -39,6 +39,7 @@ object CarbonExample {
            (ID Int, date Timestamp, country String,
            name String, phonetype String, serialname String, salary Int)
            STORED BY 'carbondata'
+           TBLPROPERTIES('NO_INVERTED_INDEX'='country,name,phonetype')
            """)
 
     // Currently there are two data loading flows in CarbonData, one uses Kettle as ETL tool

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -723,9 +723,9 @@ class CarbonSqlParser() extends AbstractSparkSQLParser {
     var noInvertedIdxColsProps: Array[String] = Array[String]()
     var noInvertedIdxCols: Seq[String] = Seq[String]()
 
-    if (tableProperties.get("NO_INVERTED_INDEX").isDefined) {
+    if (tableProperties.get(CarbonCommonConstants.NO_INVERTED_INDEX).isDefined) {
       noInvertedIdxColsProps =
-        tableProperties.get("NO_INVERTED_INDEX").get.split(',').map(_.trim)
+        tableProperties.get(CarbonCommonConstants.NO_INVERTED_INDEX).get.split(',').map(_.trim)
       noInvertedIdxColsProps
         .map { noInvertedIdxColProp =>
           if (!fields.exists(x => x.column.equalsIgnoreCase(noInvertedIdxColProp))) {

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -48,6 +48,7 @@ import org.apache.carbondata.common.logging.impl.StandardLogService;
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
 import org.apache.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
+import org.apache.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
@@ -1941,7 +1942,8 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
       dimListExcludingNoDictionaryColumn =
           new ArrayList<>(dimensionsList.size() - meta.noDictionaryCols.length);
       for (CarbonDimension dimension : dimensionsList) {
-        if (!dimension.getEncoder().isEmpty()) {
+        if (!dimension.getEncoder().isEmpty() && !((1 == dimension.getEncoder().size()) &&
+            dimension.getEncoder().contains(Encoding.INVERTED_INDEX))) {
           dimListExcludingNoDictionaryColumn.add(dimension);
         }
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -1942,6 +1942,8 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
       dimListExcludingNoDictionaryColumn =
           new ArrayList<>(dimensionsList.size() - meta.noDictionaryCols.length);
       for (CarbonDimension dimension : dimensionsList) {
+        // Here if dimension.getEncoder() lnly contains Encoding.INVERTED_INDEX, it
+        // means that NoDicColumn using InvertedIndex, so not put it into dic dims list.
         if (!dimension.getEncoder().isEmpty() && !((1 == dimension.getEncoder().size()) &&
             dimension.getEncoder().contains(Encoding.INVERTED_INDEX))) {
           dimListExcludingNoDictionaryColumn.add(dimension);


### PR DESCRIPTION
## Why raise this pr?
1. Problem: In current code, inverted index in ddl info is not stored into store, and when we restart the cluster, query might mismatch.
2. To fix problem 1, current code set always true to use inverted index, and we can not configure inverted index now. We should fix this problem from its root cause.
## How to solve?

Using the Encoding as the indentifier to check whether using inverted index, this Encoding is in thrift format now, so we no need to modify the thrift format.

Here it is the same to the query logic in  CompressedDimensionChunkFileBasedReader:

```
    if (CarbonUtil.hasEncoding(dimensionColumnChunk.get(blockIndex).getEncodingList(),
        Encoding.INVERTED_INDEX)) {
      invertedIndexes = CarbonUtil
          .getUnCompressColumnIndex(dimensionColumnChunk.get(blockIndex).getRowIdPageLength(),
              fileReader.readByteArray(filePath,
                  dimensionColumnChunk.get(blockIndex).getRowIdPageOffset(),
                  dimensionColumnChunk.get(blockIndex).getRowIdPageLength()), numberComressor);
      // get the reverse index
      invertedIndexesReverse = getInvertedReverseIndex(invertedIndexes);
    }
```

it also use  Encoding.INVERTED_INDEX to check whether one column is use inverted index.
## How to test?

Pass all the test cases.
