### PR TITLE
[SPARK2] Fix bug in spark2 module

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -1160,7 +1160,7 @@ class CarbonSqlParser() extends AbstractSparkSQLParser {
       case "string" => Field(field.column, Some("String"), field.name, Some(null), field.parent,
         field.storeType, field.schemaOrdinal
       )
-      case "smallint"  => Field(field.column, Some("SmallInt"), field.name, Some(null),
+      case "smallint" => Field(field.column, Some("SmallInt"), field.name, Some(null),
         field.parent, field.storeType, field.schemaOrdinal
       )
       case "integer" | "int" => Field(field.column, Some("Integer"), field.name, Some(null),

--- a/integration/spark2/src/main/java/org/apache/carbondata/spark/readsupport/SparkRowReadSupportImpl.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/spark/readsupport/SparkRowReadSupportImpl.java
@@ -48,7 +48,7 @@ public class SparkRowReadSupportImpl extends AbstractDictionaryDecodedReadSuppor
         } else if(dataTypes[i].equals(DataType.INT)) {
           data[i] = ((Long)(data[i])).intValue();
         } else if(dataTypes[i].equals(DataType.SHORT)) {
-          data[i] = ((Double)(data[i])).shortValue();
+          data[i] = ((Long)(data[i])).shortValue();
         }
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -24,6 +24,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.hadoop.readsupport.impl.RawDataReadSupport
 import org.apache.carbondata.spark.rdd.SparkCommonEnv
+import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 
 /**
  * Carbon Environment for unified context
@@ -57,7 +58,7 @@ object CarbonEnv {
   }
 
   private def setSparkCommonEnv(sqlContext: SQLContext): Unit = {
-    SparkCommonEnv.readSupportClass = classOf[RawDataReadSupport]
+    SparkCommonEnv.readSupportClass = classOf[SparkRowReadSupportImpl]
     SparkCommonEnv.numExistingExecutors = sqlContext.sparkContext.schedulerBackend match {
       case b: CoarseGrainedSchedulerBackend => b.getExecutorIds().length
       case _ => 0


### PR DESCRIPTION
CarbonExample in spark2 is failing because not setting current read support class.