### PR TITLE
CARBONDATA-330: Fix compiler warnings

### DIFF
--- a/common/src/test/java/org/apache/carbondata/common/logging/impl/AuditExtendedRollingFileAppenderTest_UT.java
+++ b/common/src/test/java/org/apache/carbondata/common/logging/impl/AuditExtendedRollingFileAppenderTest_UT.java
@@ -19,7 +19,7 @@
 
 package org.apache.carbondata.common.logging.impl;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import mockit.Deencapsulation;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;

--- a/common/src/test/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppenderTest_UT.java
+++ b/common/src/test/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppenderTest_UT.java
@@ -19,7 +19,7 @@
 
 package org.apache.carbondata.common.logging.impl;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import mockit.Deencapsulation;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -35,7 +35,7 @@ import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonDime
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
-import org.apache.commons.lang.NumberUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public final class DataTypeUtil {

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputFormat_FT.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputFormat_FT.java
@@ -51,7 +51,8 @@ public class CarbonInputFormat_FT extends TestCase {
   @Test public void testGetSplits() throws Exception {
     CarbonInputFormat carbonInputFormat = new CarbonInputFormat();
     JobConf jobConf = new JobConf(new Configuration());
-    Job job = new Job(jobConf);
+    Job job = Job.getInstance(jobConf);
+    //Job job = new Job(jobConf);
     FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/db/table1"));
     job.getConfiguration().set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, "1,2");
     List splits = carbonInputFormat.getSplits(job);
@@ -63,7 +64,7 @@ public class CarbonInputFormat_FT extends TestCase {
   @Test public void testGetFilteredSplits() throws Exception {
     CarbonInputFormat carbonInputFormat = new CarbonInputFormat();
     JobConf jobConf = new JobConf(new Configuration());
-    Job job = new Job(jobConf);
+    Job job = Job.getInstance(jobConf);
     FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/db/table1"));
     job.getConfiguration().set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, "1,2");
     Expression expression = new EqualToExpression(new ColumnExpression("c1", DataType.STRING),

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputFormat_FT.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputFormat_FT.java
@@ -52,7 +52,6 @@ public class CarbonInputFormat_FT extends TestCase {
     CarbonInputFormat carbonInputFormat = new CarbonInputFormat();
     JobConf jobConf = new JobConf(new Configuration());
     Job job = Job.getInstance(jobConf);
-    //Job job = new Job(jobConf);
     FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/db/table1"));
     job.getConfiguration().set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, "1,2");
     List splits = carbonInputFormat.getSplits(job);

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -223,7 +223,7 @@ case class CarbonDictionaryDecoder(
             atiMap.get(f._1).get.getCarbonTableIdentifier,
             f._2, f._3))
         } catch {
-          case _ => null
+          case _ : Throwable => null
         }
       } else {
         null

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -223,7 +223,7 @@ case class CarbonDictionaryDecoder(
             atiMap.get(f._1).get.getCarbonTableIdentifier,
             f._2, f._3))
         } catch {
-          case _:Throwable => null
+          case _: Throwable => null
         }
       } else {
         null

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -223,7 +223,7 @@ case class CarbonDictionaryDecoder(
             atiMap.get(f._1).get.getCarbonTableIdentifier,
             f._2, f._3))
         } catch {
-          case _ : Throwable => null
+          case _:Throwable => null
         }
       } else {
         null

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSQLDialect.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSQLDialect.scala
@@ -37,7 +37,7 @@ private[spark] class CarbonSQLDialect(hiveContext: HiveContext) extends ParserDi
       // because hive can no parse carbon command
       case ce: MalformedCarbonCommandException =>
         throw ce
-      case _ =>
+      case _ : Throwable =>
         HiveQl.parseSql(sqlText)
     }
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSQLDialect.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSQLDialect.scala
@@ -37,7 +37,7 @@ private[spark] class CarbonSQLDialect(hiveContext: HiveContext) extends ParserDi
       // because hive can no parse carbon command
       case ce: MalformedCarbonCommandException =>
         throw ce
