### PR TITLE
[CARBONDATA-213] Remove thrift complier dependency from default build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,16 +264,9 @@
 
   <profiles>
     <profile>
-      <id>build-all</id>
+      <id>build-with-format</id>
       <modules>
         <module>format</module>
-        <module>common</module>
-        <module>core</module>
-        <module>processing</module>
-        <module>hadoop</module>
-        <module>integration/spark</module>
-        <module>assembly</module>
-        <module>examples</module>
       </modules>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
 
   <modules>
     <module>common</module>
-    <module>format</module>
     <module>core</module>
     <module>processing</module>
     <module>hadoop</module>
@@ -264,6 +263,19 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>build-all</id>
+      <modules>
+        <module>format</module>
+        <module>common</module>
+        <module>core</module>
+        <module>processing</module>
+        <module>hadoop</module>
+        <module>integration/spark</module>
+        <module>assembly</module>
+        <module>examples</module>
+      </modules>
+    </profile>
     <profile>
       <id>hadoop-2.2.0</id>
       <!-- default -->


### PR DESCRIPTION
By default `mvn install` does not include carbon-format, it downloads dependency from repository.
User needs to use profile `mvn -Pbuild-with-format install` to build carbon including carbon-format. 

All current code is built and uploaded to apache snapshot repository https://repository.apache.org/content/repositories/snapshots/org/apache/carbondata/

If user wants to change the carbon-format then he can use profile `mvn -Pbuild-with-format install` to build carbon-format and do local testing.
It is committer responsibility to deploy snapshot if there is any changes in carbon-format before merge the PR.

**How to deploy snapshot**

Committer needs to add the following configuration to the maven settings.xml file.
 ```
<settings>
...
  <servers>
    <!-- To publish a snapshot of some part of Maven -->
    <server>
      <id>apache.snapshots.https</id>
      <username> <!-- YOUR APACHE LDAP USERNAME --> </username>
      <password> <!-- YOUR APACHE LDAP PASSWORD (encrypted) --> </password>
    </server>
   ...
  </servers>
</settings>
```

And then use the following command to deploy carbondata jars to apache snapshot repo
```
mvn clean -Pbuild-with-format -DskipTests deploy
```