### PR TITLE
[CARBONDATA-577]Fix carbon commands in spark shell

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -90,7 +90,7 @@ object CarbonSession {
 
       // Get the session from current thread's active session.
       var session: SparkSession = SparkSession.getActiveSession match {
-        case Some(sparkSession) =>
+        case Some(sparkSession: CarbonSession) =>
           if ((sparkSession ne null) && !sparkSession.sparkContext.isStopped) {
             options.foreach { case (k, v) => sparkSession.conf.set(k, v) }
             sparkSession
@@ -107,7 +107,7 @@ object CarbonSession {
       SparkSession.synchronized {
         // If the current thread does not have an active session, get it from the global session.
         session = SparkSession.getDefaultSession match {
-          case Some(sparkSession) =>
+          case Some(sparkSession: CarbonSession) =>
             if ((sparkSession ne null) && !sparkSession.sparkContext.isStopped) {
               options.foreach { case (k, v) => sparkSession.conf.set(k, v) }
               sparkSession


### PR DESCRIPTION
With this PR, user can create CarbonSesion inside the spark shell and executes the carbon commands,

```
scala> import org.apache.spark.sql.SparkSession

scala> import org.apache.spark.sql.CarbonSession._

scala> val carbon = SparkSession.builder().master("local").appName("CarbonShellExample").enableHiveSupport().getOrCreateCarbonSession()

scala> carbon.sql(
      s"""
         | CREATE TABLE carbon_table5(
         |    shortField short,
         |    intField int,
         |    bigintField long,
         |    doubleField double,
         |    stringField string,
         |    timestampField timestamp,
         |    decimalField decimal(18,2),
         |    dateField date,
         |    charField char(5)
         | )
         | STORED BY 'carbondata'
         | TBLPROPERTIES('DICTIONARY_INCLUDE'='dateField, charField')
       """.stripMargin)
```