### PR TITLE
[CARBONDATA-366]Throw error when stream is not closed during load

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -117,17 +117,26 @@ public final class CarbonUtil {
     // Added if to avoid NullPointerException in case one stream is being passed as null
     if (null != streams) {
       for (Closeable stream : streams) {
-        if (null != stream) {
-          try {
-            stream.close();
-          } catch (IOException e) {
-            LOGGER.error("Error while closing stream" + stream);
-          }
+        try {
+          closeStream(stream);
+        } catch (IOException e) {
+          LOGGER.error("Error while closing stream:" + e);
         }
       }
     }
   }
 
+  /**
+   * This method closes stream
+   *
+   * @param stream
+   * @throws IOException
+   */
+  public static void closeStream(Closeable stream) throws IOException {
+    if (null != stream) {
+      stream.close();
+    }
+  }
   /**
    * @param baseStorePath
    * @return

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -632,7 +632,8 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
           .getDataInputStream(localFilePath, FileFactory.getFileType(localFilePath), bufferSize);
       IOUtils.copyBytes(dataInputStream, dataOutputStream, bufferSize);
     } finally {
-      CarbonUtil.closeStreams(dataInputStream, dataOutputStream);
+      CarbonUtil.closeStream(dataInputStream);
+      CarbonUtil.closeStream(dataOutputStream);
     }
   }
 


### PR DESCRIPTION
**Problem**
In some scenario, when user loads data, it shows successfull but while querying it gives error. After analysing, we saw carbon index file is of 0 byte. During log analysis, it is found that there was error while closing stream.

**Solution**
We should throw the error if occured while closing stream, so that either executer can relaunch the task or propogate the error to user. Same has been handled in this pull request.

CI is passed for this PR
http://136.243.101.176:8080/job/ApacheCarbonManualPRBuilder/563/