### PR TITLE
[CARBONDATA-321] If user changes the blocklet size the queries will b…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/keygenerator/mdkey/NumberCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/keygenerator/mdkey/NumberCompressor.java
@@ -42,6 +42,11 @@ public class NumberCompressor {
 
   public NumberCompressor(int cardinaity) {
     bitsLength = (byte) Long.toBinaryString(cardinaity).length();
+    int div = bitsLength / 8;
+    int mod = bitsLength % 8;
+    if (mod > 0) {
+      bitsLength = (byte)(8 * (div + 1));
+    }
   }
 
   public byte[] compress(int[] keys) {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/BlockletSizeTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/BlockletSizeTest.scala
@@ -1,0 +1,34 @@
+package org.apache.carbondata.spark.testsuite.filterexpr
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+import org.apache.carbondata.core.util.CarbonProperties
+
+class BlockletSizeTest extends QueryTest with BeforeAndAfterAll {
+  
+  
+  override def beforeAll {
+
+    CarbonProperties.getInstance()
+      .addProperty("carbon.blocklet.size", "50")
+     sql("CREATE TABLE all_carbon_blockletsize (empno int, empname String, designation String, doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+    sql("LOAD DATA local inpath './src/test/resources/data.csv' INTO TABLE all_carbon_blockletsize OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '\"')");
+    
+    sql("CREATE TABLE all_hives_blockletsize (empno int, empname String, designation String, doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,utilization int,salary int)row format delimited fields terminated by ','")
+    sql("LOAD DATA local inpath './src/test/resources/datawithoutheader.csv' INTO TABLE all_hives_blockletsize");
+
+  }
+      test("select empno,empname from alldatatypescubeFilter where regexp_replace(workgroupcategoryname, 'er', 'ment') != 'development' for diff blocklet sizes") {
+    checkAnswer(
+      sql("select empno,empname from all_carbon_blockletsize where regexp_replace(workgroupcategoryname, 'er', 'ment') != 'development'"),
+      sql("select empno,empname from all_hives_blockletsize where regexp_replace(workgroupcategoryname, 'er', 'ment') != 'development'"))
+        }
+  override def afterAll {
+
+    sql("drop table all_carbon_blockletsize")
+    sql("drop table all_hives_blockletsize")
+  }
+  
+}


### PR DESCRIPTION
**Problem:**
If user changes the blocklet size (50) the queries will be failed.
Currently byte size calculation in number compressor is 
int array length * bit length=x
bytesize= x/8+x%8;
when cardinality is 50
then byte size will be 3
but to calculate the actual int array size of index reverse based on the reverse calculation it is coming 4
int arrayLength=(3*8)/6
**Solution:**
We need to round off bit length to nearest value which should be divisible by 8

