### PR TITLE
[CARBONDATA-343] delete some duplicated definition code

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -751,7 +751,6 @@ object GlobalDictionaryUtil extends Logging {
       val carbonTablePath = CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier)
       val dictfolderPath = carbonTablePath.getMetadataDirectoryPath
       // columns which need to generate global dictionary file
-      // val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
       val dimensions = carbonTable.getDimensionByTableName(
         carbonTable.getFactTableName).asScala.toArray
       // generate global dict from pre defined column dict file


### PR DESCRIPTION
Delete some duplicated definition code in GlobalDictionaryUtil.scala which is mentioned  as [CARBONDATA-343](https://issues.apache.org/jira/browse/CARBONDATA-343) (and learn new [Contributing to CarbonData](https://cwiki.apache.org/confluence/display/CARBONDATA/Contributing+to+CarbonData) btw.)