### PR TITLE
[CARBONDATA-428] Removed Redundant Condition Checks

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/CacheProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/CacheProvider.java
@@ -84,14 +84,13 @@ public class CacheProvider {
     //check if cache is null for given cache type, if null create one
     if (!dictionaryCacheAlreadyExists(cacheType)) {
       synchronized (lock) {
-        if (!dictionaryCacheAlreadyExists(cacheType)) {
-          if (null == cacheTypeToLRUCacheMap.get(cacheType)) {
-            createLRULevelCacheInstance(cacheType);
-          }
-          createDictionaryCacheForGivenType(cacheType, carbonStorePath);
+        if (null == cacheTypeToLRUCacheMap.get(cacheType)) {
+          createLRULevelCacheInstance(cacheType);
         }
+        createDictionaryCacheForGivenType(cacheType, carbonStorePath);
       }
     }
+
     return cacheTypeToCacheMap.get(cacheType);
   }
 


### PR DESCRIPTION
Remove the redundant conditional checking of dictionaryCacheAlreadyExists(cacheType) in CacheProvider.