-      case _ : Throwable =>
+      case _: Throwable =>
         HiveQl.parseSql(sqlText)
     }
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
@@ -154,7 +154,7 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
       assert(false)
     }
     catch {
-      case _ : Throwable => assert(true)
+      case _:Throwable => assert(true)
     }
     val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
         AbsoluteTableIdentifier(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
@@ -154,7 +154,7 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
       assert(false)
     }
     catch {
-      case _ => assert(true)
+      case _ : Throwable => assert(true)
     }
     val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
         AbsoluteTableIdentifier(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
@@ -54,7 +54,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/character_carbon.csv' into table max_columns_test options('MAXCOLUMNS'='avfgd')")
       assert(false)
     } catch {
-      case _ : Throwable => assert(true)
+      case _: Throwable => assert(true)
     }
   }
 
@@ -66,7 +66,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       checkAnswer(sql("select count(*) from valid_max_columns_test"),
         sql("select count(*) from hive_char_test"))
     } catch {
-      case _ : Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -83,7 +83,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
     } catch {
       case me: MalformedCarbonCommandException =>
         assert(false)
-      case _ :Throwable => assert(true)
+      case _: Throwable => assert(true)
     }
   }
 
@@ -95,7 +95,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       checkAnswer(sql("select count(*) from valid_max_columns_test"),
         sql("select count(*) from hive_char_test"))
     } catch {
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -111,7 +111,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/data.csv' into table boundary_max_columns_test options('MAXCOLUMNS'='14')")
       assert(true)
     } catch {
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -127,7 +127,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/data.csv' into table boundary_max_columns_test options('MAXCOLUMNS'='13')")
       assert(true)
     } catch {
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
@@ -54,7 +54,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/character_carbon.csv' into table max_columns_test options('MAXCOLUMNS'='avfgd')")
       assert(false)
     } catch {
-      case _ => assert(true)
+      case _ : Throwable => assert(true)
     }
   }
 
@@ -66,7 +66,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       checkAnswer(sql("select count(*) from valid_max_columns_test"),
         sql("select count(*) from hive_char_test"))
     } catch {
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -83,7 +83,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
     } catch {
       case me: MalformedCarbonCommandException =>
         assert(false)
-      case _ => assert(true)
+      case _ : Throwable => assert(true)
     }
   }
 
@@ -95,7 +95,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       checkAnswer(sql("select count(*) from valid_max_columns_test"),
         sql("select count(*) from hive_char_test"))
     } catch {
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -111,7 +111,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/data.csv' into table boundary_max_columns_test options('MAXCOLUMNS'='14')")
       assert(true)
     } catch {
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -127,7 +127,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/data.csv' into table boundary_max_columns_test options('MAXCOLUMNS'='13')")
       assert(true)
     } catch {
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
@@ -83,7 +83,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
     } catch {
       case me: MalformedCarbonCommandException =>
         assert(false)
-      case _ : Throwable => assert(true)
+      case _ :Throwable => assert(true)
     }
   }
 
@@ -95,7 +95,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       checkAnswer(sql("select count(*) from valid_max_columns_test"),
         sql("select count(*) from hive_char_test"))
     } catch {
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -111,7 +111,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/data.csv' into table boundary_max_columns_test options('MAXCOLUMNS'='14')")
       assert(true)
     } catch {
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -127,7 +127,7 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
       sql("LOAD DATA LOCAL INPATH './src/test/resources/data.csv' into table boundary_max_columns_test options('MAXCOLUMNS'='13')")
       assert(true)
     } catch {
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
@@ -100,7 +100,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_INCLUDE column: aaa does not exist in table. " +
           "Please check create table statement."))
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -111,7 +111,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
           "with DICTIONARY_INCLUDE. Please check create table statement."))
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -123,7 +123,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("Error: Invalid option(s): delimiterrr"))
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -135,7 +135,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("Error: Duplicate option(s): delimiter"))
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -146,7 +146,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
           "TestLoadTableOptions options('DeLIMITEr'=',', 'qUOtECHAR'='\"')"
       )
     } catch {
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -157,7 +157,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
           "with DICTIONARY_INCLUDE. Please check create table statement."))
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
@@ -89,7 +89,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE column: ccc does not exist in table. " +
           "Please check create table statement."))
