### PR TITLE
[CARBONDATA-441] Add modules for spark2 integration

### DIFF
--- a/integration/spark-common/pom.xml
+++ b/integration/spark-common/pom.xml
@@ -26,19 +26,12 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>carbondata-spark</artifactId>
-  <name>Apache CarbonData :: Spark</name>
+  <artifactId>carbondata-spark-common</artifactId>
+  <name>Apache CarbonData :: Spark Common</name>
 
   <properties>
     <dev.path>${basedir}/../../dev</dev.path>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>pentaho-releases</id>
-      <url>http://repository.pentaho.org/artifactory/repo/</url>
-    </repository>
-  </repositories>
 
   <dependencies>
     <dependency>
@@ -64,11 +57,6 @@
     <dependency>
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-hadoop</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -180,7 +168,7 @@
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
           <filereports>CarbonTestSuite.txt</filereports>
-          <argLine>-ea -Xmx3g -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=512m 
+          <argLine>-ea -Xmx3g -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=512m
           </argLine>
           <stderr />
           <environmentVariables>

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -26,26 +26,14 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>carbondata-spark</artifactId>
-  <name>Apache CarbonData :: Spark</name>
+  <artifactId>carbondata-spark2</artifactId>
+  <name>Apache CarbonData :: Spark2</name>
 
   <properties>
     <dev.path>${basedir}/../../dev</dev.path>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>pentaho-releases</id>
-      <url>http://repository.pentaho.org/artifactory/repo/</url>
-    </repository>
-  </repositories>
-
   <dependencies>
-    <dependency>
-      <groupId>com.databricks</groupId>
-      <artifactId>spark-csv_${scala.binary.version}</artifactId>
-      <version>1.2.0</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,9 @@
     <module>core</module>
     <module>processing</module>
     <module>hadoop</module>
-    <module>integration/spark</module>
     <module>assembly</module>
     <module>examples</module>
+    <module>integration/spark-common</module>
   </modules>
 
   <properties>
@@ -286,15 +286,33 @@
     <profile>
       <id>spark-1.5</id>
       <!-- default -->
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <spark.version>1.5.2</spark.version>
       </properties>
+      <modules>
+        <module>integration/spark</module>
+      </modules>
     </profile>
     <profile>
       <id>spark-1.6</id>
       <properties>
         <spark.version>1.6.2</spark.version>
       </properties>
+      <modules>
+        <module>integration/spark</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>spark-2.0</id>
+      <properties>
+        <spark.version>2.0.0</spark.version>
+      </properties>
+      <modules>
+        <module>integration/spark2</module>
+      </modules>
     </profile>
     <profile>
       <id>integration-test</id>


### PR DESCRIPTION
To start spark2.0 integration with CarbonData, new modules need to be added:
1. spark-common, which will have all common classes for both spark1 and spark2 integration
2. spark2, which have carbon-spark2 integration

After the spark2 integration is done, CarbonData master branch should be enable to work with both spark1 and spark2. The target assembling is build by using profile, like:
- To build integration with spark1.5: use -Pspark-1.5
- To build integration with spark1.6: use -Pspark-1.6
- To build integration with spark2.0: use -Pspark-2.0
