### PR TITLE
[CARBONDATA-310]Fixed compilation failure when using spark 1.6.2

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule


### PR DESCRIPTION
# Why raise this pr?
Compilation failed when using spark 1.6.2, because class not found: AggregateExpression
# How to solve?
Once Removing the import "import org.apache.spark.sql.catalyst.expressions.aggregate._" will cause compilation failure when using Spark 1.6.2, in which AggregateExpression is moved to subpackage "aggregate". So neeed changing it back.

Thanks for you remind, @harperjiang