### PR TITLE
[CARBONDATA-100]Implement BigInt value compression

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/compression/BigIntCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/compression/BigIntCompressor.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.core.compression;
+
+import org.apache.carbondata.core.datastorage.store.dataholder.CarbonWriteDataHolder;
+import org.apache.carbondata.core.util.ValueCompressionUtil.DataType;
+
+/**
+ * It compresses big int data
+ */
+public class BigIntCompressor extends ValueCompressor {
+
+  @Override protected Object compressNonDecimalMaxMin(DataType changedDataType,
+      CarbonWriteDataHolder dataHolder, int decimal, Object max) {
+    // in case if bigint, decimal will be 0
+    return compressMaxMin(changedDataType, dataHolder, max);
+  }
+
+  @Override
+  protected Object compressNonDecimal(DataType changedDataType, CarbonWriteDataHolder dataHolder,
+      int decimal) {
+    // in case if bigint, decimal will be 0
+    return compressNone(changedDataType, dataHolder);
+  }
+
+  @Override
+  protected Object compressMaxMin(DataType changedDataType, CarbonWriteDataHolder dataHolder,
+      Object max) {
+    long maxValue = (long) max;
+    long[] value = dataHolder.getWritableLongValues();
+    int i = 0;
+    switch (changedDataType) {
+      case DATA_BYTE:
+
+        byte[] result = new byte[value.length];
+        for (long a : value) {
+          result[i] = (byte) (maxValue - a);
+          i++;
+        }
+        return result;
+
+      case DATA_SHORT:
+
+        short[] shortResult = new short[value.length];
+
+        for (long a : value) {
+          shortResult[i] = (short) (maxValue - a);
+          i++;
+        }
+        return shortResult;
+
+      case DATA_INT:
+
+        int[] intResult = new int[value.length];
+
+        for (long a : value) {
+          intResult[i] = (int) (maxValue - a);
+          i++;
+        }
+        return intResult;
+
+      default:
+
+        long[] defaultResult = new long[value.length];
+
+        for (long a : value) {
+          defaultResult[i] = (long) (maxValue - a);
+          i++;
+        }
+        return defaultResult;
+
+    }
+  }
+
+  @Override
+  protected Object compressNone(DataType changedDataType, CarbonWriteDataHolder dataHolder) {
+    long[] value = dataHolder.getWritableLongValues();
+    int i = 0;
+    switch (changedDataType) {
+
+      case DATA_BYTE:
+
+        byte[] result = new byte[value.length];
+
+        for (long a : value) {
+          result[i] = (byte) a;
+          i++;
+        }
+        return result;
+
+      case DATA_SHORT:
+
+        short[] shortResult = new short[value.length];
+
+        for (long a : value) {
+          shortResult[i] = (short) a;
+          i++;
+        }
+        return shortResult;
+
+      case DATA_INT:
+
+        int[] intResult = new int[value.length];
+
+        for (long a : value) {
+          intResult[i] = (int) a;
+          i++;
+        }
+        return intResult;
+
+      default:
+
+        return value;
+
+    }
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/compression/BigIntCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/compression/BigIntCompressor.java
@@ -47,44 +47,33 @@ public class BigIntCompressor extends ValueCompressor {
     int i = 0;
     switch (changedDataType) {
       case DATA_BYTE:
-
         byte[] result = new byte[value.length];
-        for (long a : value) {
-          result[i] = (byte) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          result[i] = (byte) (maxValue - value[j]);
           i++;
         }
         return result;
-
       case DATA_SHORT:
-
         short[] shortResult = new short[value.length];
-
-        for (long a : value) {
-          shortResult[i] = (short) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          shortResult[i] = (short) (maxValue - value[j]);
           i++;
         }
         return shortResult;
-
       case DATA_INT:
-
         int[] intResult = new int[value.length];
-
-        for (long a : value) {
-          intResult[i] = (int) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          intResult[i] = (int) (maxValue - value[j]);
           i++;
         }
         return intResult;
-
       default:
-
         long[] defaultResult = new long[value.length];
-
-        for (long a : value) {
-          defaultResult[i] = (long) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          defaultResult[i] = (long) (maxValue - value[j]);
           i++;
         }
         return defaultResult;
-
     }
   }
 
@@ -93,42 +82,29 @@ public class BigIntCompressor extends ValueCompressor {
     long[] value = dataHolder.getWritableLongValues();
     int i = 0;
     switch (changedDataType) {
-
       case DATA_BYTE:
-
         byte[] result = new byte[value.length];
-
-        for (long a : value) {
-          result[i] = (byte) a;
+        for (int j = 0; j < value.length; j++)  {
+          result[i] = (byte) value[j];
           i++;
         }
         return result;
-
       case DATA_SHORT:
-
         short[] shortResult = new short[value.length];
-
-        for (long a : value) {
-          shortResult[i] = (short) a;
+        for (int j = 0; j < value.length; j++) {
+          shortResult[i] = (short) value[j];
           i++;
         }
         return shortResult;
-
       case DATA_INT:
-
         int[] intResult = new int[value.length];
-
-        for (long a : value) {
-          intResult[i] = (int) a;
+        for (int j = 0; j < value.length; j++) {
+          intResult[i] = (int) value[j];
           i++;
         }
         return intResult;
-
       default:
-
         return value;
-
     }
   }
-
 }

--- a/core/src/main/java/org/apache/carbondata/core/compression/DoubleCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/compression/DoubleCompressor.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.core.compression;
+
+import java.math.BigDecimal;
+
+import org.apache.carbondata.core.datastorage.store.dataholder.CarbonWriteDataHolder;
+import org.apache.carbondata.core.util.ValueCompressionUtil.DataType;
+
+/**
+ * Double compressor
+ */
+public class DoubleCompressor extends ValueCompressor {
+
+  @Override protected Object compressNonDecimalMaxMin(DataType changedDataType,
+      CarbonWriteDataHolder dataHolder, int decimal, Object maxValue) {
+    int i = 0;
+    BigDecimal max = BigDecimal.valueOf((double)maxValue);
+    double[] value = dataHolder.getWritableDoubleValues();
+    switch (changedDataType) {
+      case DATA_BYTE:
+        byte[] result = new byte[value.length];
+
+        for (double a : value) {
+          BigDecimal val = BigDecimal.valueOf(a);
+          double diff = max.subtract(val).doubleValue();
+          result[i] = (byte) (Math.round(diff * Math.pow(10, decimal)));
+          i++;
+        }
+        return result;
+
+      case DATA_SHORT:
+
+        short[] shortResult = new short[value.length];
+
+        for (double a : value) {
+          BigDecimal val = BigDecimal.valueOf(a);
+          double diff = max.subtract(val).doubleValue();
+          shortResult[i] = (short) (Math.round(diff * Math.pow(10, decimal)));
+          i++;
+        }
+        return shortResult;
+
+      case DATA_INT:
+
+        int[] intResult = new int[value.length];
+
+        for (double a : value) {
+          BigDecimal val = BigDecimal.valueOf(a);
+          double diff = max.subtract(val).doubleValue();
+          intResult[i] = (int) (Math.round(diff * Math.pow(10, decimal)));
+          i++;
+        }
+        return intResult;
+
+      case DATA_LONG:
+
+        long[] longResult = new long[value.length];
+
+        for (double a : value) {
+          BigDecimal val = BigDecimal.valueOf(a);
+          double diff = max.subtract(val).doubleValue();
+          longResult[i] = (long) (Math.round(diff * Math.pow(10, decimal)));
+          i++;
+        }
+        return longResult;
+
+      case DATA_FLOAT:
+
+        float[] floatResult = new float[value.length];
+
+        for (double a : value) {
+          BigDecimal val = BigDecimal.valueOf(a);
+          double diff = max.subtract(val).doubleValue();
+          floatResult[i] = (float) (Math.round(diff * Math.pow(10, decimal)));
+          i++;
+        }
+        return floatResult;
+
+      default:
+
+        double[] defaultResult = new double[value.length];
+
+        for (double a : value) {
+          BigDecimal val = BigDecimal.valueOf(a);
+          double diff = max.subtract(val).doubleValue();
+          defaultResult[i] =  (Math.round(diff * Math.pow(10, decimal)));
+          i++;
+        }
+        return defaultResult;
+
+    }
+  }
+
+  @Override
+  protected Object compressNonDecimal(DataType changedDataType, CarbonWriteDataHolder dataHolder,
+      int decimal) {
+    int i = 0;
+    double[] value = dataHolder.getWritableDoubleValues();
+    switch (changedDataType) {
+      case DATA_BYTE:
+        byte[] result = new byte[value.length];
+
+        for (double a : value) {
+          result[i] = (byte) (Math.round(Math.pow(10, decimal) * a));
+          i++;
+        }
+        return result;
+      case DATA_SHORT:
+        short[] shortResult = new short[value.length];
+
+        for (double a : value) {
+          shortResult[i] = (short) (Math.round(Math.pow(10, decimal) * a));
+          i++;
+        }
+        return shortResult;
+      case DATA_INT:
+
+        int[] intResult = new int[value.length];
+
+        for (double a : value) {
+          intResult[i] = (int) (Math.round(Math.pow(10, decimal) * a));
+          i++;
+        }
+        return intResult;
+
+      case DATA_LONG:
+
+        long[] longResult = new long[value.length];
+
+        for (double a : value) {
+          longResult[i] = (long) (Math.round(Math.pow(10, decimal) * a));
+          i++;
+        }
+        return longResult;
+
+      case DATA_FLOAT:
+
+        float[] floatResult = new float[value.length];
+
+        for (double a : value) {
+          floatResult[i] = (float) (Math.round(Math.pow(10, decimal) * a));
+          i++;
+        }
+        return floatResult;
+
+      default:
+        double[] defaultResult = new double[value.length];
+
+        for (double a : value) {
+          defaultResult[i] = (double) (Math.round(Math.pow(10, decimal) * a));
+          i++;
+        }
+        return defaultResult;
+    }
+  }
+
+  @Override
+  protected Object compressMaxMin(DataType changedDataType, CarbonWriteDataHolder dataHolder,
+      Object max) {
+    double maxValue = (double) max;
+    double[] value = dataHolder.getWritableDoubleValues();
+    int i = 0;
+    switch (changedDataType) {
+      case DATA_BYTE:
+
+        byte[] result = new byte[value.length];
+        for (double a : value) {
+          result[i] = (byte) (maxValue - a);
+          i++;
+        }
+        return result;
+
+      case DATA_SHORT:
+
+        short[] shortResult = new short[value.length];
+
+        for (double a : value) {
+          shortResult[i] = (short) (maxValue - a);
+          i++;
+        }
+        return shortResult;
+
+      case DATA_INT:
+
+        int[] intResult = new int[value.length];
+
+        for (double a : value) {
+          intResult[i] = (int) (maxValue - a);
+          i++;
+        }
+        return intResult;
+
+      case DATA_LONG:
+
+        long[] longResult = new long[value.length];
+
+        for (double a : value) {
+          longResult[i] = (long) (maxValue - a);
+          i++;
+        }
+        return longResult;
+
+      case DATA_FLOAT:
+
+        float[] floatResult = new float[value.length];
+
+        for (double a : value) {
+          floatResult[i] = (float) (maxValue - a);
+          i++;
+        }
+        return floatResult;
+
+      default:
+
+        double[] defaultResult = new double[value.length];
+
+        for (double a : value) {
+          defaultResult[i] = (double) (maxValue - a);
+          i++;
+        }
+        return defaultResult;
+
+    }
+  }
+
+  @Override
+  protected Object compressNone(DataType changedDataType, CarbonWriteDataHolder dataHolder) {
+    double[] value = dataHolder.getWritableDoubleValues();
+    int i = 0;
+    switch (changedDataType) {
+
+      case DATA_BYTE:
+
+        byte[] result = new byte[value.length];
+
+        for (double a : value) {
+          result[i] = (byte) a;
+          i++;
+        }
+        return result;
+
+      case DATA_SHORT:
+
+        short[] shortResult = new short[value.length];
+
+        for (double a : value) {
+          shortResult[i] = (short) a;
+          i++;
+        }
+        return shortResult;
+
+      case DATA_INT:
+
+        int[] intResult = new int[value.length];
+
+        for (double a : value) {
+          intResult[i] = (int) a;
+          i++;
+        }
+        return intResult;
+
+      case DATA_LONG:
+      case DATA_BIGINT:
+
+        long[] longResult = new long[value.length];
+
+        for (double a : value) {
+          longResult[i] = (long) a;
+          i++;
+        }
+        return longResult;
+
+      case DATA_FLOAT:
+
+        float[] floatResult = new float[value.length];
+
+        for (double a : value) {
+          floatResult[i] = (float) a;
+          i++;
+        }
+        return floatResult;
+
+      default:
+
+        return value;
+
+    }
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/compression/DoubleCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/compression/DoubleCompressor.java
@@ -36,75 +36,58 @@ public class DoubleCompressor extends ValueCompressor {
     switch (changedDataType) {
       case DATA_BYTE:
         byte[] result = new byte[value.length];
-
-        for (double a : value) {
-          BigDecimal val = BigDecimal.valueOf(a);
+        for (int j = 0; j < value.length; j++) {
+          BigDecimal val = BigDecimal.valueOf(value[j]);
           double diff = max.subtract(val).doubleValue();
           result[i] = (byte) (Math.round(diff * Math.pow(10, decimal)));
           i++;
         }
         return result;
-
       case DATA_SHORT:
-
         short[] shortResult = new short[value.length];
-
-        for (double a : value) {
-          BigDecimal val = BigDecimal.valueOf(a);
+        for (int j = 0; j < value.length; j++) {
+          BigDecimal val = BigDecimal.valueOf(value[j]);
           double diff = max.subtract(val).doubleValue();
           shortResult[i] = (short) (Math.round(diff * Math.pow(10, decimal)));
           i++;
         }
         return shortResult;
-
       case DATA_INT:
-
         int[] intResult = new int[value.length];
-
-        for (double a : value) {
-          BigDecimal val = BigDecimal.valueOf(a);
+        for (int j = 0; j < value.length; j++) {
+          BigDecimal val = BigDecimal.valueOf(value[j]);
           double diff = max.subtract(val).doubleValue();
           intResult[i] = (int) (Math.round(diff * Math.pow(10, decimal)));
           i++;
         }
         return intResult;
-
       case DATA_LONG:
-
         long[] longResult = new long[value.length];
-
-        for (double a : value) {
-          BigDecimal val = BigDecimal.valueOf(a);
+        for (int j = 0; j < value.length; j++) {
+          BigDecimal val = BigDecimal.valueOf(value[j]);
           double diff = max.subtract(val).doubleValue();
           longResult[i] = (long) (Math.round(diff * Math.pow(10, decimal)));
           i++;
         }
         return longResult;
-
       case DATA_FLOAT:
-
         float[] floatResult = new float[value.length];
-
-        for (double a : value) {
-          BigDecimal val = BigDecimal.valueOf(a);
+        for (int j = 0; j < value.length; j++) {
+          BigDecimal val = BigDecimal.valueOf(value[j]);
           double diff = max.subtract(val).doubleValue();
           floatResult[i] = (float) (Math.round(diff * Math.pow(10, decimal)));
           i++;
         }
         return floatResult;
-
       default:
-
         double[] defaultResult = new double[value.length];
-
-        for (double a : value) {
-          BigDecimal val = BigDecimal.valueOf(a);
+        for (int j = 0; j < value.length; j++) {
+          BigDecimal val = BigDecimal.valueOf(value[j]);
           double diff = max.subtract(val).doubleValue();
           defaultResult[i] =  (Math.round(diff * Math.pow(10, decimal)));
           i++;
         }
         return defaultResult;
-
     }
   }
 
@@ -116,55 +99,43 @@ public class DoubleCompressor extends ValueCompressor {
     switch (changedDataType) {
       case DATA_BYTE:
         byte[] result = new byte[value.length];
-
-        for (double a : value) {
-          result[i] = (byte) (Math.round(Math.pow(10, decimal) * a));
+        for (int j = 0; j < value.length; j++) {
+          result[i] = (byte) (Math.round(Math.pow(10, decimal) * value[j]));
           i++;
         }
         return result;
       case DATA_SHORT:
         short[] shortResult = new short[value.length];
-
-        for (double a : value) {
-          shortResult[i] = (short) (Math.round(Math.pow(10, decimal) * a));
+        for (int j = 0; j < value.length; j++) {
+          shortResult[i] = (short) (Math.round(Math.pow(10, decimal) * value[j]));
           i++;
         }
         return shortResult;
       case DATA_INT:
-
         int[] intResult = new int[value.length];
-
-        for (double a : value) {
-          intResult[i] = (int) (Math.round(Math.pow(10, decimal) * a));
+        for (int j = 0; j < value.length; j++) {
+          intResult[i] = (int) (Math.round(Math.pow(10, decimal) * value[j]));
           i++;
         }
         return intResult;
-
       case DATA_LONG:
-
         long[] longResult = new long[value.length];
-
-        for (double a : value) {
-          longResult[i] = (long) (Math.round(Math.pow(10, decimal) * a));
+        for (int j = 0; j < value.length; j++) {
+          longResult[i] = (long) (Math.round(Math.pow(10, decimal) * value[j]));
           i++;
         }
         return longResult;
-
       case DATA_FLOAT:
-
         float[] floatResult = new float[value.length];
-
-        for (double a : value) {
-          floatResult[i] = (float) (Math.round(Math.pow(10, decimal) * a));
+        for (int j = 0; j < value.length; j++) {
+          floatResult[i] = (float) (Math.round(Math.pow(10, decimal) * value[j]));
           i++;
         }
         return floatResult;
-
       default:
         double[] defaultResult = new double[value.length];
-
-        for (double a : value) {
-          defaultResult[i] = (double) (Math.round(Math.pow(10, decimal) * a));
+        for (int j = 0; j < value.length; j++) {
+          defaultResult[i] = (double) (Math.round(Math.pow(10, decimal) * value[j]));
           i++;
         }
         return defaultResult;
@@ -179,64 +150,47 @@ public class DoubleCompressor extends ValueCompressor {
     int i = 0;
     switch (changedDataType) {
       case DATA_BYTE:
-
         byte[] result = new byte[value.length];
-        for (double a : value) {
-          result[i] = (byte) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          result[i] = (byte) (maxValue - value[j]);
           i++;
         }
         return result;
-
       case DATA_SHORT:
-
         short[] shortResult = new short[value.length];
-
-        for (double a : value) {
-          shortResult[i] = (short) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          shortResult[i] = (short) (maxValue - value[j]);
           i++;
         }
         return shortResult;
-
       case DATA_INT:
-
         int[] intResult = new int[value.length];
-
-        for (double a : value) {
-          intResult[i] = (int) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          intResult[i] = (int) (maxValue - value[j]);
           i++;
         }
         return intResult;
-
       case DATA_LONG:
-
         long[] longResult = new long[value.length];
-
-        for (double a : value) {
-          longResult[i] = (long) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          longResult[i] = (long) (maxValue - value[j]);
           i++;
         }
         return longResult;
-
       case DATA_FLOAT:
-
         float[] floatResult = new float[value.length];
-
-        for (double a : value) {
-          floatResult[i] = (float) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          floatResult[i] = (float) (maxValue - value[j]);
           i++;
         }
         return floatResult;
-
       default:
-
         double[] defaultResult = new double[value.length];
-
-        for (double a : value) {
-          defaultResult[i] = (double) (maxValue - a);
+        for (int j = 0; j < value.length; j++) {
+          defaultResult[i] = (double) (maxValue - value[j]);
           i++;
         }
         return defaultResult;
-
     }
   }
 
@@ -245,63 +199,44 @@ public class DoubleCompressor extends ValueCompressor {
     double[] value = dataHolder.getWritableDoubleValues();
     int i = 0;
     switch (changedDataType) {
-
       case DATA_BYTE:
-
         byte[] result = new byte[value.length];
-
-        for (double a : value) {
-          result[i] = (byte) a;
+        for (int j = 0; j < value.length; j++) {
+          result[i] = (byte) value[j];
           i++;
         }
         return result;
-
       case DATA_SHORT:
-
         short[] shortResult = new short[value.length];
-
-        for (double a : value) {
-          shortResult[i] = (short) a;
+        for (int j = 0; j < value.length; j++) {
+          shortResult[i] = (short) value[j];
           i++;
         }
         return shortResult;
-
       case DATA_INT:
-
         int[] intResult = new int[value.length];
-
-        for (double a : value) {
-          intResult[i] = (int) a;
+        for (int j = 0; j < value.length; j++) {
+          intResult[i] = (int) value[j];
           i++;
         }
         return intResult;
-
       case DATA_LONG:
       case DATA_BIGINT:
-
         long[] longResult = new long[value.length];
-
-        for (double a : value) {
-          longResult[i] = (long) a;
+        for (int j = 0; j < value.length; j++) {
+          longResult[i] = (long) value[j];
           i++;
         }
         return longResult;
-
       case DATA_FLOAT:
-
         float[] floatResult = new float[value.length];
-
-        for (double a : value) {
-          floatResult[i] = (float) a;
+        for (int j = 0; j < value.length; j++) {
+          floatResult[i] = (float) value[j];
           i++;
         }
         return floatResult;
-
       default:
-
         return value;
-
     }
   }
-
 }

--- a/core/src/main/java/org/apache/carbondata/core/compression/ValueCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/compression/ValueCompressor.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.carbondata.core.compression;
+
+import org.apache.carbondata.core.datastorage.store.dataholder.CarbonWriteDataHolder;
+import org.apache.carbondata.core.util.ValueCompressionUtil.COMPRESSION_TYPE;
+import org.apache.carbondata.core.util.ValueCompressionUtil.DataType;
+
+/**
+ * Measure compressor
+ */
+public abstract class ValueCompressor {
+
+  /**
+   *
+   * @param compType
+   * @param dataHolder
+   * @param changedDataType
+   * @param maxValue
+   * @param decimal
+   * @return compressed data
+   */
+  public Object getCompressedValues(COMPRESSION_TYPE compType, CarbonWriteDataHolder dataHolder,
+      DataType changedDataType, Object maxValue, int decimal) {
+    Object o;
+    switch (compType) {
+      case NONE:
+
+        o = compressNone(changedDataType, dataHolder);
+        return o;
+
+      case MAX_MIN:
+
+        o = compressMaxMin(changedDataType, dataHolder, maxValue);
+        return o;
+
+      case NON_DECIMAL_CONVERT:
+
+        o = compressNonDecimal(changedDataType, dataHolder, decimal);
+        return o;
+
+      default:
+        o = compressNonDecimalMaxMin(changedDataType, dataHolder, decimal, maxValue);
+        return o;
+    }
+  }
+
+  /**
+   *
+   * @param changedDataType
+   * @param dataHolder
+   * @param decimal
+   * @param maxValue
+   * @return compressed data
+   */
+  protected abstract Object compressNonDecimalMaxMin(DataType changedDataType,
+      CarbonWriteDataHolder dataHolder, int decimal, Object maxValue);
+
+  /**
+   *
+   * @param changedDataType
+   * @param dataHolder
+   * @param decimal
+   * @return compressed data
+   */
+  protected abstract Object compressNonDecimal(DataType changedDataType,
+      CarbonWriteDataHolder dataHolder, int decimal);
+
+  /**
+   *
+   * @param changedDataType
+   * @param dataHolder
+   * @param maxValue
+   * @return compressed data
+   */
+  protected abstract Object compressMaxMin(DataType changedDataType,
+      CarbonWriteDataHolder dataHolder, Object maxValue);
+
+  /**
+   *
+   * @param changedDataType
+   * @param dataHolder
+   * @return compressed data
+   */
+  protected abstract Object compressNone(DataType changedDataType,
+      CarbonWriteDataHolder dataHolder);
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressDefaultLong.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressDefaultLong.java
@@ -22,18 +22,21 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.datastorage.store.compression.ValueCompressonHolder;
 import org.apache.carbondata.core.datastorage.store.dataholder.CarbonReadDataHolder;
+import org.apache.carbondata.core.util.ValueCompressionUtil.DataType;
 
 public class UnCompressDefaultLong extends UnCompressNoneLong {
+  private static final LogService LOGGER = LogServiceFactory
+      .getLogService(UnCompressDefaultLong.class.getName());
 
-  private static final LogService LOGGER =
-      LogServiceFactory.getLogService(UnCompressDefaultLong.class.getName());
+  public UnCompressDefaultLong(DataType actualDataType) {
+    super(actualDataType);
+  }
 
   public ValueCompressonHolder.UnCompressValue getNew() {
     try {
       return (ValueCompressonHolder.UnCompressValue) clone();
     } catch (CloneNotSupportedException clnNotSupportedExc) {
-      LOGGER.error(clnNotSupportedExc,
-          clnNotSupportedExc.getMessage());
+      LOGGER.error(clnNotSupportedExc, clnNotSupportedExc.getMessage());
     }
     return null;
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinByteForLong.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinByteForLong.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.datastorage.store.compression.SnappyCompressio
 import org.apache.carbondata.core.datastorage.store.compression.ValueCompressonHolder;
 import org.apache.carbondata.core.datastorage.store.dataholder.CarbonReadDataHolder;
 import org.apache.carbondata.core.util.ValueCompressionUtil;
+import org.apache.carbondata.core.util.ValueCompressionUtil.DataType;
 
 public class UnCompressMaxMinByteForLong extends UnCompressMaxMinByte {
 
@@ -33,6 +34,9 @@ public class UnCompressMaxMinByteForLong extends UnCompressMaxMinByte {
   private static Compressor<byte[]> byteCompressor =
       SnappyCompression.SnappyByteCompression.INSTANCE;
 
+  public UnCompressMaxMinByteForLong(DataType actualDataType) {
+    super(actualDataType);
+  }
   @Override public ValueCompressonHolder.UnCompressValue getNew() {
     try {
       return (ValueCompressonHolder.UnCompressValue) clone();
@@ -44,7 +48,7 @@ public class UnCompressMaxMinByteForLong extends UnCompressMaxMinByte {
 
   @Override public ValueCompressonHolder.UnCompressValue compress() {
 
-    UnCompressMaxMinByteForLong byte1 = new UnCompressMaxMinByteForLong();
+    UnCompressMaxMinByteForLong byte1 = new UnCompressMaxMinByteForLong(actualDataType);
     byte1.setValue(byteCompressor.compress(value));
     return byte1;
   }
@@ -58,7 +62,7 @@ public class UnCompressMaxMinByteForLong extends UnCompressMaxMinByte {
   }
 
   @Override public ValueCompressonHolder.UnCompressValue getCompressorObject() {
-    return new UnCompressMaxMinByteForLong();
+    return new UnCompressMaxMinByteForLong(actualDataType);
   }
 
   @Override public CarbonReadDataHolder getValues(int decimal, Object maxValueObject) {

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinDefault.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinDefault.java
@@ -48,6 +48,15 @@ public class UnCompressMaxMinDefault implements ValueCompressonHolder.UnCompress
    */
   private double[] value;
 
+  /**
+   * actual data type
+   */
+  private DataType actualDataType;
+
+  public UnCompressMaxMinDefault(DataType actualDataType) {
+    this.actualDataType = actualDataType;
+  }
+
   @Override public void setValue(double[] value) {
     this.value = (double[]) value;
 
@@ -63,7 +72,7 @@ public class UnCompressMaxMinDefault implements ValueCompressonHolder.UnCompress
   }
 
   @Override public ValueCompressonHolder.UnCompressValue compress() {
-    UnCompressMaxMinByte byte1 = new UnCompressMaxMinByte();
+    UnCompressMaxMinByte byte1 = new UnCompressMaxMinByte(actualDataType);
     byte1.setValue(doubleCompressor.compress(value));
     return byte1;
   }
@@ -85,7 +94,7 @@ public class UnCompressMaxMinDefault implements ValueCompressonHolder.UnCompress
    * @see ValueCompressonHolder.UnCompressValue#getCompressorObject()
    */
   @Override public ValueCompressonHolder.UnCompressValue getCompressorObject() {
-    return new UnCompressMaxMinByte();
+    return new UnCompressMaxMinByte(actualDataType);
   }
 
   //TODO SIMIAN

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinDefaultLong.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinDefaultLong.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.datastorage.store.compression.SnappyCompressio
 import org.apache.carbondata.core.datastorage.store.compression.ValueCompressonHolder;
 import org.apache.carbondata.core.datastorage.store.dataholder.CarbonReadDataHolder;
 import org.apache.carbondata.core.util.ValueCompressionUtil;
+import org.apache.carbondata.core.util.ValueCompressionUtil.DataType;
 
 public class UnCompressMaxMinDefaultLong extends UnCompressMaxMinLong {
 
@@ -33,6 +34,10 @@ public class UnCompressMaxMinDefaultLong extends UnCompressMaxMinLong {
   private static Compressor<long[]> longCompressor =
       SnappyCompression.SnappyLongCompression.INSTANCE;
 
+  public UnCompressMaxMinDefaultLong(DataType actualDataType) {
+    super(actualDataType);
+    // TODO Auto-generated constructor stub
+  }
   @Override public ValueCompressonHolder.UnCompressValue getNew() {
     try {
       return (ValueCompressonHolder.UnCompressValue) clone();
@@ -43,7 +48,7 @@ public class UnCompressMaxMinDefaultLong extends UnCompressMaxMinLong {
   }
 
   @Override public ValueCompressonHolder.UnCompressValue compress() {
-    UnCompressMaxMinByteForLong byte1 = new UnCompressMaxMinByteForLong();
+    UnCompressMaxMinByteForLong byte1 = new UnCompressMaxMinByteForLong(actualDataType);
     byte1.setValue(longCompressor.compress(value));
     return byte1;
   }
@@ -53,7 +58,7 @@ public class UnCompressMaxMinDefaultLong extends UnCompressMaxMinLong {
   }
 
   @Override public ValueCompressonHolder.UnCompressValue getCompressorObject() {
-    return new UnCompressMaxMinByteForLong();
+    return new UnCompressMaxMinByteForLong(actualDataType);
   }
 
   @Override public CarbonReadDataHolder getValues(int decimal, Object maxValueObject) {

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinFloat.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressMaxMinFloat.java
@@ -47,6 +47,12 @@ public class UnCompressMaxMinFloat implements UnCompressValue<float[]> {
    */
   private float[] value;
 
+  private DataType actualDataType;
+
+  public UnCompressMaxMinFloat(DataType actualDataType) {
+    this.actualDataType = actualDataType;
+  }
+
   @Override public void setValue(float[] value) {
     this.value = (float[]) value;
 
@@ -63,7 +69,7 @@ public class UnCompressMaxMinFloat implements UnCompressValue<float[]> {
 
   @Override public UnCompressValue compress() {
 
-    UnCompressMaxMinByte byte1 = new UnCompressMaxMinByte();
+    UnCompressMaxMinByte byte1 = new UnCompressMaxMinByte(actualDataType);
     byte1.setValue(floatCompressor.compress(value));
     return byte1;
   }
@@ -85,7 +91,7 @@ public class UnCompressMaxMinFloat implements UnCompressValue<float[]> {
    * @see ValueCompressonHolder.UnCompressValue#getCompressorObject()
    */
   @Override public UnCompressValue getCompressorObject() {
-    return new UnCompressMaxMinByte();
+    return new UnCompressMaxMinByte(actualDataType);
   }
 
   @Override public CarbonReadDataHolder getValues(int decimal, Object maxValueObject) {

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneByte.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneByte.java
@@ -47,6 +47,15 @@ public class UnCompressNoneByte implements UnCompressValue<byte[]> {
    */
   private byte[] value;
 
+  /**
+   * actual data type
+   */
+  private DataType actualDataType;
+
+  public UnCompressNoneByte(DataType actualDataType) {
+    this.actualDataType = actualDataType;
+  }
+
   @Override public UnCompressValue getNew() {
     try {
       return (UnCompressValue) clone();
@@ -61,13 +70,13 @@ public class UnCompressNoneByte implements UnCompressValue<byte[]> {
   }
 
   @Override public UnCompressValue uncompress(DataType dataType) {
-    UnCompressValue byte1 = ValueCompressionUtil.unCompressNone(dataType, dataType);
+    UnCompressValue byte1 = ValueCompressionUtil.unCompressNone(dataType, actualDataType);
     ValueCompressonHolder.unCompress(dataType, byte1, value);
     return byte1;
   }
 
   @Override public UnCompressValue compress() {
-    UnCompressNoneByte byte1 = new UnCompressNoneByte();
+    UnCompressNoneByte byte1 = new UnCompressNoneByte(actualDataType);
     byte1.setValue(byteCompressor.compress(value));
     return byte1;
   }
@@ -84,16 +93,40 @@ public class UnCompressNoneByte implements UnCompressValue<byte[]> {
    * @see ValueCompressonHolder.UnCompressValue#getCompressorObject()
    */
   @Override public UnCompressValue getCompressorObject() {
-    return new UnCompressNoneByte();
+    return new UnCompressNoneByte(actualDataType);
   }
 
   @Override public CarbonReadDataHolder getValues(int decimal, Object maxValueObject) {
+    switch (actualDataType) {
+      case DATA_BIGINT:
+        return unCompressLong();
+      default:
+        return unCompressDouble();
+    }
+
+  }
+
+  private CarbonReadDataHolder unCompressDouble() {
     CarbonReadDataHolder dataHldr = new CarbonReadDataHolder();
+
     double[] vals = new double[value.length];
+
     for (int i = 0; i < vals.length; i++) {
       vals[i] = value[i];
     }
     dataHldr.setReadableDoubleValues(vals);
+    return dataHldr;
+  }
+
+  private CarbonReadDataHolder unCompressLong() {
+    CarbonReadDataHolder dataHldr = new CarbonReadDataHolder();
+
+    long[] vals = new long[value.length];
+
+    for (int i = 0; i < vals.length; i++) {
+      vals[i] = value[i];
+    }
+    dataHldr.setReadableLongValues(vals);
     return dataHldr;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneDefault.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneDefault.java
@@ -46,6 +46,12 @@ public class UnCompressNoneDefault implements UnCompressValue<double[]> {
    */
   private double[] value;
 
+  private DataType actualDataType;
+
+  public UnCompressNoneDefault(DataType actualDataType) {
+    this.actualDataType = actualDataType;
+  }
+
   @Override public void setValue(double[] value) {
     this.value = value;
 
@@ -61,7 +67,7 @@ public class UnCompressNoneDefault implements UnCompressValue<double[]> {
   }
 
   @Override public UnCompressValue compress() {
-    UnCompressNoneByte byte1 = new UnCompressNoneByte();
+    UnCompressNoneByte byte1 = new UnCompressNoneByte(actualDataType);
     byte1.setValue(doubleCompressor.compress(value));
 
     return byte1;
@@ -75,7 +81,7 @@ public class UnCompressNoneDefault implements UnCompressValue<double[]> {
    * @see ValueCompressonHolder.UnCompressValue#getCompressorObject()
    */
   @Override public UnCompressValue getCompressorObject() {
-    return new UnCompressNoneByte();
+    return new UnCompressNoneByte(actualDataType);
   }
 
   @Override public byte[] getBackArrayData() {

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneFloat.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneFloat.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.datastorage.store.compression.SnappyCompressio
 import org.apache.carbondata.core.datastorage.store.compression.ValueCompressonHolder;
 import org.apache.carbondata.core.datastorage.store.dataholder.CarbonReadDataHolder;
 import org.apache.carbondata.core.util.ValueCompressionUtil;
+import org.apache.carbondata.core.util.ValueCompressionUtil.DataType;
 
 public class UnCompressNoneFloat implements ValueCompressonHolder.UnCompressValue<float[]> {
   /**
@@ -45,6 +46,12 @@ public class UnCompressNoneFloat implements ValueCompressonHolder.UnCompressValu
    */
   private float[] value;
 
+  private DataType actualDataType;
+
+  public UnCompressNoneFloat(DataType actualDataType) {
+    this.actualDataType = actualDataType;
+  }
+
   @Override public void setValue(float[] value) {
     this.value = value;
 
@@ -60,7 +67,7 @@ public class UnCompressNoneFloat implements ValueCompressonHolder.UnCompressValu
   }
 
   @Override public ValueCompressonHolder.UnCompressValue compress() {
-    UnCompressNoneByte byte1 = new UnCompressNoneByte();
+    UnCompressNoneByte byte1 = new UnCompressNoneByte(this.actualDataType);
     byte1.setValue(floatCompressor.compress(value));
 
     return byte1;
@@ -76,7 +83,7 @@ public class UnCompressNoneFloat implements ValueCompressonHolder.UnCompressValu
    * @see ValueCompressonHolder.UnCompressValue#getCompressorObject()
    */
   @Override public ValueCompressonHolder.UnCompressValue getCompressorObject() {
-    return new UnCompressNoneByte();
+    return new UnCompressNoneByte(this.actualDataType);
   }
 
   @Override public CarbonReadDataHolder getValues(int decimal, Object maxValueObject) {

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneInt.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneInt.java
@@ -45,6 +45,12 @@ public class UnCompressNoneInt implements ValueCompressonHolder.UnCompressValue<
    */
   private int[] value;
 
+  private DataType actualDataType;
+
+  public UnCompressNoneInt(DataType actualDataType) {
+    this.actualDataType = actualDataType;
+  }
+
   @Override public void setValue(int[] value) {
     this.value = value;
 
@@ -64,7 +70,7 @@ public class UnCompressNoneInt implements ValueCompressonHolder.UnCompressValue<
   }
 
   @Override public ValueCompressonHolder.UnCompressValue compress() {
-    UnCompressNoneByte byte1 = new UnCompressNoneByte();
+    UnCompressNoneByte byte1 = new UnCompressNoneByte(this.actualDataType);
     byte1.setValue(intCompressor.compress(value));
 
     return byte1;
@@ -84,10 +90,19 @@ public class UnCompressNoneInt implements ValueCompressonHolder.UnCompressValue<
    * @see ValueCompressonHolder.UnCompressValue#getCompressorObject()
    */
   @Override public ValueCompressonHolder.UnCompressValue getCompressorObject() {
-    return new UnCompressNoneByte();
+    return new UnCompressNoneByte(this.actualDataType);
   }
 
   @Override public CarbonReadDataHolder getValues(int decimal, Object maxValueObject) {
+    switch (actualDataType) {
+      case DATA_BIGINT:
+        return unCompressLong();
+      default:
+        return unCompressDouble();
+    }
+  }
+
+  private CarbonReadDataHolder unCompressDouble() {
     CarbonReadDataHolder dataHolderInfoObj = new CarbonReadDataHolder();
     double[] vals = new double[value.length];
     for (int i = 0; i < vals.length; i++) {
@@ -98,4 +113,14 @@ public class UnCompressNoneInt implements ValueCompressonHolder.UnCompressValue<
     return dataHolderInfoObj;
   }
 
+  private CarbonReadDataHolder unCompressLong() {
+    CarbonReadDataHolder dataHolderInfoObj = new CarbonReadDataHolder();
+    long[] vals = new long[value.length];
+    for (int i = 0; i < vals.length; i++) {
+      vals[i] = value[i];
+    }
+
+    dataHolderInfoObj.setReadableLongValues(vals);
+    return dataHolderInfoObj;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneShort.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/compression/type/UnCompressNoneShort.java
@@ -48,6 +48,12 @@ public class UnCompressNoneShort implements ValueCompressonHolder.UnCompressValu
    */
   private short[] shortValue;
 
+  private DataType actualDataType;
+
+  public UnCompressNoneShort(DataType actualDataType) {
+    this.actualDataType = actualDataType;
+  }
+
   @Override public void setValue(short[] shortValue) {
     this.shortValue = shortValue;
 
@@ -64,7 +70,7 @@ public class UnCompressNoneShort implements ValueCompressonHolder.UnCompressValu
 
   @Override public ValueCompressonHolder.UnCompressValue compress() {
 
-    UnCompressNoneByte byte1 = new UnCompressNoneByte();
+    UnCompressNoneByte byte1 = new UnCompressNoneByte(this.actualDataType);
     byte1.setValue(shortCompressor.compress(shortValue));
 
     return byte1;
@@ -88,17 +94,39 @@ public class UnCompressNoneShort implements ValueCompressonHolder.UnCompressValu
    * @see ValueCompressonHolder.UnCompressValue#getCompressorObject()
    */
   @Override public ValueCompressonHolder.UnCompressValue getCompressorObject() {
-    return new UnCompressNoneByte();
+    return new UnCompressNoneByte(this.actualDataType);
   }
 
   @Override public CarbonReadDataHolder getValues(int decimal, Object maxValueObject) {
-    CarbonReadDataHolder dataHolder = new CarbonReadDataHolder();
+    switch (actualDataType) {
+      case DATA_BIGINT:
+        return unCompressLong();
+      default:
+        return unCompressDouble();
+    }
+  }
+
+  private CarbonReadDataHolder unCompressDouble() {
+    CarbonReadDataHolder dataHldr = new CarbonReadDataHolder();
+
     double[] vals = new double[shortValue.length];
+
     for (int i = 0; i < vals.length; i++) {
       vals[i] = shortValue[i];
     }
-    dataHolder.setReadableDoubleValues(vals);
-    return dataHolder;
+    dataHldr.setReadableDoubleValues(vals);
+    return dataHldr;
   }
 
+  private CarbonReadDataHolder unCompressLong() {
+    CarbonReadDataHolder dataHldr = new CarbonReadDataHolder();
+
+    long[] vals = new long[shortValue.length];
+
+    for (int i = 0; i < vals.length; i++) {
+      vals[i] = shortValue[i];
+    }
+    dataHldr.setReadableLongValues(vals);
+    return dataHldr;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastorage/store/impl/data/compressed/AbstractHeavyCompressedDoubleArrayDataStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastorage/store/impl/data/compressed/AbstractHeavyCompressedDoubleArrayDataStore.java
@@ -64,17 +64,12 @@ public abstract class AbstractHeavyCompressedDoubleArrayDataStore
       values[i] = compressionModel.getUnCompressValues()[i].getNew();
       if (type[i] != CarbonCommonConstants.BYTE_VALUE_MEASURE
           && type[i] != CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
-        if (type[i] == CarbonCommonConstants.BIG_INT_MEASURE) {
-          values[i].setValue(ValueCompressionUtil
-              .getCompressedValues(compressionModel.getCompType()[i],
-                  dataHolder[i].getWritableLongValues(), compressionModel.getChangedDataType()[i],
-                  (long) compressionModel.getMaxValue()[i], compressionModel.getDecimal()[i]));
-        } else {
-          values[i].setValue(ValueCompressionUtil
-              .getCompressedValues(compressionModel.getCompType()[i],
-                  dataHolder[i].getWritableDoubleValues(), compressionModel.getChangedDataType()[i],
-                  (double) compressionModel.getMaxValue()[i], compressionModel.getDecimal()[i]));
-        }
+
+        values[i].setValue(
+            ValueCompressionUtil.getValueCompressor(compressionModel.getActualDataType()[i])
+                .getCompressedValues(compressionModel.getCompType()[i], dataHolder[i],
+                    compressionModel.getChangedDataType()[i], compressionModel.getMaxValue()[i],
+                    compressionModel.getDecimal()[i]));
       } else {
         values[i].setValue(dataHolder[i].getWritableByteArrayValues());
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ValueCompressionUtil.java
@@ -262,7 +262,7 @@ public final class ValueCompressionUtil {
   }
 
   /**
-   *
+   * It returns Compressor for given datatype
    * @param actualDataType
    * @return compressor based on actualdatatype
    */

--- a/core/src/test/java/org/apache/carbondata/core/util/ValueCompressionUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/ValueCompressionUtilTest.java
@@ -320,7 +320,7 @@ public class ValueCompressionUtilTest {
   @Test public void testToUnCompressNone() {
     ValueCompressonHolder.UnCompressValue result =
         ValueCompressionUtil.unCompressNone(DataType.DATA_BIGINT, DataType.DATA_BIGINT);
-    assertEquals(result.getClass(), UnCompressDefaultLong.class);
+    assertEquals(result.getClass(), UnCompressNoneDefault.class);
   }
 
   @Test public void testToUnCompressNoneForByte() {
@@ -563,10 +563,10 @@ public class ValueCompressionUtilTest {
   }
 
   @Test public void testToGetValueCompressionModel() {
-    Object[] maxValues = { 10, 20, 30 };
-    Object[] minValues = { 1, 2, 3 };
+    Object[] maxValues = { 10, 20, 30l };
+    Object[] minValues = { 1, 2, 3l };
     int[] decimalLength = { 0, 0, 0 };
-    Object[] uniqueValues = { 5, 3, 2 };
+    Object[] uniqueValues = { 5, 3, 2l };
     char[] types = { 'c', 'b', 'l' };
     byte[] dataTypeSelected = { 1, 2, 4 };
     MeasureMetaDataModel measureMetaDataModel =

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -1195,8 +1195,6 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
           long minVal = (long) min[count];
           max[count] = (maxVal > value ? max[count] : value);
           min[count] = (minVal < value ? min[count] : value);
-          int num = getDecimalCount(value);
-          decimal[count] = (decimal[count] > num ? decimal[count] : num);
         } else if (type[count] == CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
           byte[] buff = null;
           // in compaction flow the measure with decimal type will come as spark decimal.


### PR DESCRIPTION
**Problem**
Carbon convert int data type to bigint internally while doing data loading. It has compression mechanism for decimal and double data type. But it doesn't have compression mechanism for int and bigint data type.
So any table which has int and bigint datatype will lead to increase in size of store.

**Solution**
This pr will do compression for int and bigint data type as carbon does for double datatype.

**CI Pass Url**
http://136.243.101.176:8080/job/ApacheCarbonManualPRBuilder/643/