### PR TITLE
trivial fix in documentation

### DIFF
--- a/docs/Quick-Start.md
+++ b/docs/Quick-Start.md
@@ -59,7 +59,7 @@ scala>cc.sql("create table if not exists test_table (id string, name string, cit
 **Load data to table**
 ```
 scala>val dataFilePath = new File("../carbondata/sample.csv").getCanonicalPath
-scala>cc.sql("load data inpath '$dataFilePath' into table test_table")
+scala>cc.sql(s"load data inpath '$dataFilePath' into table test_table")
 ```
 
 **Query data from table**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is too trivial so i didn't create JIRA task.
In Quick Start Guide there is use of string interpolation to create the file but while we are using it in SQL without using 's' before the string to apply string interpolation.

## How was this patch tested?
Manually tested it by run the string manipulation on carbon-spark-shell