### PR TITLE
[CARBONDATA-447] Use Carbon log service instead of spark Logging

### DIFF
--- a/examples/src/main/scala/org/apache/carbondata/examples/util/AllDictionaryUtil.scala
+++ b/examples/src/main/scala/org/apache/carbondata/examples/util/AllDictionaryUtil.scala
@@ -21,12 +21,13 @@ import java.io.DataOutputStream
 
 import scala.collection.mutable.{ArrayBuffer, HashSet}
 
-import org.apache.spark.Logging
 import org.apache.spark.SparkContext
 
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory
 
-object AllDictionaryUtil extends Logging{
+object AllDictionaryUtil {
+  private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
   def extractDictionary(sc: SparkContext,
                         srcData: String,
                         outputPath: String,
@@ -50,7 +51,7 @@ object AllDictionaryUtil extends Logging{
             result += ((i, tokens(i)))
           } catch {
             case ex: ArrayIndexOutOfBoundsException =>
-              logError("Read a bad record: " + x)
+              LOGGER.error("Read a bad record: " + x)
           }
         }
       }
@@ -75,7 +76,7 @@ object AllDictionaryUtil extends Logging{
       }
     } catch {
       case ex: Exception =>
-        logError("Clean dictionary catching exception:" + ex)
+        LOGGER.error("Clean dictionary catching exception:" + ex)
     }
   }
 
