### PR TITLE
[CARBONDATA-518]Fix the bug of CarbonExample in spark1.5 moudle

### DIFF
--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
@@ -42,8 +42,10 @@ object ExampleUtils {
     println(s"Starting $appName using spark version ${sc.version}")
 
     val cc = new CarbonContext(sc, storeLocation, currentPath + "/target/carbonmetastore")
-    cc.setConf("carbon.kettle.home", kettleHome)
 
+    CarbonProperties.getInstance()
+      .addProperty("carbon.kettle.home", kettleHome)
+      .addProperty("carbon.storelocation", storeLocation)
     // whether use table split partition
     // true -> use table split partition, support multiple partition loading
     // false -> use node split partition, support data load by host partition


### PR DESCRIPTION
## Why raise this pr?
CarbonExample of spark moudle can not run as kettlehome and storepath shoud get form carbon properties now
## How to test?
Pass CI