### PR TITLE
[CARBONDATA-295]Abstract Compressor interface and let Snappy interface extends from Compressor

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/SnappyCompression.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/SnappyCompression.java
@@ -36,7 +36,7 @@ public class SnappyCompression {
   /**
    * SnappyByteCompression.
    */
-  public static enum SnappyByteCompression implements Compressor<byte[]> {
+  public static enum SnappyByteCompression implements SnappyCompressor<byte[]> {
     /**
      *
      */
@@ -72,7 +72,7 @@ public class SnappyCompression {
   /**
    * enum class for SnappyDoubleCompression.
    */
-  public static enum SnappyDoubleCompression implements Compressor<double[]> {
+  public static enum SnappyDoubleCompression implements SnappyCompressor<double[]> {
     /**
      *
      */
@@ -112,7 +112,7 @@ public class SnappyCompression {
    *
    * @author S71955
    */
-  public static enum SnappyShortCompression implements Compressor<short[]> {
+  public static enum SnappyShortCompression implements SnappyCompressor<short[]> {
     /**
      *
      */
@@ -152,7 +152,7 @@ public class SnappyCompression {
   /**
    * enum class for SnappyIntCompression.
    */
-  public static enum SnappyIntCompression implements Compressor<int[]> {
+  public static enum SnappyIntCompression implements SnappyCompressor<int[]> {
     /**
      *
      */
@@ -192,7 +192,7 @@ public class SnappyCompression {
   /**
    * enum class for SnappyLongCompression.
    */
-  public static enum SnappyLongCompression implements Compressor<long[]> {
+  public static enum SnappyLongCompression implements SnappyCompressor<long[]> {
     /**
      *
      */
@@ -233,7 +233,7 @@ public class SnappyCompression {
    * enum class for SnappyFloatCompression.
    */
 
-  public static enum SnappyFloatCompression implements Compressor<float[]> {
+  public static enum SnappyFloatCompression implements SnappyCompressor<float[]> {
     /**
      *
      */

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/SnappyCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/SnappyCompressor.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.carbondata.core.datastorage.store.compression;
+
+interface SnappyCompressor<T> extends Compressor<T> {
+
+  @Override byte[] compress(T input);
+
+  @Override T unCompress(byte[] input);
+}


### PR DESCRIPTION
## Why raise this pr?
Currently, we only have snappy compressor who extends form Compressor interface, for future expansion, we need to abstract Snappy interface and seperate it from Compressor interface, it means `Compressor interface is the parent of all compressors, and SnappyCompressor interface and the other compressor's interface(or abstract class) should extends Compressor interface, as to different data type for different compressor, it would extend its own interface/abstract class.`

For example: Compressor -> SnappyCompressor ->  SnappyDoubleCompression.

In the future, we can define abstract class B for other compressor who extends from Compressor A, and define compressors implimentations C1/C2/C3/C4 .etc for this kind of compressor.

## How to test?
Pass all the test cases.