@@ -93,14 +94,14 @@ object AllDictionaryUtil extends Logging{
       }
     } catch {
       case ex: Exception =>
-        logError("Save dictionary to file catching exception:" + ex)
+        LOGGER.error("Save dictionary to file catching exception:" + ex)
     } finally {
       if (writer != null) {
         try {
           writer.close()
         } catch {
           case ex: Exception =>
-            logError("Close output stream catching exception:" + ex)
+            LOGGER.error("Close output stream catching exception:" + ex)
         }
       }
     }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -18,15 +18,17 @@
 package org.apache.carbondata.spark
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.command.LoadTable
 import org.apache.spark.sql.types._
 
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.carbon.metadata.datatype.{DataType => CarbonType}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 
-class CarbonDataFrameWriter(val dataFrame: DataFrame) extends Logging {
+class CarbonDataFrameWriter(val dataFrame: DataFrame) {
+
+  private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
   def saveAsCarbonFile(parameters: Map[String, String] = Map()): Unit = {
     checkContext()
@@ -84,7 +86,7 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) extends Logging {
       size
     }
 
-    logInfo(s"temporary CSV file size: ${countSize / 1024 / 1024} MB")
+    LOGGER.info(s"temporary CSV file size: ${countSize / 1024 / 1024} MB")
 
     try {
       cc.sql(makeLoadString(tempCSVFolder, options))

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonCleanFilesRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonCleanFilesRDD.scala
@@ -20,7 +20,7 @@ package org.apache.carbondata.spark.rdd
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.command.Partitioner
 
@@ -34,7 +34,7 @@ class CarbonCleanFilesRDD[V: ClassTag](
     databaseName: String,
     tableName: String,
     partitioner: Partitioner)
-  extends RDD[V](sc, Nil) with Logging {
+  extends RDD[V](sc, Nil) {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
@@ -19,7 +19,7 @@ package org.apache.carbondata.spark.rdd
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.command.Partitioner
 
@@ -42,7 +42,7 @@ class CarbonDeleteLoadByDateRDD[K, V](
     dimTableName: String,
     storePath: String,
     loadMetadataDetails: List[LoadMetadataDetails])
-  extends RDD[(K, V)](sc, Nil) with Logging {
+  extends RDD[(K, V)](sc, Nil) {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeleteLoadRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeleteLoadRDD.scala
@@ -20,7 +20,7 @@ package org.apache.carbondata.spark.rdd
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.command.Partitioner
 
@@ -34,7 +34,7 @@ class CarbonDeleteLoadRDD[V: ClassTag](
     databaseName: String,
     tableName: String,
     partitioner: Partitioner)
-  extends RDD[V](sc, Nil) with Logging {
+  extends RDD[V](sc, Nil) {
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
 
   override def getPartitions: Array[Partition] = {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDropTableRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDropTableRDD.scala
@@ -19,7 +19,7 @@ package org.apache.carbondata.spark.rdd
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.command.Partitioner
 
@@ -32,7 +32,7 @@ class CarbonDropTableRDD[V: ClassTag](
     databaseName: String,
     tableName: String,
     partitioner: Partitioner)
-  extends RDD[V](sc, Nil) with Logging {
+  extends RDD[V](sc, Nil) {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -171,7 +171,7 @@ case class ColumnDistinctValues(values: Array[String], rowCount: Long) extends S
 class CarbonAllDictionaryCombineRDD(
     prev: RDD[(String, Iterable[String])],
     model: DictionaryLoadModel)
-  extends RDD[(Int, ColumnDistinctValues)](prev) with Logging {
+  extends RDD[(Int, ColumnDistinctValues)](prev) {
 
   override def getPartitions: Array[Partition] = {
     firstParent[(String, Iterable[String])].partitions
@@ -235,7 +235,7 @@ class CarbonAllDictionaryCombineRDD(
 class CarbonBlockDistinctValuesCombineRDD(
     prev: RDD[Row],
     model: DictionaryLoadModel)
-  extends RDD[(Int, ColumnDistinctValues)](prev) with Logging {
+  extends RDD[(Int, ColumnDistinctValues)](prev) {
 
   override def getPartitions: Array[Partition] = firstParent[Row].partitions
 
@@ -285,7 +285,7 @@ class CarbonBlockDistinctValuesCombineRDD(
 class CarbonGlobalDictionaryGenerateRDD(
     prev: RDD[(Int, ColumnDistinctValues)],
     model: DictionaryLoadModel)
-  extends RDD[(Int, String, Boolean)](prev) with Logging {
+  extends RDD[(Int, String, Boolean)](prev) {
 
   override def getPartitions: Array[Partition] = firstParent[(Int, ColumnDistinctValues)].partitions
 
@@ -479,7 +479,7 @@ class CarbonColumnDictGenerateRDD(carbonLoadModel: CarbonLoadModel,
     dimensions: Array[CarbonDimension],
     hdfsLocation: String,
     dictFolderPath: String)
-  extends RDD[(Int, ColumnDistinctValues)](sparkContext, Nil) with Logging {
+  extends RDD[(Int, ColumnDistinctValues)](sparkContext, Nil) {
 
   override def getPartitions: Array[Partition] = {
     val primDimensions = dictionaryLoadModel.primDimensions

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -56,7 +56,7 @@ class CarbonMergerRDD[K, V](
     carbonLoadModel: CarbonLoadModel,
     carbonMergerMapping: CarbonMergerMapping,
     confExecutorsTemp: String)
-  extends RDD[(K, V)](sc, Nil) with Logging {
+  extends RDD[(K, V)](sc, Nil) {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
   sc.setLocalProperty("spark.job.interruptOnCancel", "true")

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.InputSplit
 import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.hive.DistributionUtil
 
@@ -76,7 +76,7 @@ class CarbonScanRDD[V: ClassTag](
     tableCreationTime: Long,
     schemaLastUpdatedTime: Long,
     baseStoreLocation: String)
-  extends RDD[V](sc, Nil) with Logging {
+  extends RDD[V](sc, Nil) {
 
 
   override def getPartitions: Array[Partition] = {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -24,7 +24,7 @@ import java.util.{Date, UUID}
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.mapred.{CarbonHadoopMapReduceUtil, CarbonSerializableConfiguration}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.command.Partitioner
@@ -55,7 +55,7 @@ class NewCarbonDataLoadRDD[K, V](
     loadCount: Integer,
     blocksGroupBy: Array[(String, Array[BlockDetails])],
     isTableSplitPartition: Boolean)
-  extends RDD[(K, V)](sc, Nil) with CarbonHadoopMapReduceUtil with Logging {
+  extends RDD[(K, V)](sc, Nil) with CarbonHadoopMapReduceUtil {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -21,11 +21,11 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.hive.{CarbonMetaData, DictionaryMap}
 import org.apache.spark.sql.types._
 
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.carbon.metadata.datatype.{DataType => CarbonDataType}
 import org.apache.carbondata.core.carbon.metadata.encoder.Encoding
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable
@@ -33,7 +33,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 
-object CarbonScalaUtil extends Logging {
+object CarbonScalaUtil {
   def convertSparkToCarbonDataType(
       dataType: org.apache.spark.sql.types.DataType): CarbonDataType = {
     dataType match {
@@ -149,7 +149,8 @@ object CarbonScalaUtil extends Logging {
           // find the kettle home under the previous folder
           // e.g:file:/srv/bigdata/install/spark/sparkJdbc/carbonlib/cabonplugins
           kettleHomePath = carbonLibPath + File.separator + CarbonCommonConstants.KETTLE_HOME_NAME
-          logInfo(s"carbon.kettle.home path is not exists, reset it as $kettleHomePath")
+          val logger = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+          logger.error(s"carbon.kettle.home path is not exists, reset it as $kettleHomePath")
           val newKettleHomeFileType = FileFactory.getFileType(kettleHomePath)
           val newKettleHomeFile = FileFactory.getCarbonFile(kettleHomePath, newKettleHomeFileType)
           // check if the found kettle home exists

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -21,7 +21,7 @@ import java.io.File
 
 import scala.language.implicitConversions
 
-import org.apache.spark.{Logging, SparkContext}
+import org.apache.spark.SparkContext
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.sql.catalyst.ParserDialect
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, OverrideCatalog}
@@ -41,7 +41,7 @@ import org.apache.carbondata.spark.rdd.CarbonDataFrameRDD
 class CarbonContext(
     val sc: SparkContext,
     val storePath: String,
-    metaStorePath: String) extends HiveContext(sc) with Logging {
+    metaStorePath: String) extends HiveContext(sc) {
   self =>
 
   def this(sc: SparkContext) = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -132,9 +132,7 @@ class CarbonHadoopFSRDD[V: ClassTag](
   identifier: AbsoluteTableIdentifier,
   inputFormatClass: Class[_ <: CarbonInputFormat[V]],
   valueClass: Class[V])
-  extends RDD[V](sc, Nil)
-    with SparkHadoopMapReduceUtil
-    with Logging {
+  extends RDD[V](sc, Nil) with SparkHadoopMapReduceUtil {
 
   private val jobTrackerId: String = {
     val formatter = new SimpleDateFormat("yyyyMMddHHmm")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
@@ -132,7 +132,7 @@ private[sql] case class CarbonDatasourceRelation(
     tableIdentifier: TableIdentifier,
     alias: Option[String])
     (@transient context: SQLContext)
-    extends BaseRelation with Serializable with Logging {
+    extends BaseRelation with Serializable {
 
   lazy val carbonRelation: CarbonRelation = {
     CarbonEnv.getInstance(context)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -27,7 +27,6 @@ import scala.util.matching.Regex
 
 import org.apache.hadoop.hive.ql.lib.Node
 import org.apache.hadoop.hive.ql.parse._
-import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.CarbonTableIdentifierImplicit._
 import org.apache.spark.sql.catalyst.analysis._
@@ -48,8 +47,7 @@ import org.apache.carbondata.spark.util.CommonUtil
 /**
  * Parser for All Carbon DDL, DML cases in Unified context
  */
-class CarbonSqlParser()
-  extends AbstractSparkSQLParser with Logging {
+class CarbonSqlParser() extends AbstractSparkSQLParser {
 
   val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
   protected val AGGREGATE = carbonKeyWord("AGGREGATE")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -100,19 +100,16 @@ case class DictionaryMap(dictionaryMap: Map[String, Boolean]) {
 }
 
 class CarbonMetastoreCatalog(hiveContext: HiveContext, val storePath: String,
-    client: ClientInterface, queryId: String)
-  extends HiveMetastoreCatalog(client, hiveContext)
-    with spark.Logging {
+    client: ClientInterface, queryId: String) extends HiveMetastoreCatalog(client, hiveContext) {
 
-  @transient val LOGGER = LogServiceFactory
-    .getLogService("org.apache.spark.sql.CarbonMetastoreCatalog")
+  @transient
+  val LOGGER = LogServiceFactory.getLogService("org.apache.spark.sql.CarbonMetastoreCatalog")
 
   val tableModifiedTimeStore = new java.util.HashMap[String, Long]()
   tableModifiedTimeStore
     .put(CarbonCommonConstants.DATABASE_DEFAULT_NAME, System.currentTimeMillis())
 
   val metadata = loadMetadata(storePath)
-
 
   def getTableCreationTime(databaseName: String, tableName: String): Long = {
     val tableMeta = metadata.tablesMeta.filter(

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/cli/CarbonSQLCLIDriver.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/cli/CarbonSQLCLIDriver.scala
@@ -20,15 +20,18 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.{Logging, SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.scheduler.StatsReportListener
 import org.apache.spark.sql.CarbonContext
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.hive.thriftserver.{SparkSQLCLIDriver, SparkSQLEnv}
 import org.apache.spark.util.Utils
 
-object CarbonSQLCLIDriver extends Logging {
+import org.apache.carbondata.common.logging.LogServiceFactory
 
+object CarbonSQLCLIDriver {
+
+  private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
   var hiveContext: HiveContext = _
   var sparkContext: SparkContext = _
 
@@ -71,11 +74,8 @@ object CarbonSQLCLIDriver extends Logging {
         store.getCanonicalPath)
 
       hiveContext.setConf("spark.sql.hive.version", HiveContext.hiveExecutionVersion)
-
-      if (log.isDebugEnabled) {
-        hiveContext.hiveconf.getAllProperties.asScala.toSeq.sorted.foreach { case (k, v) =>
-          logDebug(s"HiveConf var: $k=$v")
-        }
+      hiveContext.hiveconf.getAllProperties.asScala.toSeq.sorted.foreach { case (k, v) =>
+        LOGGER.debug(s"HiveConf var: $k=$v")
       }
     }
   }

--- a/integration/spark/src/main/scala/org/apache/spark/util/FileUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/FileUtils.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.util
 
-import org.apache.spark.Logging
-
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastorage.store.filesystem.CarbonFile
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory
 import org.apache.carbondata.processing.etl.DataLoadingException
 
-object FileUtils extends Logging {
+object FileUtils {
   /**
    * append all csv file path to a String, file path separated by comma
    */
@@ -38,10 +37,12 @@ object FileUtils extends Logging {
       val path = carbonFile.getAbsolutePath
       val fileName = carbonFile.getName
       if (carbonFile.getSize == 0) {
-        logWarning(s"skip empty input file: $path")
+        LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+            .warn(s"skip empty input file: $path")
       } else if (fileName.startsWith(CarbonCommonConstants.UNDERSCORE) ||
                  fileName.startsWith(CarbonCommonConstants.POINT)) {
-        logWarning(s"skip invisible input file: $path")
+        LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+            .warn(s"skip invisible input file: $path")
       } else {
         stringBuild.append(path.replace('\\', '/')).append(CarbonCommonConstants.COMMA)
       }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
@@ -54,14 +54,14 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
       }
     } catch {
       case ex: Exception =>
-        logError("Build test file for block prune failed" + ex)
+        LOGGER.error(ex, "Build test file for block prune failed")
     } finally {
       if (writer != null) {
         try {
           writer.close()
         } catch {
           case ex: Exception =>
-            logError("Close output stream catching exception:" + ex)
+            LOGGER.error(ex, "Close output stream catching exception")
         }
       }
     }
@@ -107,7 +107,7 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
       }
     } catch {
       case ex: Exception =>
-        logError("Delete temp test data file for block prune catching exception:" + ex)
+        LOGGER.error(ex, "Delete temp test data file for block prune catching exception")
     }
     sql("DROP TABLE IF EXISTS blockprune")
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/DefaultSourceTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/DefaultSourceTestCase.scala
@@ -23,11 +23,11 @@ import java.io.File
 import java.io.FileWriter
 import java.util.Random
 
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.sql.common.util.CarbonHiveContext
 import org.apache.spark.sql.common.util.CarbonHiveContext.sql
 import org.apache.spark.sql.common.util.QueryTest
-
 import org.scalatest.BeforeAndAfterAll
 
 /**
@@ -69,7 +69,7 @@ class DefaultSourceTestCase extends QueryTest with BeforeAndAfterAll {
              (c1 string, c2 string, c3 int, c4 int)
              STORED BY 'org.apache.carbondata.format'""")
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataWithDicExcludeAndInclude.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataWithDicExcludeAndInclude.scala
@@ -63,7 +63,7 @@ class TestLoadDataWithDictionaryExcludeAndInclude extends QueryTest with BeforeA
            'DICTIONARY_INCLUDE'='ID')
         """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 
@@ -80,7 +80,7 @@ class TestLoadDataWithDictionaryExcludeAndInclude extends QueryTest with BeforeA
            LOAD DATA LOCAL INPATH './src/test/resources/emptyDimensionDataHive.csv' into table exclude_include_hive_t3
            """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
@@ -89,7 +89,7 @@ class AllDictionaryTestCase extends QueryTest with BeforeAndAfterAll {
           "age INT) STORED BY 'org.apache.carbondata.format'"
       )
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
     try {
       sql(
@@ -102,7 +102,7 @@ class AllDictionaryTestCase extends QueryTest with BeforeAndAfterAll {
           "TBLPROPERTIES('DICTIONARY_EXCLUDE'='ROMSize')"
       )
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
@@ -96,7 +96,7 @@ class AutoHighCardinalityIdentifyTestCase extends QueryTest with BeforeAndAfterA
              (hc1 string, c2 string, c3 int)
              STORED BY 'org.apache.carbondata.format'""")
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 
@@ -107,7 +107,7 @@ class AutoHighCardinalityIdentifyTestCase extends QueryTest with BeforeAndAfterA
              (hc1 string, c2 string, c3 int)
              STORED BY 'org.apache.carbondata.format' tblproperties('COLUMN_GROUPS'='(hc1,c2)')""")
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
   def relation(tableName: String): CarbonRelation = {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -83,7 +83,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
 
     try {
@@ -93,7 +93,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
 
     try {
@@ -108,7 +108,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
      TBLPROPERTIES('DICTIONARY_INCLUDE' = 'deviceInformationId')
       """)
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 
@@ -204,7 +204,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
         """)
     } catch {
       case ex: Exception =>
-        logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+        LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
         assert(false)
     }
     DictionaryTestCaseUtil.checkDictionary(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
@@ -88,7 +88,7 @@ class GlobalDictionaryUtilConcurrentTestCase extends QueryTest with BeforeAndAft
       sql(
         "CREATE TABLE IF NOT EXISTS employee (empid STRING) STORED BY 'org.apache.carbondata.format'")
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
@@ -97,7 +97,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
           "age INT) STORED BY 'org.apache.carbondata.format'"
       )
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
     try {
       sql(
@@ -106,7 +106,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
         "TBLPROPERTIES('DICTIONARY_EXCLUDE'='id,name')"
       )
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
     try {
       sql(
@@ -120,7 +120,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
 
       )
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
 
     try {
@@ -134,7 +134,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
           "TBLPROPERTIES('DICTIONARY_INCLUDE'='deviceInformationId')"
       )
     } catch {
-      case ex: Throwable => logError(ex.getMessage + "\r\n" + ex.getStackTraceString)
+      case ex: Throwable => LOGGER.error(ex.getMessage + "\r\n" + ex.getStackTraceString)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/spark/sql/common/util/CarbonFunSuite.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/sql/common/util/CarbonFunSuite.scala
@@ -19,11 +19,13 @@
 
 package org.apache.spark.sql.common.util
 
-import org.apache.spark.Logging
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.scalatest.{FunSuite, Outcome}
 
 
-private[spark] abstract class CarbonFunSuite extends FunSuite with Logging {
+private[spark] abstract class CarbonFunSuite extends FunSuite {
+
+  private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
   /**
    * Log the suite name and the test name before and after each test.
@@ -37,10 +39,10 @@ private[spark] abstract class CarbonFunSuite extends FunSuite with Logging {
     val suiteName = this.getClass.getName
     val shortSuiteName = suiteName.replaceAll("org.apache.spark", "o.a.s")
     try {
-      logInfo(s"\n\n===== TEST OUTPUT FOR $shortSuiteName: '$testName' =====\n")
+      LOGGER.info(s"\n\n===== TEST OUTPUT FOR $shortSuiteName: '$testName' =====\n")
       test()
     } finally {
-      logInfo(s"\n\n===== FINISHED $shortSuiteName: '$testName' =====\n")
+      LOGGER.info(s"\n\n===== FINISHED $shortSuiteName: '$testName' =====\n")
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
@@ -19,13 +19,16 @@ package org.apache.spark.sql.common.util
 
 import java.util.{Locale, TimeZone}
 
-import scala.collection.JavaConversions._
+import org.apache.carbondata.common.logging.LogServiceFactory
 
+import scala.collection.JavaConversions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 
 class QueryTest extends PlanTest {
+
+  val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
   // Timezone is fixed to America/Los_Angeles for those timezone sensitive tests (timestamp_*)
   TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))


### PR DESCRIPTION
Change all place that uses spark Logging interface, use log service in carbon-common module. This is a preparation towards spark2 integration.
No function is modified in this PR.