### PR TITLE
[CARBONDATA-558] Fix load performace issue when use_kettle=false

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/MeasureFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/MeasureFieldConverterImpl.java
@@ -22,6 +22,7 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.carbon.metadata.datatype.DataType;
 import org.apache.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.newflow.DataField;
 import org.apache.carbondata.processing.newflow.converter.BadRecordLogHolder;
@@ -57,7 +58,8 @@ public class MeasureFieldConverterImpl implements FieldConverter {
       throws CarbonDataLoadingException {
     String value = row.getString(index);
     Object output;
-    if (value == null) {
+    boolean isNull = CarbonCommonConstants.MEMBER_DEFAULT_VAL.equals(value);
+    if (value == null || value.length() == 0 || isNull) {
       logHolder.setReason(
           "The value " + " \"" + value + "\"" + " with column name " + measure.getColName()
               + " and column data type " + dataType + " is not a valid " + dataType + " type.");


### PR DESCRIPTION
# Why raise this pr?
When I load a data file, the measure column contains many empty strings, if use_kettle=false, the load performance has a sharp decline
I checked the logs of executor, many warnnings printed like below:
16/12/22 07:03:12 WARN MeasureFieldConverterImpl: pool-22-thread-6 Cant not convert : to Numeric type value. Value considered as null.

# How to solve it?
When measureValue = "", we should set it as null directly, no need to do datatype conversion
