### PR TITLE
[CARBONDATA-421]Time Stamp Filter issue with other than yyyy-mm-dd format

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.carbon.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.scan.expression.ColumnExpression;
 import org.apache.carbondata.scan.expression.exception.FilterIllegalMemberException;
 import org.apache.carbondata.scan.expression.exception.FilterUnsupportedException;
@@ -98,7 +99,9 @@ public class CustomTypeDictionaryVisitor implements ResolvedFilterInfoVisitorInt
   private void getSurrogateValuesForDictionary(List<String> evaluateResultListFinal,
       List<Integer> surrogates, boolean isNotTimestampType,
       DirectDictionaryGenerator directDictionaryGenerator) {
-    String timeFormat = CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT;
+    String timeFormat = CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+            CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
     if (isNotTimestampType) {
       timeFormat = null;
     }


### PR DESCRIPTION
Problem: When time format is yyyy/mm/dd other than "-" filter query is not working , As in filter only "-" is allowed user need to give the filter value is "-" but as data loaded in in "/" filter is not working and returning 0 result. 
Soluntion: Problem is in filter we are taking default format but we need to take format used during data loaded while converting the filter values to surrogate key