### PR TITLE
[CARBONDATA-365]Pass block size to model during compaction.

### DIFF
--- a/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/RowResultMerger.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/integration/spark/merger/RowResultMerger.java
@@ -102,7 +102,8 @@ public class RowResultMerger {
     this.tableName = tableName;
 
     this.measureCount = segprop.getMeasures().size();
-
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+            .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
     CarbonFactDataHandlerModel carbonFactDataHandlerModel =
         getCarbonFactDataHandlerModel(loadModel);
     carbonFactDataHandlerModel.setPrimitiveDimLens(segprop.getDimColumnsCardinality());
@@ -117,7 +118,7 @@ public class RowResultMerger {
       carbonFactDataHandlerModel.setMdKeyIndex(measureCount);
     }
     carbonFactDataHandlerModel.setColCardinality(colCardinality);
-
+    carbonFactDataHandlerModel.setBlockSizeInMB(carbonTable.getBlockSizeInMB());
     dataHandler = new CarbonFactDataHandlerColumnar(carbonFactDataHandlerModel);
 
     tupleConvertor = new TupleConversionAdapter(segProp);


### PR DESCRIPTION
**Problem**
When user creates table by passing configured block size. After multiple load, compaction is triggered but it fails. After analysis, it is found that configured block size is not passed to processing layer.

**Solution**
Pass configured block size in model to next step in processing layer.

CI is passed for this PR
http://136.243.101.176:8080/job/ApacheCarbonManualPRBuilder/562/