### PR TITLE
[CARBONDATA-429][WIP]reduce the no of of io operation being done for dictionary.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractColumnDictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractColumnDictionaryInfo.java
@@ -68,6 +68,11 @@ public abstract class AbstractColumnDictionaryInfo implements DictionaryInfo {
   private final int dictionaryOneChunkSize = CarbonUtil.getDictionaryChunkSize();
 
   /**
+   * last cache updation time. it depends on new segment being loaded to table
+   */
+  private long lastUpdatedTime;
+
+  /**
    * This method will return the timestamp of file based on which decision
    * the decision will be taken whether to read that file or not
    *
@@ -287,6 +292,20 @@ public abstract class AbstractColumnDictionaryInfo implements DictionaryInfo {
   @Override public int getSurrogateKey(String value) {
     byte[] keyData = value.getBytes(Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
     return getSurrogateKey(keyData);
+  }
+
+  /**
+   * get lastUpdatedTime
+   */
+  public long getLastUpdatedTime() {
+    return this.lastUpdatedTime;
+  }
+
+  /**
+   * set lastUpdatedTime
+   */
+  public void setLastUpdatedTime(long lastUpdatedTime) {
+    this.lastUpdatedTime = lastUpdatedTime;
   }
 }
 

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/AbstractDictionaryCache.java
@@ -182,56 +182,90 @@ public abstract class AbstractDictionaryCache<K extends DictionaryColumnUniqueId
       DictionaryInfo dictionaryInfo, String lruCacheKey, boolean loadSortIndex)
       throws CarbonUtilException {
     try {
-      // read last segment dictionary meta chunk entry to get the end offset of file
-      CarbonFile carbonFile = getDictionaryMetaCarbonFile(dictionaryColumnUniqueIdentifier);
-      boolean dictionaryMetaFileModified =
-          isDictionaryMetaFileModified(carbonFile, dictionaryInfo.getFileTimeStamp(),
-              dictionaryInfo.getDictionaryMetaFileLength());
-      // if dictionary metadata file is modified then only read the last entry from dictionary
-      // meta file
-      if (dictionaryMetaFileModified) {
-        synchronized (dictionaryInfo) {
-          carbonFile = getDictionaryMetaCarbonFile(dictionaryColumnUniqueIdentifier);
-          dictionaryMetaFileModified =
-              isDictionaryMetaFileModified(carbonFile, dictionaryInfo.getFileTimeStamp(),
-                  dictionaryInfo.getDictionaryMetaFileLength());
-          // Double Check :
-          // if dictionary metadata file is modified then only read the last entry from dictionary
-          // meta file
-          if (dictionaryMetaFileModified) {
-            CarbonDictionaryColumnMetaChunk carbonDictionaryColumnMetaChunk =
-                readLastChunkFromDictionaryMetadataFile(dictionaryColumnUniqueIdentifier);
-            // required size will be size total size of file - offset till file is
-            // already read
-            long requiredSize =
-                carbonDictionaryColumnMetaChunk.getEnd_offset() - dictionaryInfo.getMemorySize();
-            if (requiredSize > 0) {
-              boolean columnAddedToLRUCache =
-                  carbonLRUCache.put(lruCacheKey, dictionaryInfo, requiredSize);
-              // if column is successfully added to lru cache then only load the
-              // dictionary data
-              if (columnAddedToLRUCache) {
-                // load dictionary data
-                loadDictionaryData(dictionaryInfo, dictionaryColumnUniqueIdentifier,
-                    dictionaryInfo.getMemorySize(), carbonDictionaryColumnMetaChunk.getEnd_offset(),
-                    loadSortIndex);
-                // set the end offset till where file is read
-                dictionaryInfo
-                    .setOffsetTillFileIsRead(carbonDictionaryColumnMetaChunk.getEnd_offset());
-                dictionaryInfo.setFileTimeStamp(carbonFile.getLastModifiedTime());
-                dictionaryInfo.setDictionaryMetaFileLength(carbonFile.getSize());
-              } else {
-                throw new CarbonUtilException(
-                    "Cannot load dictionary into memory. Not enough memory available");
-              }
-            }
-          }
-        }
+      long currentUpdationTime = dictionaryColumnUniqueIdentifier
+          .getCarbonTableIdentifier().getLastUpdatedTime();
+      long lastUpdationTime = dictionaryInfo.getLastUpdatedTime();
+      boolean needToUpdateCache = true;
+      /**
+       * try to reload load cache only if currentUpdation time
+       * i.e table last modified time is either 0
+       * or its more then cached last updation time.
+       */
+      if ((currentUpdationTime !=0 && lastUpdationTime >= currentUpdationTime)) {
+        needToUpdateCache = false;
+      }
+      if (needToUpdateCache) {
+        loadDictionaryData(dictionaryColumnUniqueIdentifier, dictionaryInfo,
+            lruCacheKey, loadSortIndex);
       }
       // increment the column access count
       incrementDictionaryAccessCount(dictionaryInfo);
     } catch (IOException e) {
       throw new CarbonUtilException(e.getMessage());
+    }
+  }
+
+  /**
+   * load dictionary data if dictionary meta file is modified
+   * @param dictionaryColumnUniqueIdentifier
+   * @param dictionaryInfo
+   * @param lruCacheKey
+   * @param loadSortIndex
+   * @throws IOException
+   * @throws CarbonUtilException
+   */
+  private void loadDictionaryData(
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
+      DictionaryInfo dictionaryInfo, String lruCacheKey, boolean loadSortIndex)
+      throws IOException, CarbonUtilException {
+    // read last segment dictionary meta chunk entry to get the end offset of file
+    CarbonFile carbonFile = getDictionaryMetaCarbonFile(dictionaryColumnUniqueIdentifier);
+    boolean dictionaryMetaFileModified =
+        isDictionaryMetaFileModified(carbonFile, dictionaryInfo.getFileTimeStamp(),
+            dictionaryInfo.getDictionaryMetaFileLength());
+    // if dictionary metadata file is modified then only read the last entry from dictionary
+    // meta file
+    if (dictionaryMetaFileModified) {
+      synchronized (dictionaryInfo) {
+        carbonFile = getDictionaryMetaCarbonFile(dictionaryColumnUniqueIdentifier);
+        dictionaryMetaFileModified =
+            isDictionaryMetaFileModified(carbonFile, dictionaryInfo.getFileTimeStamp(),
+                dictionaryInfo.getDictionaryMetaFileLength());
+        // Double Check :
+        // if dictionary metadata file is modified then only read the last entry from dictionary
+        // meta file
+        if (dictionaryMetaFileModified) {
+          CarbonDictionaryColumnMetaChunk carbonDictionaryColumnMetaChunk =
+              readLastChunkFromDictionaryMetadataFile(dictionaryColumnUniqueIdentifier);
+          // required size will be size total size of file - offset till file is
+          // already read
+          long requiredSize =
+              carbonDictionaryColumnMetaChunk.getEnd_offset() - dictionaryInfo.getMemorySize();
+          dictionaryInfo.setLastUpdatedTime(
+              dictionaryColumnUniqueIdentifier.getCarbonTableIdentifier()
+              .getLastUpdatedTime());
+          if (requiredSize > 0) {
+            boolean columnAddedToLRUCache =
+                carbonLRUCache.put(lruCacheKey, dictionaryInfo, requiredSize);
+            // if column is successfully added to lru cache then only load the
+            // dictionary data
+            if (columnAddedToLRUCache) {
+              // load dictionary data
+              loadDictionaryData(dictionaryInfo, dictionaryColumnUniqueIdentifier,
+                  dictionaryInfo.getMemorySize(), carbonDictionaryColumnMetaChunk.getEnd_offset(),
+                  loadSortIndex);
+              // set the end offset till where file is read
+              dictionaryInfo
+                  .setOffsetTillFileIsRead(carbonDictionaryColumnMetaChunk.getEnd_offset());
+              dictionaryInfo.setFileTimeStamp(carbonFile.getLastModifiedTime());
+              dictionaryInfo.setDictionaryMetaFileLength(carbonFile.getSize());
+            } else {
+              throw new CarbonUtilException(
+                  "Cannot load dictionary into memory. Not enough memory available");
+            }
+          }
+        }
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryInfo.java
@@ -96,4 +96,16 @@ public interface DictionaryInfo extends Cacheable, Dictionary {
    * @return
    */
   long getDictionaryMetaFileLength();
+
+  /**
+   * It return the last updation time of dictionary cache
+   * @return
+   */
+  long getLastUpdatedTime();
+
+  /**
+   * It sets last updation time
+   * @param lastUpdatedTime
+   */
+  void setLastUpdatedTime(long lastUpdatedTime);
 }

--- a/core/src/main/java/org/apache/carbondata/core/carbon/CarbonTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/CarbonTableIdentifier.java
@@ -43,6 +43,10 @@ public class CarbonTableIdentifier implements Serializable {
   private String tableId;
 
   /**
+   * last time new segment being loaded
+   */
+  private long lastUpdatedTime;
+  /**
    * constructor
    */
   public CarbonTableIdentifier(String databaseName, String tableName, String tableId) {
@@ -70,6 +74,23 @@ public class CarbonTableIdentifier implements Serializable {
    */
   public String getTableId() {
     return tableId;
+  }
+
+
+  /**
+   *
+   * @return lastUpdatedTime
+   */
+  public long getLastUpdatedTime() {
+    return lastUpdatedTime;
+  }
+
+  /**
+   * set lastUpdatedTime
+   * @param lastUpdatedTime
+   */
+  public void setLastUpdatedTime(long lastUpdatedTime) {
+    this.lastUpdatedTime = lastUpdatedTime;
   }
 
   /**

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
@@ -119,6 +119,8 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       // read it from schema file in the store
       AbsoluteTableIdentifier absIdentifier = getAbsoluteTableIdentifier(configuration);
       CarbonTable carbonTable = SchemaReader.readCarbonTableFromStore(absIdentifier);
+      carbonTable.getAbsoluteTableIdentifier().getCarbonTableIdentifier().setLastUpdatedTime(
+          absIdentifier.getCarbonTableIdentifier().getLastUpdatedTime());
       setCarbonTable(configuration, carbonTable);
       return carbonTable;
     }
@@ -186,13 +188,19 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
         .set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, CarbonUtil.getSegmentString(validSegments));
   }
 
-  private static AbsoluteTableIdentifier getAbsoluteTableIdentifier(Configuration configuration) {
+  private static AbsoluteTableIdentifier getAbsoluteTableIdentifier(
+      Configuration configuration) throws IOException {
     String dirs = configuration.get(INPUT_DIR, "");
     String[] inputPaths = StringUtils.split(dirs);
     if (inputPaths.length == 0) {
       throw new InvalidPathException("No input paths specified in job");
     }
-    return AbsoluteTableIdentifier.fromTablePath(inputPaths[0]);
+    AbsoluteTableIdentifier absTableIdentifier =
+        AbsoluteTableIdentifier.fromTablePath(inputPaths[0]);
+    long lastModifiedTime =
+        SegmentStatusManager.getTableStatusLastModifiedTime(absTableIdentifier);
+    absTableIdentifier.getCarbonTableIdentifier().setLastUpdatedTime(lastModifiedTime);
+    return absTableIdentifier;
   }
 
   /**

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -224,19 +226,18 @@ case class CarbonDictionaryDecoder(
 
   private def getDictionary(atiMap: Map[String, AbsoluteTableIdentifier],
       cache: Cache[DictionaryColumnUniqueIdentifier, Dictionary]) = {
-    val dicts: Seq[Dictionary] = getDictionaryColumnIds.map { f =>
+    val dictColumnUniqueIdentifiers: java.util.List[DictionaryColumnUniqueIdentifier] =
+      new java.util.ArrayList[DictionaryColumnUniqueIdentifier]()
+    getDictionaryColumnIds.foreach{f =>
       if (f._2 != null) {
-        try {
-          cache.get(new DictionaryColumnUniqueIdentifier(
+          dictColumnUniqueIdentifiers.add(new DictionaryColumnUniqueIdentifier(
             atiMap(f._1).getCarbonTableIdentifier,
             f._2, f._3))
-        } catch {
-          case _: Throwable => null
-        }
       } else {
-        null
+        dictColumnUniqueIdentifiers.add(null)
       }
     }
+    val dicts = cache.getAll(dictColumnUniqueIdentifiers).asScala.toSeq
     dicts
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -544,7 +544,11 @@ case class LoadTable(
                          "Problem deleting the partition folder")
             throw ex
         }
-
+        // update carbonTableIdentifier with latest updated time
+        val absTableIdentifier = table.getAbsoluteTableIdentifier
+        val currentUpdateTime =
+          SegmentStatusManager.getTableStatusLastModifiedTime(table.getAbsoluteTableIdentifier)
+        absTableIdentifier.getCarbonTableIdentifier.setLastUpdatedTime(currentUpdateTime)
       }
     } catch {
       case dle: DataLoadingException =>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastore.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastore.scala
@@ -48,6 +48,7 @@ import org.apache.carbondata.core.util.{CarbonProperties, CarbonTimeStatisticsFa
 import org.apache.carbondata.core.writer.ThriftWriter
 import org.apache.carbondata.format.{SchemaEvolutionEntry, TableInfo}
 import org.apache.carbondata.lcm.locks.ZookeeperInit
+import org.apache.carbondata.lcm.status.SegmentStatusManager
 import org.apache.carbondata.spark.merger.TableMeta
 
 case class MetaData(var tablesMeta: ArrayBuffer[TableMeta])
@@ -238,6 +239,10 @@ class CarbonMetastore(hiveContext: HiveContext, val storePath: String,
                   val carbonTable =
                     org.apache.carbondata.core.carbon.metadata.CarbonMetadata.getInstance()
                       .getCarbonTable(tableUniqueName)
+                  val tableLastUpdatedTime = SegmentStatusManager.getTableStatusLastModifiedTime(
+                      carbonTable.getAbsoluteTableIdentifier)
+                  carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.
+                  setLastUpdatedTime(tableLastUpdatedTime)
                   metaDataBuffer += new TableMeta(carbonTable.getCarbonTableIdentifier, storePath,
                     carbonTable)
                 }


### PR DESCRIPTION
**Problem**
Every single query is triggered by user, carbon does an io operation for all dictionary column to check if its dictionary meta is modified. 
**Solution**
This PR will try to reduce the no of IO operation done for above mentioned problem. Idea behind solution is, check for modification of dictionary meta only if table has been loaded with new segment.