### PR TITLE
[CARBONDATA-493]fix bug for insert into select from empty table 

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -367,6 +367,13 @@ case class LoadTable(
 
 
   def run(sqlContext: SQLContext): Seq[Row] = {
+    if (dataFrame.isDefined) {
+      val rdd = dataFrame.get.rdd
+      if (rdd.partitions == null || rdd.partitions.length == 0) {
+        LOGGER.warn("DataLoading finished. No data was loaded.")
+        return Seq.empty
+      }
+    }
 
     val dbName = getDB.getDatabaseName(databaseNameOp, sqlContext)
     if (isOverwriteExist) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -293,8 +293,14 @@ case class LoadTable(
 
   val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
-
   def run(sparkSession: SparkSession): Seq[Row] = {
+    if (dataFrame.isDefined) {
+      val rdd = dataFrame.get.rdd
+      if (rdd.partitions == null || rdd.partitions.length == 0) {
+        LOGGER.warn("DataLoading finished. No data was loaded.")
+        return Seq.empty
+      }
+    }
 
     val dbName = databaseNameOp.getOrElse(sparkSession.catalog.currentDatabase)
     val identifier = TableIdentifier(tableName, Option(dbName))


### PR DESCRIPTION
InsertInto Feature:
If there is no partition in select sub-query dataframe , data loading will throw dataloadingexception

Solution:
The dataframe without partition, no need to do data loading.
