### PR TITLE
[CARBONDATA-404] Fixing dataframe save when loading in cluster mode.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -65,7 +65,7 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) extends Logging {
     val tempCSVFolder = new StringBuilder(storePath).append(CarbonCommonConstants.FILE_SEPARATOR)
       .append("tempCSV")
       .append(CarbonCommonConstants.UNDERSCORE).append(options.dbName)
-      .append(CarbonCommonConstants.UNDERSCORE + options.tableName)
+      .append(CarbonCommonConstants.UNDERSCORE).append(options.tableName)
       .append(CarbonCommonConstants.UNDERSCORE).append(System.nanoTime()).toString
     writeToTempCSVFile(tempCSVFolder, options)
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.execution.command.LoadTable
 import org.apache.spark.sql.types._
 
 import org.apache.carbondata.core.carbon.metadata.datatype.{DataType => CarbonType}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 
 class CarbonDataFrameWriter(val dataFrame: DataFrame) extends Logging {
 
@@ -61,7 +62,11 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) extends Logging {
   private def loadTempCSV(options: CarbonOption, cc: CarbonContext): Unit = {
     // temporary solution: write to csv file, then load the csv into carbon
     val storePath = CarbonEnv.getInstance(cc).carbonCatalog.storePath
-    val tempCSVFolder = storePath + "/tempCSV" + options.tableIdentifier + System.nanoTime()
+    val tempCSVFolder = new StringBuilder(storePath).append(CarbonCommonConstants.FILE_SEPARATOR)
+      .append("tempCSV")
+      .append(CarbonCommonConstants.UNDERSCORE).append(options.dbName)
+      .append(CarbonCommonConstants.UNDERSCORE + options.tableName)
+      .append(CarbonCommonConstants.UNDERSCORE).append(System.nanoTime()).toString
     writeToTempCSVFile(tempCSVFolder, options)
 
     val tempCSVPath = new Path(tempCSVFolder)

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -60,7 +60,8 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) extends Logging {
    */
   private def loadTempCSV(options: CarbonOption, cc: CarbonContext): Unit = {
     // temporary solution: write to csv file, then load the csv into carbon
-    val tempCSVFolder = "./tempCSV"
+    val storePath = CarbonEnv.getInstance(cc).carbonCatalog.storePath
+    val tempCSVFolder = storePath + "/tempCSV" + options.tableIdentifier + System.nanoTime()
     writeToTempCSVFile(tempCSVFolder, options)
 
     val tempCSVPath = new Path(tempCSVFolder)


### PR DESCRIPTION
Currently dataframe save writes temp csv in local folder so it fails in cluster mode. This PR changes the temp csv location to store path.