### PR TITLE
[CARBONDATA-429] Remove unnecessary file name check in dictionary cache

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryColumnUniqueIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryColumnUniqueIdentifier.java
@@ -49,8 +49,15 @@ public class DictionaryColumnUniqueIdentifier {
    */
   public DictionaryColumnUniqueIdentifier(CarbonTableIdentifier carbonTableIdentifier,
       ColumnIdentifier columnIdentifier) {
+    if (carbonTableIdentifier == null) {
+      throw new IllegalArgumentException("carbonTableIdentifier is null");
+    }
+    if (columnIdentifier == null) {
+      throw new IllegalArgumentException("columnIdentifier is null");
+    }
     this.carbonTableIdentifier = carbonTableIdentifier;
     this.columnIdentifier = columnIdentifier;
+    this.dataType = columnIdentifier.getDataType();
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCache.java
@@ -166,12 +166,9 @@ public class ForwardDictionaryCache<K extends DictionaryColumnUniqueIdentifier,
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier)
       throws CarbonUtilException {
     Dictionary forwardDictionary = null;
-    // create column dictionary info object only if dictionary and its
-    // metadata file exists for a given column identifier
-    if (!isFileExistsForGivenColumn(dictionaryColumnUniqueIdentifier)) {
-      throw new CarbonUtilException(
-          "Either dictionary or its metadata does not exist for column identifier :: "
-              + dictionaryColumnUniqueIdentifier.getColumnIdentifier());
+    // create column dictionary info object only if it is primitive type.
+    if (dictionaryColumnUniqueIdentifier.getDataType().isComplexType()) {
+      return null;
     }
     String columnIdentifier = dictionaryColumnUniqueIdentifier.getColumnIdentifier().getColumnId();
     ColumnDictionaryInfo columnDictionaryInfo =

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCache.java
@@ -166,10 +166,8 @@ public class ForwardDictionaryCache<K extends DictionaryColumnUniqueIdentifier,
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier)
       throws CarbonUtilException {
     Dictionary forwardDictionary = null;
-    // create column dictionary info object only if it is primitive type.
-    if (dictionaryColumnUniqueIdentifier.getDataType().isComplexType()) {
-      return null;
-    }
+    // dictionary is only for primitive data type
+    assert(!dictionaryColumnUniqueIdentifier.getDataType().isComplexType());
     String columnIdentifier = dictionaryColumnUniqueIdentifier.getColumnIdentifier().getColumnId();
     ColumnDictionaryInfo columnDictionaryInfo =
         getColumnDictionaryInfo(dictionaryColumnUniqueIdentifier, columnIdentifier);

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCache.java
@@ -167,12 +167,9 @@ public class ReverseDictionaryCache<K extends DictionaryColumnUniqueIdentifier,
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier)
       throws CarbonUtilException {
     Dictionary reverseDictionary = null;
-    // create column dictionary info object only if dictionary and its
-    // metadata file exists for a given column identifier
-    if (!isFileExistsForGivenColumn(dictionaryColumnUniqueIdentifier)) {
-      throw new CarbonUtilException(
-          "Either dictionary or its metadata does not exist for column identifier :: "
-              + dictionaryColumnUniqueIdentifier.getColumnIdentifier());
+    // create column dictionary info object only if it is primitive type.
+    if (dictionaryColumnUniqueIdentifier.getDataType().isComplexType()) {
+      return null;
     }
     String columnIdentifier = dictionaryColumnUniqueIdentifier.getColumnIdentifier().getColumnId();
     ColumnReverseDictionaryInfo columnReverseDictionaryInfo =

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCache.java
@@ -167,10 +167,8 @@ public class ReverseDictionaryCache<K extends DictionaryColumnUniqueIdentifier,
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier)
       throws CarbonUtilException {
     Dictionary reverseDictionary = null;
-    // create column dictionary info object only if it is primitive type.
-    if (dictionaryColumnUniqueIdentifier.getDataType().isComplexType()) {
-      return null;
-    }
+    // dictionary is only for primitive data type
+    assert(!dictionaryColumnUniqueIdentifier.getDataType().isComplexType());
     String columnIdentifier = dictionaryColumnUniqueIdentifier.getColumnIdentifier().getColumnId();
     ColumnReverseDictionaryInfo columnReverseDictionaryInfo =
         getColumnReverseDictionaryInfo(dictionaryColumnUniqueIdentifier, columnIdentifier);

--- a/core/src/main/java/org/apache/carbondata/core/carbon/metadata/datatype/DataType.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/metadata/datatype/DataType.java
@@ -51,4 +51,8 @@ public enum DataType {
   public String getName() {
     return name;
   }
+
+  public boolean isComplexType() {
+    return precedenceOrder >= 9 && precedenceOrder <= 11;
+  }
 }

--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
@@ -35,6 +35,7 @@ import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.cache.CacheType;
 import org.apache.carbondata.core.carbon.CarbonTableIdentifier;
 import org.apache.carbondata.core.carbon.ColumnIdentifier;
+import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.reader.CarbonDictionaryColumnMetaChunk;
 import org.apache.carbondata.core.util.CarbonProperties;
@@ -270,7 +271,7 @@ public class ReverseDictionaryCacheTest extends AbstractDictionaryCacheTest {
   }
   protected DictionaryColumnUniqueIdentifier createDictionaryColumnUniqueIdentifier(
 	      String columnId) {
-	    ColumnIdentifier columnIdentifier = new ColumnIdentifier(columnId, null, null);
+	    ColumnIdentifier columnIdentifier = new ColumnIdentifier(columnId, null, DataType.DOUBLE);
 	    DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier =
 	        new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier);
 	    return dictionaryColumnUniqueIdentifier;

--- a/core/src/test/java/org/apache/carbondata/scan/filter/FilterUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/scan/filter/FilterUtilTest.java
@@ -416,21 +416,6 @@ public class FilterUtilTest extends AbstractDictionaryCacheTest {
     assertTrue(FilterUtil.prepareDefaultEndIndexKey(segmentProperties) instanceof IndexKey);
   }
 
-  @Test(expected = QueryExecutionException.class)
-  public void testGetForwardDictionaryCacheWithException() throws Exception {
-
-    AbsoluteTableIdentifier absoluteTableIdentifier =
-        new AbsoluteTableIdentifier(this.carbonStorePath, carbonTableIdentifier);
-    int ordinal = 1;
-    int keyOrdinal = 1;
-    int columnGroupOrdinal = 1;
-    int complexTypeOrdinal = 1;
-    CarbonDimension carbonDimension =
-        new CarbonDimension(columnSchema, ordinal, keyOrdinal, columnGroupOrdinal,
-            complexTypeOrdinal);
-    FilterUtil.getForwardDictionaryCache(absoluteTableIdentifier, carbonDimension);
-  }
-
   @Test public void testCheckIfRightExpressionRequireEvaluation() {
     Expression expression = new ColumnExpression("test", DataType.STRING);
     boolean result = FilterUtil.checkIfRightExpressionRequireEvaluation(expression);


### PR DESCRIPTION
In dictionary cache, there are currently unnecessary file name check for each column, which increase the number of HDFS interactions unnecessarily.
In this PR, file name check is replaced by primitive type check, and returns null if it is a complex type.

One test case (`testGetForwardDictionaryCacheWithException`) is removed, it is expecting an exception when getting the dictionary from cache when the cache is not there. It is invalid test case now as the file name check is removed