### PR TITLE
[CARBONDATA-364]Fixed drop and load table concurrent issue

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1283,8 +1283,10 @@ private[sql] case class DropTableCommand(ifExistsSet: Boolean, databaseNameOp: O
     val carbonLock = CarbonLockFactory
       .getCarbonLockObj(carbonTableIdentifier, LockUsage.DROP_TABLE_LOCK)
     val storePath = CarbonEnv.getInstance(sqlContext).carbonCatalog.storePath
+    var isLocked = false
     try {
-      if (carbonLock.lockWithRetries()) {
+      isLocked = carbonLock.lockWithRetries()
+      if (isLocked) {
         logInfo("Successfully able to get the lock for drop.")
       }
       else {
@@ -1296,7 +1298,7 @@ private[sql] case class DropTableCommand(ifExistsSet: Boolean, databaseNameOp: O
       LOGGER.audit(s"Deleted table [$tableName] under database [$dbName]")
     }
     finally {
-      if (carbonLock != null) {
+      if (carbonLock != null && isLocked) {
         if (carbonLock.unlock()) {
           logInfo("Table MetaData Unlocked Successfully after dropping the table")
           // deleting any remaining files.


### PR DESCRIPTION
**Problem**
When load and drop command being run parallely or concurrently. Load table command will acquire lock on table so that further modification on table will be locked.
Since load in table is in progess, when user runs drop table command, we check if table is locked do not perform any operation and send message as table is locked for updation. 
But in finally block we are not checking if lock is acquired or not, because of which system is deleting all files from store.

**Solution**
Before deleting data from store in finally block, check if lock is acquired. 
If lock is acquired then only proceed to delete table related data.
