### PR TITLE
[CARBONDATA-456] Fixing select count(*) slow issue

### DIFF
--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
@@ -71,6 +71,7 @@ public class ReverseDictionaryCacheTest extends AbstractDictionaryCacheTest {
     CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.CARBON_MAX_LEVEL_CACHE_SIZE, "10");
     CacheProvider cacheProvider = CacheProvider.getInstance();
+    cacheProvider.dropAllCache();
     reverseDictionaryCache =
         cacheProvider.createCache(CacheType.REVERSE_DICTIONARY, this.carbonStorePath);
   }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
@@ -55,18 +55,7 @@ public class CarbonInputFormatUtil {
     // fill dimensions
     // If columns are null, set all dimensions and measures
     int i = 0;
-    List<CarbonMeasure> tableMsrs = carbonTable.getMeasureByTableName(factTableName);
-    List<CarbonDimension> tableDims = carbonTable.getDimensionByTableName(factTableName);
-    if (columns == null) {
-      for (CarbonDimension dimension : tableDims) {
-        addQueryDimension(plan, i, dimension);
-        i++;
-      }
-      for (CarbonMeasure measure : tableMsrs) {
-        addQueryMeasure(plan, i, measure);
-        i++;
-      }
-    } else {
+    if (columns != null) {
       for (String column : columns) {
         CarbonDimension dimensionByName = carbonTable.getDimensionByName(factTableName, column);
         if (dimensionByName != null) {

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputMapperTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonInputMapperTest.java
@@ -59,7 +59,15 @@ public class CarbonInputMapperTest extends TestCase {
   @Test public void testInputFormatMapperReadAllRowsAndColumns() throws Exception {
     try {
       String outPath = "target/output";
-      runJob(outPath, null, null);
+      CarbonProjection carbonProjection = new CarbonProjection();
+      carbonProjection.addColumn("ID");
+      carbonProjection.addColumn("date");
+      carbonProjection.addColumn("country");
+      carbonProjection.addColumn("name");
+      carbonProjection.addColumn("phonetype");
+      carbonProjection.addColumn("serialname");
+      carbonProjection.addColumn("salary");
+      runJob(outPath, carbonProjection, null);
       Assert.assertEquals("Count lines are not matching", 1000, countTheLines(outPath));
       Assert.assertEquals("Column count are not matching", 7, countTheColumns(outPath));
     } catch (Exception e) {


### PR DESCRIPTION
In the current master select count(*) query is slower because it try to retrieve all columns out of store and count it. But it is not needed using metadata could count the number of rows. So in driver side we no need to add all columns when projection is null, just don't add any columns and execute to return the empty rows  but count could be calculated from those empty rows.