### PR TITLE
[CARBONDATA-539] Fiix column projection bug

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
@@ -45,15 +45,14 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
  */
 public class CarbonInputFormatUtil {
 
-  public static CarbonQueryPlan createQueryPlan(CarbonTable carbonTable, String columnString) {
+  public static CarbonQueryPlan createQueryPlan(CarbonTable carbonTable, String[] projection) {
     String[] columns = null;
-    if (columnString != null) {
-      columns = columnString.split(",");
+    if (projection != null) {
+      columns = projection;
     }
     String factTableName = carbonTable.getFactTableName();
     CarbonQueryPlan plan = new CarbonQueryPlan(carbonTable.getDatabaseName(), factTableName);
-    // fill dimensions
-    // If columns are null, set all dimensions and measures
+    // fill dimensions, if projection columns are null, set all dimensions and measures
     int i = 0;
     if (columns != null) {
       for (String column : columns) {
@@ -69,6 +68,18 @@ public class CarbonInputFormatUtil {
           addQueryMeasure(plan, i, measure);
           i++;
         }
+      }
+    } else {
+      // query all columns
+      List<CarbonMeasure> tableMsrs = carbonTable.getMeasureByTableName(factTableName);
+      List<CarbonDimension> tableDims = carbonTable.getDimensionByTableName(factTableName);
+      for (CarbonDimension dimension : tableDims) {
+        addQueryDimension(plan, i, dimension);
+        i++;
+      }
+      for (CarbonMeasure measure : tableMsrs) {
+        addQueryMeasure(plan, i, measure);
+        i++;
       }
     }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -192,12 +192,11 @@ class CarbonScanRDD[V: ClassTag](
   }
 
   private def prepareInputFormatForDriver(conf: Configuration): CarbonInputFormat[V] = {
-    CarbonInputFormat.setCarbonTable(conf, carbonTable)
     createInputFormat(conf)
   }
 
   private def prepareInputFormatForExecutor(conf: Configuration): CarbonInputFormat[V] = {
-    CarbonInputFormat.setCarbonReadSupport(conf, SparkReadSupport.readSupportClass)
+    CarbonInputFormat.setReadSupportClass(conf, SparkReadSupport.readSupportClass)
     createInputFormat(conf)
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -93,7 +93,7 @@ private[sql] case class CarbonDatasourceHadoopRelation(
     val projection = new CarbonProjection
     requiredColumns.foreach(projection.addColumn)
     CarbonInputFormat.setColumnProjection(conf, projection)
-    CarbonInputFormat.setCarbonReadSupport(conf, classOf[SparkRowReadSupportImpl])
+    CarbonInputFormat.setReadSupportClass(conf, classOf[SparkRowReadSupportImpl])
 
     new CarbonHadoopFSRDD[Row](sqlContext.sparkContext,
       new SerializableConfiguration(conf),


### PR DESCRIPTION
Currently when using CarbonInputFormat in map reduce app, if projection columns are not set, then  Carbon will return empty row, but the correct behavior should read all columns. This PR fix this bug.

`CarbonInputFormat` are refactored to make cleaner API to application. 
Only 4 settings are now public to application. 
1. TablePath
2. Column Projection
3. Filter Expression
4. ReadSupport class
Function descriptions are added in `CarbonInputFormat`