### PR TITLE
[CARBONDATA-304] Fixed data loading failure when set table_blocksize=2048

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -197,8 +197,9 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     blockIndexInfoList = new ArrayList<>();
     // get max file size;
     CarbonProperties propInstance = CarbonProperties.getInstance();
-    this.fileSizeInBytes = blocksize * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR
-        * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR * 1L;
+    // if blocksize=2048, then 2048*1024*1024 will beyond the range of Int
+    this.fileSizeInBytes = 1L * blocksize * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR
+        * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR;
     this.spaceReservedForBlockMetaSize = Integer.parseInt(propInstance
         .getProperty(CarbonCommonConstants.CARBON_BLOCK_META_RESERVED_SPACE,
             CarbonCommonConstants.CARBON_BLOCK_META_RESERVED_SPACE_DEFAULT));

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -198,7 +198,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     // get max file size;
     CarbonProperties propInstance = CarbonProperties.getInstance();
     // if blocksize=2048, then 2048*1024*1024 will beyond the range of Int
-    this.fileSizeInBytes = 1L * blocksize * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR
+    this.fileSizeInBytes = (long) blocksize * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR
         * CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR;
     this.spaceReservedForBlockMetaSize = Integer.parseInt(propInstance
         .getProperty(CarbonCommonConstants.CARBON_BLOCK_META_RESERVED_SPACE,


### PR DESCRIPTION
# Why raise this pr?
Load data failure when set table_blocksize=2048
# How to solve?
if blocksize=2048, then `2048 * 1024 * 1024` will beyond the range of Int, the result is `-2147483648`, so it will use the file size as block size. But once the file size is smaller than `1Mb (dfs.namenode.fs-limits.min-block-size 1048576) ` , create hdfs file failed.
So use `1L * 2048 * 1024 * 1024` instead of` 2048 * 1024 * 1024 * 1L`