### PR TITLE
[CARBONDATA-557] Fix use_kettle not working

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -436,7 +436,7 @@ case class LoadTable(
       val columinar = sqlContext.getConf("carbon.is.columnar.storage", "true").toBoolean
 
       // TODO It will be removed after kettle is removed.
-      val useKettle = options.get("useKettle") match {
+      val useKettle = options.get("use_kettle") match {
         case Some(value) => value.toBoolean
         case _ =>
           val useKettleLocal = System.getProperty("use.kettle")


### PR DESCRIPTION
# Why raise this pr?
when run command: 
LOAD DATA LOCAL INPATH '/path/data.csv' into table t3 OPTIONS('USE_KETTLE'='false');
load data still using the orginal flow instead of the new flow
# How to solve it?
repair the spell mistake of keyword "USE_KETTLE"