### PR TITLE
Add example:directly write dataframe to carbon file without temp CSV

### DIFF
--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
@@ -23,7 +23,7 @@ import org.apache.carbondata.examples.util.{AllDictionaryUtil, ExampleUtils}
 object AllDictionaryExample {
 
   def main(args: Array[String]) {
-    val cc = ExampleUtils.createCarbonContext("CarbonExample")
+    val cc = ExampleUtils.createCarbonContext("AllDictionaryExample")
     val testData = ExampleUtils.currentPath + "/src/main/resources/data.csv"
     val csvHeader = "ID,date,country,name,phonetype,serialname,salary"
     val dictCol = "|date|country|name|phonetype|serialname|"

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/HadoopFileExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/HadoopFileExample.scala
@@ -24,7 +24,7 @@ import org.apache.carbondata.hadoop.CarbonInputFormat
 object HadoopFileExample {
 
   def main(args: Array[String]): Unit = {
-    val cc = ExampleUtils.createCarbonContext("DataFrameAPIExample")
+    val cc = ExampleUtils.createCarbonContext("HadoopFileExample")
     ExampleUtils.writeSampleCarbonFile(cc, "carbon1")
 
     val sc = cc.sparkContext

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/PerfTest.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/PerfTest.scala
@@ -145,15 +145,13 @@ class QueryRunner(sqlContext: SQLContext, dataFrame: DataFrame, datasources: Seq
 
   def shutDown(): Unit = {
     // drop all tables and temp files
-    datasources.foreach { datasource =>
-      datasource match {
-        case "parquet" | "orc" =>
+    datasources.foreach {
+        case datasource @ ("parquet" | "orc") =>
           val f = new File(PerfTest.savePath(datasource))
           if (f.exists()) f.delete()
         case "carbon" =>
           sqlContext.sql(s"DROP TABLE IF EXISTS ${PerfTest.makeTableName("carbon")}")
         case _ => sys.error("unsupported data source")
-      }
     }
   }
 }

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
@@ -81,7 +81,7 @@ object ExampleUtils {
         .map(x => ("a", "b", x))
         .toDF("c1", "c2", "c3")
 
-    // save dataframe to carbon file
+    // save dataframe to carbon file:(df->csv->carbon file)
     df.write
         .format("carbondata")
         .option("tableName", tableName)
@@ -89,6 +89,17 @@ object ExampleUtils {
         .option("useKettle", "false")
         .mode(mode)
         .save()
+
+    // save dataframe directl to carbon file without tempCSV
+    df.write
+      .format("carbondata")
+      .option("tableName", tableName)
+      .option("compress", "true")
+      .option("useKettle", "false")
+      .option("tempCSV", "false")
+      .mode(mode)
+      .save()
+
   }
 }
 // scalastyle:on println


### PR DESCRIPTION
Some uses want to transfer dataframe to carbon file, don't want to generate very big temp CSV due to the storage limitation.
Add example:directly write dataframe to carbon file without temp CSV.

In addition, optimize small part for some examples also.