-      case _ : Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -100,7 +100,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_INCLUDE column: aaa does not exist in table. " +
           "Please check create table statement."))
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -111,7 +111,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
           "with DICTIONARY_INCLUDE. Please check create table statement."))
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -123,7 +123,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("Error: Invalid option(s): delimiterrr"))
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -135,7 +135,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("Error: Duplicate option(s): delimiter"))
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -146,7 +146,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
           "TestLoadTableOptions options('DeLIMITEr'=',', 'qUOtECHAR'='\"')"
       )
     } catch {
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -157,7 +157,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
           "with DICTIONARY_INCLUDE. Please check create table statement."))
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
@@ -89,7 +89,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE column: ccc does not exist in table. " +
           "Please check create table statement."))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -100,7 +100,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_INCLUDE column: aaa does not exist in table. " +
           "Please check create table statement."))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -111,7 +111,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
           "with DICTIONARY_INCLUDE. Please check create table statement."))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -123,7 +123,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("Error: Invalid option(s): delimiterrr"))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -135,7 +135,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("Error: Duplicate option(s): delimiter"))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -146,7 +146,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
           "TestLoadTableOptions options('DeLIMITEr'=',', 'qUOtECHAR'='\"')"
       )
     } catch {
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -157,7 +157,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
           "with DICTIONARY_INCLUDE. Please check create table statement."))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
