### PR TITLE
[CARBONDATA-398] In DropCarbonTable flow, Metadata lock should be acquired only if tab…

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1284,10 +1284,10 @@ private[sql] case class DropTableCommand(ifExistsSet: Boolean, databaseNameOp: O
       .getCarbonLockObj(carbonTableIdentifier, LockUsage.DROP_TABLE_LOCK)
     val storePath = CarbonEnv.getInstance(sqlContext).carbonCatalog.storePath
     var isLocked = false
-    val tmpTable = org.apache.carbondata.core.carbon.metadata.CarbonMetadata.getInstance()
-      .getCarbonTable(dbName + '_' + tableName)
+    val tableExists = CarbonEnv.getInstance(sqlContext).carbonCatalog
+      .tableExists(TableIdentifier(tableName, databaseNameOp))(sqlContext)
     try {
-      if (null != tmpTable) {
+      if (tableExists) {
         isLocked = carbonLock.lockWithRetries()
         if (isLocked) {
           logInfo("Successfully able to get the lock for drop.")


### PR DESCRIPTION
Issue : In drop table flow, we acquiring metadata lock even if table not exist which is creating table folder and creating meta.lock file.
Solution : Check and acquire lock only if carbon table exist.