### PR TITLE
[CARBONDATA-513] reduce new too many BigDecimal

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -299,10 +299,7 @@ public final class DataTypeUtil {
             return null;
           }
           java.math.BigDecimal javaDecVal = new java.math.BigDecimal(data);
-          scala.math.BigDecimal scalaDecVal = new scala.math.BigDecimal(javaDecVal);
-          org.apache.spark.sql.types.Decimal decConverter =
-              new org.apache.spark.sql.types.Decimal();
-          return decConverter.set(scalaDecVal);
+          return org.apache.spark.sql.types.Decimal.apply(javaDecVal);
         default:
           return UTF8String.fromString(data);
       }
@@ -325,11 +322,7 @@ public final class DataTypeUtil {
         case LONG:
           return data;
         case DECIMAL:
-          java.math.BigDecimal javaDecVal = new java.math.BigDecimal(data.toString());
-          scala.math.BigDecimal scalaDecVal = new scala.math.BigDecimal(javaDecVal);
-          org.apache.spark.sql.types.Decimal decConverter =
-              new org.apache.spark.sql.types.Decimal();
-          return decConverter.set(scalaDecVal);
+          return org.apache.spark.sql.types.Decimal.apply((java.math.BigDecimal) data);
         default:
           return data;
       }

--- a/core/src/main/java/org/apache/carbondata/scan/collector/impl/AbstractScannedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/scan/collector/impl/AbstractScannedResultCollector.java
@@ -100,20 +100,17 @@ public abstract class AbstractScannedResultCollector implements ScannedResultCol
 
   private Object getMeasureData(MeasureColumnDataChunk dataChunk, int index, DataType dataType) {
     if (!dataChunk.getNullValueIndexHolder().getBitSet().get(index)) {
-      Object msrVal;
       switch (dataType) {
         case SHORT:
         case INT:
         case LONG:
-          msrVal = dataChunk.getMeasureDataHolder().getReadableLongValueByIndex(index);
-          break;
+          return dataChunk.getMeasureDataHolder().getReadableLongValueByIndex(index);
         case DECIMAL:
-          msrVal = dataChunk.getMeasureDataHolder().getReadableBigDecimalValueByIndex(index);
-          break;
+          return  org.apache.spark.sql.types.Decimal.apply(
+                  dataChunk.getMeasureDataHolder().getReadableBigDecimalValueByIndex(index));
         default:
-          msrVal = dataChunk.getMeasureDataHolder().getReadableDoubleValueByIndex(index);
+          return  dataChunk.getMeasureDataHolder().getReadableDoubleValueByIndex(index);
       }
-      return DataTypeUtil.getMeasureDataBasedOnDataType(msrVal, dataType);
     }
     return null;
   }

--- a/core/src/main/java/org/apache/carbondata/scan/collector/impl/AbstractScannedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/scan/collector/impl/AbstractScannedResultCollector.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.carbon.datastore.chunk.MeasureColumnDataChunk;
 import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
-import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.scan.collector.ScannedResultCollector;
 import org.apache.carbondata.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.scan.executor.infos.KeyStructureInfo;

--- a/core/src/test/java/org/apache/carbondata/core/util/DataTypeUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/DataTypeUtilTest.java
@@ -117,7 +117,11 @@ public class DataTypeUtilTest {
     scala.math.BigDecimal scalaDecVal = new scala.math.BigDecimal(javaDecVal);
     org.apache.spark.sql.types.Decimal expected =
         new org.apache.spark.sql.types.Decimal().set(scalaDecVal);
-    assertEquals(getMeasureDataBasedOnDataType(1, DataType.DECIMAL), expected);
+    assertEquals(
+            getMeasureDataBasedOnDataType(
+                    new java.math.BigDecimal(1),
+                    DataType.DECIMAL),
+            expected);
     assertEquals(getMeasureDataBasedOnDataType("1", DataType.STRING), "1");
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/SparkUnknownExpression.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/SparkUnknownExpression.scala
@@ -42,11 +42,7 @@ class SparkUnknownExpression(var sparkExp: SparkExpression)
 
     val values = carbonRowInstance.getValues.toSeq.map {
       case s: String => org.apache.spark.unsafe.types.UTF8String.fromString(s)
-      case d: java.math.BigDecimal =>
-        val javaDecVal = new java.math.BigDecimal(d.toString)
-        val scalaDecVal = new scala.math.BigDecimal(javaDecVal)
-        val decConverter = new org.apache.spark.sql.types.Decimal()
-        decConverter.set(scalaDecVal)
+      case d: java.math.BigDecimal => org.apache.spark.sql.types.Decimal.apply(d)
       case value => value
     }
     try {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/SparkUnknownExpression.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/SparkUnknownExpression.scala
@@ -43,10 +43,7 @@ class SparkUnknownExpression(var sparkExp: SparkExpression)
     val values = carbonRowInstance.getValues.toSeq.map {
       case s: String => org.apache.spark.unsafe.types.UTF8String.fromString(s)
       case d: java.math.BigDecimal =>
-        val javaDecVal = new java.math.BigDecimal(d.toString)
-        val scalaDecVal = new scala.math.BigDecimal(javaDecVal)
-        val decConverter = new org.apache.spark.sql.types.Decimal()
-        decConverter.set(scalaDecVal)
+        org.apache.spark.sql.types.Decimal.apply(d)
       case value => value
     }
     try {


### PR DESCRIPTION
Currently, we new too many BigDecimal object while scan, we could reduce some unnecessary object allocate