### PR TITLE
[CARBONDATA-412] Fix load bug when table name has '_'

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/path/CarbonTablePath.java
@@ -397,10 +397,12 @@ public class CarbonTablePath extends Path {
      */
     public static String getSegmentId(String dataFileAbsolutePath) {
       // find segment id from last of data file path
-      int endIndex = dataFileAbsolutePath.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR);
+      String tempdataFileAbsolutePath = dataFileAbsolutePath.replace(
+              CarbonCommonConstants.WINDOWS_FILE_SEPARATOR, CarbonCommonConstants.FILE_SEPARATOR);
+      int endIndex = tempdataFileAbsolutePath.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR);
       // + 1 for size of "/"
-      int startIndex =
-          dataFileAbsolutePath.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR, endIndex - 1) + 1;
+      int startIndex = tempdataFileAbsolutePath.lastIndexOf(
+              CarbonCommonConstants.FILE_SEPARATOR, endIndex - 1) + 1;
       String segmentDirStr = dataFileAbsolutePath.substring(startIndex, endIndex);
       //identify id in segment_<id>
       String[] segmentDirSplits = segmentDirStr.split("_");

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -456,6 +456,10 @@ public final class CarbonCommonConstants {
    */
   public static final String POINT = ".";
   /**
+   * Windows File separator
+   */
+  public static final String WINDOWS_FILE_SEPARATOR = "\\";
+  /**
    * File separator
    */
   public static final String FILE_SEPARATOR = "/";


### PR DESCRIPTION
  https://issues.apache.org/jira/browse/CARBONDATA-412

## Reason: 
this is because in windows, file separator is "\", then in getSegmentId method, when split with 
 linux file separator "/", carbon can not get the correct segment number,  then the segment is treated as an invalid segment and will be deleted..

## Solution:
the file path should be firstly replaced with  file separator "/"
