### PR TITLE
[CARBONDATA-520] Executor can not get the read support class

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkReadSupport.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkReadSupport.scala
@@ -21,10 +21,8 @@ import org.apache.carbondata.hadoop.readsupport.CarbonReadSupport
 
 // Used to solve cyclic-dependency issue of carbon-spark-common and carbon-spark, carbon-spark2
 // modules, variables or functions that different in carbon-spark and carbon-spark2 are set here
-object SparkCommonEnv {
+object SparkReadSupport {
 
   var readSupportClass: Class[_ <: CarbonReadSupport[_]] = _
-
-  var numExistingExecutors: Int = _
 
 }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -230,9 +230,6 @@ object DistributionUtil {
       hostToLocalTaskCount: Map[String, Int] = Map.empty): Boolean = {
     sc.schedulerBackend match {
       case b: CoarseGrainedSchedulerBackend =>
-        LOGGER.info(
-            s"number of required executors are = $requiredExecutors and existing executors are = " +
-            s"${b.getExecutorIds().length}")
         if (requiredExecutors > 0) {
           LOGGER.info(s"Requesting total executors: $requiredExecutors")
           b.requestTotalExecutors(requiredExecutors, localityAwareTasks, hostToLocalTaskCount)

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -29,7 +29,6 @@ import org.apache.carbondata.core.carbon.datastore.block.Distributable
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.load.CarbonLoaderUtil
-import org.apache.carbondata.spark.rdd.SparkCommonEnv
 
 object DistributionUtil {
   @transient
@@ -233,7 +232,7 @@ object DistributionUtil {
       case b: CoarseGrainedSchedulerBackend =>
         LOGGER.info(
             s"number of required executors are = $requiredExecutors and existing executors are = " +
-            s"${SparkCommonEnv.numExistingExecutors}")
+            s"${b.getExecutorIds().length}")
         if (requiredExecutors > 0) {
           LOGGER.info(s"Requesting total executors: $requiredExecutors")
           b.requestTotalExecutors(requiredExecutors, localityAwareTasks, hostToLocalTaskCount)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.sql.hive.CarbonMetastore
 
+import org.apache.carbondata.hadoop.readsupport.impl.RawDataReadSupport
 import org.apache.carbondata.spark.rdd.SparkReadSupport
-import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 
 case class CarbonEnv(carbonMetastore: CarbonMetastore)
 
@@ -30,7 +30,7 @@ object CarbonEnv {
   @volatile private var carbonEnv: CarbonEnv = _
 
   // set readsupport class global so that the executor can get it.
-  SparkReadSupport.readSupportClass = classOf[SparkRowReadSupportImpl]
+  SparkReadSupport.readSupportClass = classOf[RawDataReadSupport]
 
   var initialized = false
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -20,14 +20,17 @@ package org.apache.spark.sql
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.sql.hive.CarbonMetastore
 
-import org.apache.carbondata.hadoop.readsupport.impl.RawDataReadSupport
-import org.apache.carbondata.spark.rdd.SparkCommonEnv
+import org.apache.carbondata.spark.rdd.SparkReadSupport
+import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 
 case class CarbonEnv(carbonMetastore: CarbonMetastore)
 
 object CarbonEnv {
 
   @volatile private var carbonEnv: CarbonEnv = _
+
+  // set readsupport class global so that the executor can get it.
+  SparkReadSupport.readSupportClass = classOf[SparkRowReadSupportImpl]
 
   var initialized = false
 
@@ -36,7 +39,6 @@ object CarbonEnv {
       val cc = sqlContext.asInstanceOf[CarbonContext]
       val catalog = new CarbonMetastore(cc, cc.storePath, cc.hiveClientInterface, "")
       carbonEnv = CarbonEnv(catalog)
-      setSparkCommonEnv(sqlContext)
       initialized = true
     }
   }
@@ -44,14 +46,6 @@ object CarbonEnv {
   def get: CarbonEnv = {
     if (initialized) carbonEnv
     else throw new RuntimeException("CarbonEnv not initialized")
-  }
-
-  private def setSparkCommonEnv(sqlContext: SQLContext): Unit = {
-    SparkCommonEnv.readSupportClass = classOf[RawDataReadSupport]
-    SparkCommonEnv.numExistingExecutors = sqlContext.sparkContext.schedulerBackend match {
-      case b: CoarseGrainedSchedulerBackend => b.numExistingExecutors
-      case _ => 0
-    }
   }
 }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -62,18 +62,14 @@ case class CarbonDatasourceHadoopRelation(
   override def schema: StructType = tableSchema.getOrElse(carbonRelation.schema)
 
   def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
-    val job = new Job(new JobConf())
-    val conf = new Configuration(job.getConfiguration)
     val filterExpression: Option[Expression] = filters.flatMap { filter =>
       CarbonFilters.createCarbonFilter(schema, filter)
     }.reduceOption(new AndExpression(_, _))
 
     val projection = new CarbonProjection
     requiredColumns.foreach(projection.addColumn)
-    CarbonInputFormat.setColumnProjection(conf, projection)
-    CarbonInputFormat.setCarbonReadSupport(conf, classOf[SparkRowReadSupportImpl])
 
-    new CarbonScanRDD[Row](sqlContext.sparkContext, conf, projection, filterExpression.orNull,
+    new CarbonScanRDD[Row](sqlContext.sparkContext, projection, filterExpression.orNull,
       absIdentifier, carbonTable)
   }
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = new Array[Filter](0)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -73,7 +73,7 @@ case class CarbonDatasourceHadoopRelation(
     CarbonInputFormat.setColumnProjection(conf, projection)
     CarbonInputFormat.setCarbonReadSupport(conf, classOf[SparkRowReadSupportImpl])
 
-    new CarbonScanRDD[Row](sqlContext.sparkContext, projection, filterExpression.orNull,
+    new CarbonScanRDD[Row](sqlContext.sparkContext, conf, projection, filterExpression.orNull,
       absIdentifier, carbonTable)
   }
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = new Array[Filter](0)


### PR DESCRIPTION
Executor can not get the read support class, this leads to cast exception when running carbon on spark2 in cluster mode
