### PR TITLE
[CARBONDATA-305] Add load option for new loading flow

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -123,7 +123,8 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) extends Logging {
       Map(("fileheader" -> header)),
       false,
       null,
-      Some(dataFrame)).run(cc)
+      Some(dataFrame),
+      options.useKettle).run(cc)
   }
 
   private def csvPackage: String = "com.databricks.spark.csv.newapi"

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
@@ -42,4 +42,5 @@ class CarbonOption(options: Map[String, String]) {
 
   def compress: Boolean = options.getOrElse("compress", "false").toBoolean
 
+  def useKettle: Boolean = options.getOrElse("useKettle", "true").toBoolean
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -667,7 +667,7 @@ object CarbonDataRDDFactory extends Logging {
       columinar: Boolean,
       isAgg: Boolean,
       partitionStatus: String = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS,
-      dataFrame: Option[DataFrame] = None) {
+      dataFrame: Option[DataFrame] = None): Unit = {
     val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
 
     // for handling of the segment Merging.

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -227,12 +227,12 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
       case ShowLoadsCommand(databaseName, table, limit) =>
         ExecutedCommand(ShowLoads(databaseName, table, limit, plan.output)) :: Nil
       case LoadTable(databaseNameOp, tableName, factPathFromUser, dimFilesPath,
-      partionValues, isOverwriteExist, inputSqlString, _) =>
+      options, isOverwriteExist, inputSqlString, dataFrame, useKettle) =>
         val isCarbonTable = CarbonEnv.getInstance(sqlContext).carbonCatalog
             .tableExists(TableIdentifier(tableName, databaseNameOp))(sqlContext)
-        if (isCarbonTable || partionValues.nonEmpty) {
-          ExecutedCommand(LoadTable(databaseNameOp, tableName, factPathFromUser,
-            dimFilesPath, partionValues, isOverwriteExist, inputSqlString)) :: Nil
+        if (isCarbonTable || options.nonEmpty) {
+          ExecutedCommand(LoadTable(databaseNameOp, tableName, factPathFromUser, dimFilesPath,
+            options, isOverwriteExist, inputSqlString, dataFrame, useKettle)) :: Nil
         } else {
           ExecutedCommand(HiveNativeCommand(inputSqlString)) :: Nil
         }


### PR DESCRIPTION
Added new option for SQL and dataframe.write
- For SQL, option is: `USE_KETTLE`, default value is true
- For dataframe, option is `useKettle`, default value is true

like:
`LOAD DATA INPATH 'path' INTO TABLE t1 OPTIONS("USE_KETTLE"="false")`

`df.write.format("carbondata").option("useKettle", "false").save`
