### PR TITLE
[CARBONDATA-355] Remove unnecessary method argument columnIdentifier of PathService.getCarbonTablePath

### DIFF
--- a/core/src/main/java/org/apache/carbondata/common/ext/PathFactory.java
+++ b/core/src/main/java/org/apache/carbondata/common/ext/PathFactory.java
@@ -19,7 +19,6 @@
 package org.apache.carbondata.common.ext;
 
 import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
-import org.apache.carbondata.core.carbon.ColumnIdentifier;
 import org.apache.carbondata.core.carbon.path.CarbonStorePath;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
 import org.apache.carbondata.core.service.PathService;
@@ -37,8 +36,8 @@ public class PathFactory implements PathService {
    * @param tableIdentifier
    * @return store path related to tables
    */
-  @Override public CarbonTablePath getCarbonTablePath(ColumnIdentifier columnIdentifier,
-      String storeLocation, CarbonTableIdentifier tableIdentifier) {
+  @Override public CarbonTablePath getCarbonTablePath(
+          String storeLocation, CarbonTableIdentifier tableIdentifier) {
     return CarbonStorePath.getCarbonTablePath(storeLocation, tableIdentifier);
   }
 

--- a/core/src/main/java/org/apache/carbondata/common/ext/PathFactory.java
+++ b/core/src/main/java/org/apache/carbondata/common/ext/PathFactory.java
@@ -37,7 +37,7 @@ public class PathFactory implements PathService {
    * @return store path related to tables
    */
   @Override public CarbonTablePath getCarbonTablePath(
-          String storeLocation, CarbonTableIdentifier tableIdentifier) {
+      String storeLocation, CarbonTableIdentifier tableIdentifier) {
     return CarbonStorePath.getCarbonTablePath(storeLocation, tableIdentifier);
   }
 

--- a/core/src/main/java/org/apache/carbondata/common/ext/PathFactory.java
+++ b/core/src/main/java/org/apache/carbondata/common/ext/PathFactory.java
@@ -31,7 +31,6 @@ public class PathFactory implements PathService {
   private static PathService pathService = new PathFactory();
 
   /**
-   * @param columnIdentifier
    * @param storeLocation
    * @param tableIdentifier
    * @return store path related to tables

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractDictionaryCache.java
@@ -94,8 +94,7 @@ public abstract class AbstractDictionaryCache<K extends DictionaryColumnUniqueId
   protected boolean isFileExistsForGivenColumn(
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier) {
     PathService pathService = CarbonCommonFactory.getPathService();
-    CarbonTablePath carbonTablePath = pathService
-        .getCarbonTablePath(dictionaryColumnUniqueIdentifier.getColumnIdentifier(), carbonStorePath,
+    CarbonTablePath carbonTablePath = pathService.getCarbonTablePath(carbonStorePath,
             dictionaryColumnUniqueIdentifier.getCarbonTableIdentifier());
 
     String dictionaryFilePath =
@@ -157,8 +156,7 @@ public abstract class AbstractDictionaryCache<K extends DictionaryColumnUniqueId
   private CarbonFile getDictionaryMetaCarbonFile(
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier) {
     PathService pathService = CarbonCommonFactory.getPathService();
-    CarbonTablePath carbonTablePath = pathService
-        .getCarbonTablePath(dictionaryColumnUniqueIdentifier.getColumnIdentifier(), carbonStorePath,
+    CarbonTablePath carbonTablePath = pathService.getCarbonTablePath(carbonStorePath,
             dictionaryColumnUniqueIdentifier.getCarbonTableIdentifier());
     String dictionaryFilePath =
         carbonTablePath.getDictionaryMetaFilePath(dictionaryColumnUniqueIdentifier

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryMetadataReaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryMetadataReaderImpl.java
@@ -157,7 +157,7 @@ public class CarbonDictionaryMetadataReaderImpl implements CarbonDictionaryMetad
   protected void initFileLocation() {
     PathService pathService = CarbonCommonFactory.getPathService();
     CarbonTablePath carbonTablePath =
-        pathService.getCarbonTablePath(columnIdentifier, this.hdfsStorePath, carbonTableIdentifier);
+        pathService.getCarbonTablePath(this.hdfsStorePath, carbonTableIdentifier);
     this.columnDictionaryMetadataFilePath =
         carbonTablePath.getDictionaryMetaFilePath(columnIdentifier.getColumnId());
   }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImpl.java
@@ -222,7 +222,7 @@ public class CarbonDictionaryReaderImpl implements CarbonDictionaryReader {
    */
   protected void initFileLocation() {
     PathService pathService = CarbonCommonFactory.getPathService();
-    CarbonTablePath carbonTablePath = pathService.getCarbonTablePath(columnIdentifier,
+    CarbonTablePath carbonTablePath = pathService.getCarbonTablePath(
                 this.hdfsStorePath, carbonTableIdentifier);
     this.columnDictionaryFilePath = carbonTablePath
         .getDictionaryFilePath(columnIdentifier.getColumnId());

--- a/core/src/main/java/org/apache/carbondata/core/reader/sortindex/CarbonDictionarySortIndexReaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/sortindex/CarbonDictionarySortIndexReaderImpl.java
@@ -154,7 +154,7 @@ public class CarbonDictionarySortIndexReaderImpl implements CarbonDictionarySort
   protected void initPath() {
     PathService pathService = CarbonCommonFactory.getPathService();
     CarbonTablePath carbonTablePath =
-        pathService.getCarbonTablePath(columnIdentifier, carbonStorePath, carbonTableIdentifier);
+        pathService.getCarbonTablePath(carbonStorePath, carbonTableIdentifier);
     try {
       CarbonDictionaryColumnMetaChunk chunkMetaObjectForLastSegmentEntry =
           getChunkMetaObjectForLastSegmentEntry();

--- a/core/src/main/java/org/apache/carbondata/core/service/PathService.java
+++ b/core/src/main/java/org/apache/carbondata/core/service/PathService.java
@@ -27,7 +27,6 @@ import org.apache.carbondata.core.carbon.path.CarbonTablePath;
 public interface PathService {
 
   /**
-   * @param columnIdentifier
    * @param storeLocation
    * @param tableIdentifier
    * @return store path related to tables

--- a/core/src/main/java/org/apache/carbondata/core/service/PathService.java
+++ b/core/src/main/java/org/apache/carbondata/core/service/PathService.java
@@ -19,7 +19,6 @@
 package org.apache.carbondata.core.service;
 
 import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
-import org.apache.carbondata.core.carbon.ColumnIdentifier;
 import org.apache.carbondata.core.carbon.path.CarbonTablePath;
 
 /**
@@ -33,6 +32,5 @@ public interface PathService {
    * @param tableIdentifier
    * @return store path related to tables
    */
-  CarbonTablePath getCarbonTablePath(ColumnIdentifier columnIdentifier, String storeLocation,
-      CarbonTableIdentifier tableIdentifier);
+  CarbonTablePath getCarbonTablePath(String storeLocation, CarbonTableIdentifier tableIdentifier);
 }

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImpl.java
@@ -252,7 +252,7 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
 
   protected void initPaths() {
     PathService pathService = CarbonCommonFactory.getPathService();
-    CarbonTablePath carbonTablePath = pathService.getCarbonTablePath(columnIdentifier,
+    CarbonTablePath carbonTablePath = pathService.getCarbonTablePath(
             this.hdfsStorePath, carbonTableIdentifier);
     this.dictionaryFilePath = carbonTablePath.getDictionaryFilePath(columnIdentifier.getColumnId());
     this.dictionaryMetaFilePath =

--- a/core/src/main/java/org/apache/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImpl.java
@@ -153,7 +153,7 @@ public class CarbonDictionarySortIndexWriterImpl implements CarbonDictionarySort
   protected void initPath() {
     PathService pathService = CarbonCommonFactory.getPathService();
     CarbonTablePath carbonTablePath = pathService
-        .getCarbonTablePath(columnIdentifier, carbonStorePath, carbonTableIdentifier);
+        .getCarbonTablePath(carbonStorePath, carbonTableIdentifier);
     String dictionaryPath = carbonTablePath.getDictionaryFilePath(columnIdentifier.getColumnId());
     long dictOffset = CarbonUtil.getFileSize(dictionaryPath);
     this.sortIndexFilePath =

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -296,8 +296,7 @@ class CarbonGlobalDictionaryGenerateRDD(
       var dictionaryForSortIndexWriting: org.apache.carbondata.core.cache.dictionary.Dictionary = _
       var dictionaryForDistinctValueLookUpCleared: Boolean = false
       val pathService = CarbonCommonFactory.getPathService
-      val carbonTablePath = pathService.getCarbonTablePath(model.columnIdentifier(split.index),
-          model.hdfsLocation, model.table)
+      val carbonTablePath = pathService.getCarbonTablePath(model.hdfsLocation, model.table)
       if (StringUtils.isNotBlank(model.hdfsTempLocation )) {
          CarbonProperties.getInstance.addProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION,
            model.hdfsTempLocation)

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
@@ -139,7 +139,7 @@ class GlobalDictionaryUtilConcurrentTestCase extends QueryTest with BeforeAndAft
     val carbonTableIdentifier = sampleRelation.tableMeta.carbonTable.getCarbonTableIdentifier
     val columnIdentifier = sampleRelation.tableMeta.carbonTable.getDimensionByName("employee", "empid").getColumnIdentifier
     val carbonTablePath = PathFactory.getInstance()
-        .getCarbonTablePath(columnIdentifier, sampleRelation.tableMeta.storePath, carbonTableIdentifier);
+        .getCarbonTablePath(sampleRelation.tableMeta.storePath, carbonTableIdentifier);
     val dictPath = carbonTablePath.getDictionaryFilePath(columnIdentifier.getColumnId)
     val dictFile = FileFactory.getCarbonFile(dictPath, FileFactory.getFileType(dictPath))
     val offSet = dictFile.getSize


### PR DESCRIPTION
 It is not necessary pass argument #columnIdentifier when get table path through PathService.getCarbonTablePath.