@@ -183,7 +183,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.contains("should not be empty"))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -221,7 +221,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.contains("Invalid load start time format"))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
 
     try {
@@ -232,7 +232,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.contains("Invalid load start time format"))
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
 
     checkAnswer(
@@ -258,7 +258,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ => assert(true)
+      case _ : Throwable => assert(true)
     }
 
     try {
@@ -267,7 +267,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ => assert(true)
+      case _ : Throwable => assert(true)
     }
 
     try {
@@ -276,7 +276,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ => assert(true)
+      case _ : Throwable => assert(true)
     }
 
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
@@ -183,7 +183,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.contains("should not be empty"))
-      case _ : Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -221,7 +221,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.contains("Invalid load start time format"))
-      case _ : Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
 
     try {
@@ -232,7 +232,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(e.getMessage.contains("Invalid load start time format"))
-      case _ : Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
 
     checkAnswer(
@@ -258,7 +258,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ :Throwable => assert(true)
+      case _: Throwable => assert(true)
     }
 
     try {
@@ -267,7 +267,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ :Throwable => assert(true)
+      case _: Throwable => assert(true)
     }
 
     try {
@@ -276,7 +276,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ : Throwable => assert(true)
+      case _: Throwable => assert(true)
     }
 
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
@@ -258,7 +258,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ : Throwable => assert(true)
+      case _ :Throwable => assert(true)
     }
 
     try {
@@ -267,7 +267,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e: MalformedCarbonCommandException =>
         assert(!e.getMessage.equalsIgnoreCase("Invalid query"))
-      case _ : Throwable => assert(true)
+      case _ :Throwable => assert(true)
     }
 
     try {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ColumnPropertyValidationTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ColumnPropertyValidationTestCase.scala
@@ -30,7 +30,7 @@ class ColumnPropertyValidationTestCase extends QueryTest with BeforeAndAfterAll 
        assert(true)
        sql("drop table employee")
      } catch {
-       case e : Throwable =>assert(false)
+       case e :Throwable =>assert(false)
      }
   }
   test("Validate Dictionary include _ invalid key") {
@@ -39,7 +39,7 @@ class ColumnPropertyValidationTestCase extends QueryTest with BeforeAndAfterAll 
        assert(false)
        sql("drop table employee")
      } catch {
-       case e : Throwable =>assert(true)
+       case e :Throwable =>assert(true)
      }
   }
   

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ColumnPropertyValidationTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ColumnPropertyValidationTestCase.scala
@@ -30,7 +30,7 @@ class ColumnPropertyValidationTestCase extends QueryTest with BeforeAndAfterAll 
        assert(true)
        sql("drop table employee")
      } catch {
-       case e =>assert(false)
+       case e : Throwable =>assert(false)
      }
   }
   test("Validate Dictionary include _ invalid key") {
@@ -39,7 +39,7 @@ class ColumnPropertyValidationTestCase extends QueryTest with BeforeAndAfterAll 
        assert(false)
        sql("drop table employee")
      } catch {
-       case e =>assert(true)
+       case e : Throwable =>assert(true)
      }
   }
   

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ColumnPropertyValidationTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ColumnPropertyValidationTestCase.scala
@@ -30,7 +30,7 @@ class ColumnPropertyValidationTestCase extends QueryTest with BeforeAndAfterAll 
        assert(true)
        sql("drop table employee")
      } catch {
-       case e :Throwable =>assert(false)
+       case e: Throwable =>assert(false)
      }
   }
   test("Validate Dictionary include _ invalid key") {
@@ -39,7 +39,7 @@ class ColumnPropertyValidationTestCase extends QueryTest with BeforeAndAfterAll 
        assert(false)
        sql("drop table employee")
      } catch {
-       case e :Throwable =>assert(true)
+       case e: Throwable =>assert(true)
      }
   }
   

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -82,7 +82,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex:Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
 
     try {
@@ -92,7 +92,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex:Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
 
     try {
@@ -107,7 +107,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex:Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 
@@ -221,7 +221,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
       case ex: MalformedCarbonCommandException =>
         assertResult(ex.getMessage)("Error: COLUMNDICT and ALL_DICTIONARY_PATH can not be used together " +
           "in options")
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 
@@ -236,7 +236,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
       case ex: DataLoadingException =>
         assertResult(ex.getMessage)("Column gamePointId is not a key column. Only key column can be part " +
           "of dictionary and used in COLUMNDICT option.")
-      case _ : Throwable => assert(false)
+      case _ :Throwable => assert(false)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -82,7 +82,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex:Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
 
     try {
@@ -92,7 +92,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex:Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
 
     try {
@@ -107,7 +107,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex:Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 
@@ -221,7 +221,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
       case ex: MalformedCarbonCommandException =>
         assertResult(ex.getMessage)("Error: COLUMNDICT and ALL_DICTIONARY_PATH can not be used together " +
           "in options")
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 
@@ -236,7 +236,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
       case ex: DataLoadingException =>
         assertResult(ex.getMessage)("Column gamePointId is not a key column. Only key column can be part " +
           "of dictionary and used in COLUMNDICT option.")
-      case _ :Throwable => assert(false)
+      case _: Throwable => assert(false)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -221,7 +221,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
       case ex: MalformedCarbonCommandException =>
         assertResult(ex.getMessage)("Error: COLUMNDICT and ALL_DICTIONARY_PATH can not be used together " +
           "in options")
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 
@@ -236,7 +236,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
       case ex: DataLoadingException =>
         assertResult(ex.getMessage)("Column gamePointId is not a key column. Only key column can be part " +
           "of dictionary and used in COLUMNDICT option.")
-      case _ => assert(false)
+      case _ : Throwable => assert(false)
     }
   }
 


### PR DESCRIPTION

    Removed some compilation warnings in Java code and scala tests.
    Not all warning can be removed at this point as some them may require code change that may impact the functionality.

    **Please provide details on**
    **- Whether new unit test cases have been added or why no new tests are required?**
    Not Required. No change in functionality.
    **- What manual testing you have done?**
    Basic carbon examples + "mvn clean verify"
    **- Any additional information to help reviewers in testing this change.**
    No
                 
---

