### PR TITLE
[CARBONDATA-517] Use carbon property to get the store path/kettle home

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -360,8 +360,9 @@ public final class CarbonProperties {
    * @param key
    * @return properties value
    */
-  public void addProperty(String key, String value) {
+  public CarbonProperties addProperty(String key, String value) {
     carbonProperties.setProperty(key, value);
+    return this;
   }
 
   private ColumnarFormatVersion getDefaultFormatVersion() {

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -47,13 +47,15 @@ object CarbonExample {
         .master("local")
         .appName("CarbonExample")
         .enableHiveSupport()
-        .config("carbon.kettle.home",
-          s"$rootPath/processing/carbonplugins")
-        .config("carbon.storelocation", storeLocation)
         .config("spark.sql.warehouse.dir", warehouse)
         .config("javax.jdo.option.ConnectionURL",
           s"jdbc:derby:;databaseName=$metastoredb;create=true")
         .getOrCreate()
+
+    CarbonProperties.getInstance()
+      .addProperty("carbon.kettle.home", s"$rootPath/processing/carbonplugins")
+      .addProperty("carbon.storelocation", storeLocation)
+
     spark.sparkContext.setLogLevel("WARN")
 
     CarbonProperties.getInstance()

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -91,10 +91,7 @@ object CarbonScalaUtil {
   }
 
   def getKettleHome(sqlContext: SQLContext): String = {
-    var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
-    if (null == kettleHomePath) {
-      kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
-    }
+    var kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
     if (null == kettleHomePath) {
       val carbonHome = System.getenv("CARBON_HOME")
       if (null != carbonHome) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.hive.CarbonMetastore
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.hadoop.readsupport.impl.RawDataReadSupport
 import org.apache.carbondata.spark.rdd.SparkCommonEnv
 import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
@@ -42,8 +43,7 @@ object CarbonEnv {
   def init(sqlContext: SQLContext): Unit = {
     if (!initialized) {
       val catalog = {
-        val storePath = sqlContext.sparkSession.conf.get(
-        CarbonCommonConstants.STORE_LOCATION, "/user/hive/warehouse/carbonstore")
+        val storePath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION)
         LOGGER.info(s"carbon env initial: $storePath")
         new CarbonMetastore(sqlContext.sparkSession.conf, storePath)
       }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -42,7 +42,8 @@ object CarbonEnv {
   def init(sqlContext: SQLContext): Unit = {
     if (!initialized) {
       val catalog = {
-        val storePath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION)
+        val storePath =
+          CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION)
         LOGGER.info(s"carbon env initial: $storePath")
         new CarbonMetastore(sqlContext.sparkSession.conf, storePath)
       }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.hive.CarbonMetastore
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
-import org.apache.carbondata.hadoop.readsupport.impl.RawDataReadSupport
 import org.apache.carbondata.spark.rdd.SparkCommonEnv
 import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 


### PR DESCRIPTION
Spark conf will ignore the config which does not start with "spark.", so let's use carbon property to get the store path

/cc @QiangCai plz review this