### PR TITLE
[CARBONDATA-83] Fixing support carbon-spark-sql CLI options

### DIFF
--- a/bin/carbon-spark-sql
+++ b/bin/carbon-spark-sql
@@ -65,10 +65,7 @@ function usage {
   pattern+="\|--help"
   pattern+="\|======="
 
-  "$FWDIR"/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
-  echo
-  echo "CLI options:"
-  "$FWDIR"/bin/spark-class "$CLASS" --help 2>&1 | grep -v "$pattern" 1>&2
+  "$FWDIR"/bin/spark-sql --help 2>&1 | grep -v Usage 1>&2
   exit "$2"
 }
 export -f usage
@@ -77,4 +74,16 @@ if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
   usage "" 0
 fi
 
-exec "$FWDIR"/bin/spark-submit --class "$CLASS" "$JAR" "$@"
+#split options and cli_options, final submit example is spark-submit options --class xxx xxx.jar cli_options
+options=""
+cmd
+while true ; do
+    case "$1" in
+        -d|--define|-f|-i|--hiveconf|--hivevar|--database|-e|-S|--silent) cmd="$1"; break;;
+        -v|--verbose) options="$options $1" ; shift  ;;
+        -*) options="$options $1 $2" ; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+exec "$FWDIR"/bin/spark-submit $options --class "$CLASS" "$JAR" "$@"

--- a/bin/carbon-spark-sql
+++ b/bin/carbon-spark-sql
@@ -77,4 +77,4 @@ if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
   usage "" 0
 fi
 
-exec "$FWDIR"/bin/spark-submit "$@" --class "$CLASS" "$JAR"
+exec "$FWDIR"/bin/spark-submit --class "$CLASS" "$JAR" "$@"


### PR DESCRIPTION
sql support  CLI options

the bug is in the carbon-spark-sql 
line 80 
/bin/spark-submit $@  the arguments should set to main class  
like this /bin/spark-submit --class Hello $@  