### PR TITLE
[CARBONDATA-451]Fix the bug of storePath.substring on windows which lead to query can not run

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
@@ -66,14 +66,15 @@ public class AbsoluteTableIdentifier implements Serializable {
   }
 
   public static AbsoluteTableIdentifier fromTablePath(String tablePath) {
-    String[] names = tablePath.replace('\\', '/').split("/");
+    String formattedTablePath = tablePath.replace('\\', '/');
+    String[] names = formattedTablePath.split("/");
     if (names.length < 3) {
       throw new IllegalArgumentException("invalid table path: " + tablePath);
     }
 
     String tableName = names[names.length - 1];
     String dbName = names[names.length - 2];
-    String storePath = tablePath.substring(0, tablePath.lastIndexOf(dbName +
+    String storePath = formattedTablePath.substring(0, formattedTablePath.lastIndexOf(dbName +
             CarbonCommonConstants.FILE_SEPARATOR + tableName));
 
     CarbonTableIdentifier identifier =

--- a/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifier.java
@@ -66,6 +66,8 @@ public class AbsoluteTableIdentifier implements Serializable {
   }
 
   public static AbsoluteTableIdentifier fromTablePath(String tablePath) {
+    //Here the tablePath might has '\' running on windows, for example: '/target/store\default\t3',
+    //need to format the tablePath to '\target\store\default\t3' and use the formattedTablePath.
     String formattedTablePath = tablePath.replace('\\', '/');
     String[] names = formattedTablePath.split("/");
     if (names.length < 3) {


### PR DESCRIPTION
## Why rasie this pr?
To fix the bug that when query execute on windows can not run, this is becasue when table path is got on windows, the patch might contains '\\' but current code substring the path not format it.
## How to solve?
Using the formatted table path.
## How to test?
Pass all the test cases.