### PR TITLE
[CARBONDATA-363]fixed block loading issue in case of blocklet distribution

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/datastore/block/BlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/datastore/block/BlockInfo.java
@@ -91,7 +91,7 @@ public class BlockInfo {
     if (info.getBlockOffset() != other.info.getBlockOffset()) {
       return false;
     }
-    if (info.getBlockLength() != info.getBlockLength()) {
+    if (info.getBlockLength() != other.info.getBlockLength()) {
       return false;
     }
 

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -882,7 +882,7 @@ public final class CarbonCommonConstants {
   /**
    * to enable blocklet distribution default value
    */
-  public static String ENABLE_BLOCKLET_DISTRIBUTION_DEFAULTVALUE = "true";
+  public static String ENABLE_BLOCKLET_DISTRIBUTION_DEFAULTVALUE = "false";
 
   /**
    * This batch size is used to send rows from load step to another step in batches.


### PR DESCRIPTION
**Problem**: In case of blocklet distribution same block is getting loaded multiple times this is because when blocklet distribution is enabled same block will divided inside a task so there is not synchronisation as block loading is done in different thread because of this same block is getting read from carbon data file footer multiple times and it is hitting the first time query performance.
**Solution**: Need to add locking for above issue, if one thread is loading particulate block other thread need and once block loaded other thread need to use same reference of the block 
