### PR TITLE
[CARBONDATA-326] Create wrong table using 'create table like'

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -107,6 +107,7 @@ case class DropDatabase(dbName: String, isCascade: Boolean, sql: String)
 }
 
 /**
+<<<<<<< 28eb96f84af708e273d5dcab0859952c08f5aac9
  * A logical plan representing insertion into Hive table.
  * This plan ignores nullability of ArrayType, MapType, StructType unlike InsertIntoTable
  * because Hive table doesn't have nullability for ARRAY, MAP, STRUCT types.

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -125,4 +125,21 @@ case class InsertIntoCarbonTable(
   // This is the expected schema of the table prepared to be inserted into,
   // including dynamic partition columns.
   val tableOutput = table.carbonRelation.output
+
+}
+
+/**
+ * Here the syntax is 'CREATE TABLE target LIKE src'.
+ *
+ * @param likeTableName the src table's name, used to create target table, should check
+ *                      whether the src table is carbon table.
+ * @param createHiveLikeTableSql the sql string only used to create hive target table.
+ */
+case class CreateLikeTable(likeTableName: String, createHiveLikeTableSql: String)
+  extends LogicalPlan with Command {
+
+  override def children: Seq[LogicalPlan] = Seq.empty
+
+  override def output: Seq[Attribute] = Seq.empty
+
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -107,7 +107,6 @@ case class DropDatabase(dbName: String, isCascade: Boolean, sql: String)
 }
 
 /**
-<<<<<<< 28eb96f84af708e273d5dcab0859952c08f5aac9
  * A logical plan representing insertion into Hive table.
  * This plan ignores nullability of ArrayType, MapType, StructType unlike InsertIntoTable
  * because Hive table doesn't have nullability for ARRAY, MAP, STRUCT types.

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -22,17 +22,15 @@ import java.text.SimpleDateFormat
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Cast, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{RunnableCommand, SparkPlan}
-import org.apache.spark.sql.hive.CarbonMetastore
+import org.apache.spark.sql.hive.{CarbonHiveMetadataUtil, CarbonMetastore}
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.util.FileUtils
 import org.codehaus.jackson.map.ObjectMapper
-
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.carbon.{CarbonDataLoadSchema, CarbonTableIdentifier}
 import org.apache.carbondata.core.carbon.metadata.CarbonMetadata
@@ -604,7 +602,7 @@ private[sql] case class CreateLikeTableCommand(likeTableName: String,
 
     def isCarbonTable(tableName: String): Boolean = {
       val databaseName = getDB.getDatabaseName(None, sqlContext)
-      val tableExists = CarbonEnv.getInstance(sqlContext).carbonCatalog
+      val tableExists = CarbonEnv.get.carbonMetastore
         .tableExists(TableIdentifier(tableName, None))(sqlContext)
       tableExists
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Cast, Literal}
@@ -31,6 +32,7 @@ import org.apache.spark.sql.hive.{CarbonHiveMetadataUtil, CarbonMetastore}
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.util.FileUtils
 import org.codehaus.jackson.map.ObjectMapper
+
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.carbon.{CarbonDataLoadSchema, CarbonTableIdentifier}
 import org.apache.carbondata.core.carbon.metadata.CarbonMetadata

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetadataUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetadataUtil.scala
@@ -55,4 +55,9 @@ object CarbonHiveMetadataUtil {
     }
   }
 
+  def createHiveLikeTable(sqlContext: SQLContext, sql: String): Unit = {
+    val hiveContext = sqlContext.asInstanceOf[HiveContext]
+    hiveContext.runSqlHive(sql)
+  }
+
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -302,6 +302,8 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
         } else {
           ExecutedCommand(HiveNativeCommand(sql)) :: Nil
         }
+      case CreateLikeTable(likeTableName, sql) =>
+        ExecutedCommand(CreateLikeTableCommand(likeTableName, sql)) :: Nil
       case _ =>
         Nil
     }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableLike.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableLike.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.createtable
+
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestCreateTableLike extends QueryTest with BeforeAndAfterAll {
+  override def beforeAll {
+    sql("drop table if exists table_hive")
+    sql("drop table if exists table_hive_new")
+    sql("drop table if exists table_carbon")
+    sql("drop table if exists table_carbon_new")
+  }
+
+  test("test hive table can be created with like table syntax") {
+    try {
+      sql(
+        """
+           CREATE TABLE table_hive(name string, age int)
+        """)
+      sql(
+        """
+           CREATE TABLE table_hive_new like table_hive
+        """)
+    } catch {
+      case _ => assert(false)
+    }
+  }
+
+  test("test when carbon table created using like table should throw error and not create it") {
+    sql(
+      """
+          CREATE TABLE IF NOT EXISTS table_carbon
+          (id Int, name String, city String)
+          STORED BY 'org.apache.carbondata.format'
+      """)
+    try {
+      sql(
+        """
+           CREATE TABLE table_carbon_new LIKE table_carbon
+        """)
+      assert(false)
+    } catch {
+      case e : MalformedCarbonCommandException => {
+        assert(e.getMessage.equals(
+          "Carbon does not support CREATE TABLE LIKE syntax"))
+      }
+    }
+  }
+
+  override def afterAll {
+    sql("drop table if exists table_hive")
+    sql("drop table if exists table_hive_new")
+    sql("drop table if exists table_carbon")
+    sql("drop table if exists table_carbon_new")
+  }
+}


### PR DESCRIPTION
## Why raise this pr?

For this problem on jira:

```
I'm trying to create a table like my old table but it is not creating as expected.
0: jdbc:hive2://localhost:10000> CREATE TABLE mainTable(id INT, name STRING) STORED BY 'carbondata';
---------+
Result
---------+
---------+
No rows selected (0.206 seconds)
0: jdbc:hive2://localhost:10000> DESC mainTable;
-----------------------------+
col_name    data_type   comment
-----------------------------+
name    string   
id  bigint   
-----------------------------+
2 rows selected (0.056 seconds)
Above one is my mainTable and I wants to create copiedTable from it but everytime it is show something like:
0: jdbc:hive2://localhost:10000> CREATE TABLE copiedTable LIKE mainTable;
---------+
result
---------+
---------+
No rows selected (0.101 seconds)
0: jdbc:hive2://localhost:10000> DESC copiedTable;
-------------------------------------------+
col_name    data_type   comment
-------------------------------------------+
col array<string>   from deserializer
-------------------------------------------+
1 row selected (0.022 seconds)
0: jdbc:hive2://localhost:10000> LOAD DATA LOCAL INPATH 'hdfs://localhost:54310/user/hduser/datafiles/data.csv' INTO TABLE copiedTable OPTIONS('DELIMITER'=',');
Error: java.lang.RuntimeException: Data loading failed. table not found: knoldus.copiedtable (state=,code=0)
```

Since carbon does not support 'create table like', when the table is carbon table, we should throw error to the user and not create such a table, **meanwhile, we should not effect the behavior of hive tables**.
## How to test?

Pass all the test cases and the new added testcase.
