### PR TITLE
[CARBONDATA-373] Drop Database Cascade command implementation.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -90,3 +90,18 @@ abstract class CarbonProfile(attributes: Seq[Attribute]) extends Serializable {
 case class IncludeProfile(attributes: Seq[Attribute]) extends CarbonProfile(attributes)
 
 case class ExcludeProfile(attributes: Seq[Attribute]) extends CarbonProfile(attributes)
+
+case class CreateDatabase(dbName: String, sql: String) extends LogicalPlan with Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+  override def output: Seq[AttributeReference] = {
+    Seq()
+  }
+}
+
+case class DropDatabase(dbName: String, isCascade: Boolean, sql: String)
+    extends LogicalPlan with Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+  override def output: Seq[AttributeReference] = {
+    Seq()
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -575,6 +575,21 @@ class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
     (databaseName, tableName, dataPath, schema, partitioner, tableCreationTime)
   }
 
+  def createDatabaseDirectory(dbName: String) {
+    val databasePath = storePath + File.separator + dbName
+    val fileType = FileFactory.getFileType(databasePath)
+    FileFactory.mkdirs(databasePath, fileType)
+  }
+
+  def dropDatabaseDirectory(dbName: String) {
+    val databasePath = storePath + File.separator + dbName
+    val fileType = FileFactory.getFileType(databasePath)
+    if (FileFactory.isFileExist(databasePath, fileType)) {
+      val dbPath = FileFactory.getCarbonFile(databasePath, fileType)
+      CarbonUtil.deleteFoldersAndFiles(dbPath)
+    }
+  }
+
 }
 
 
@@ -653,5 +668,4 @@ object CarbonMetastoreTypes extends RegexParsers {
       case TimestampType => "timestamp"
     }
   }
-
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.execution.{ExecutedCommand, Filter, Project, SparkPl
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.{DescribeCommand => LogicalDescribeCommand, LogicalRelation}
 import org.apache.spark.sql.hive.execution.{DropTable, HiveNativeCommand}
+import org.apache.spark.sql.hive.execution.command._
 import org.apache.spark.sql.optimizer.{CarbonAliasDecoderRelation, CarbonDecoderRelation}
 import org.apache.spark.sql.types.IntegerType
 
@@ -250,6 +251,14 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
           }
         } else {
           ExecutedCommand(HiveNativeCommand(altertablemodel.alterSql)) :: Nil
+        }
+      case CreateDatabase(dbName, sql) =>
+        ExecutedCommand(CreateDatabaseCommand(dbName, HiveNativeCommand(sql))) :: Nil
+      case DropDatabase(dbName, isCascade, sql) =>
+        if (isCascade) {
+          ExecutedCommand(DropDatabaseCascadeCommand(dbName, HiveNativeCommand(sql))) :: Nil
+        } else {
+          ExecutedCommand(DropDatabaseCommand(dbName, HiveNativeCommand(sql))) :: Nil
         }
       case d: HiveNativeCommand =>
         try {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution.command
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.execution.RunnableCommand
+import org.apache.spark.sql.execution.command.DropTableCommand
+import org.apache.spark.sql.hive.execution.HiveNativeCommand
+
+private[hive] case class CreateDatabaseCommand(dbName: String,
+    command: HiveNativeCommand) extends RunnableCommand {
+  def run(sqlContext: SQLContext): Seq[Row] = {
+    val rows = command.run(sqlContext)
+    CarbonEnv.getInstance(sqlContext).carbonCatalog.createDatabaseDirectory(dbName)
+    rows
+  }
+}
+
+private[hive] case class DropDatabaseCommand(dbName: String,
+    command: HiveNativeCommand) extends RunnableCommand {
+  def run(sqlContext: SQLContext): Seq[Row] = {
+    val rows = command.run(sqlContext)
+    CarbonEnv.getInstance(sqlContext).carbonCatalog.dropDatabaseDirectory(dbName)
+    rows
+  }
+}
+
+private[hive] case class DropDatabaseCascadeCommand(dbName: String,
+    command: HiveNativeCommand) extends RunnableCommand {
+  def run(sqlContext: SQLContext): Seq[Row] = {
+    val tablesInDB = CarbonEnv.getInstance(sqlContext).carbonCatalog
+        .getTables(Some(dbName))(sqlContext).map(x => x._1)
+    val rows = command.run(sqlContext)
+    tablesInDB.foreach{tableName =>
+      DropTableCommand(true, Some(dbName), tableName).run(sqlContext)
+    }
+    CarbonEnv.getInstance(sqlContext).carbonCatalog.dropDatabaseDirectory(dbName)
+    rows
+  }
+}

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/deleteTable/TestDeleteTableNewDDL.scala
@@ -50,20 +50,27 @@ class TestDeleteTableNewDDL extends QueryTest with BeforeAndAfterAll {
   // normal deletion case
   test("drop table Test with new DDL") {
     sql("drop table table1")
-
   }
   
   test("test drop database cascade command") {
     sql("create database testdb")
+    sql("use testdb")
+    sql("CREATE TABLE IF NOT EXISTS testtable(empno Int, empname string, utilization Int,salary Int)"
+        + " STORED BY 'org.apache.carbondata.format' ")
     try {
-      sql("drop database testdb cascade")
+      sql("drop database testdb")
       assert(false)
     } catch {
-      case e : MalformedCarbonCommandException => {
-        assert(e.getMessage.equals("Unsupported cascade operation in drop database/schema command"))
-      }
+      case e : Exception => 
     }
-    sql("drop database testdb")
+    sql("drop database testdb cascade")
+    try {
+      sql("use testdb")
+      assert(false)
+    } catch {
+      case e : Exception => 
+    }
+    sql("use default")
   }
 
   // deletion case with if exists


### PR DESCRIPTION
Issue : Currently drop database cascade command is restricted in Carbon
Solution : Implemented code to support below changes
1) Create DB folder in carbon store when user triggers Create database command
2) Removing DB folder from carbon store when user triggers Drop database command
3) Removing Tables & DB folder from carbon store when user triggers Drop database cascade command