### PR TITLE
[CARBONDATA-581] Wrong number of executors requested when preferred locations are not obtained

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -141,7 +141,9 @@ object DistributionUtil {
     val nodesOfData = nodeMapping.size()
     val confExecutors: Int = getConfiguredExecutors(sparkContext)
     LOGGER.info(s"Executors configured : $confExecutors")
-    val requiredExecutors = if (nodesOfData < 1 || nodesOfData > confExecutors) {
+    val requiredExecutors = if (nodesOfData < 1) {
+      1
+    } else if (nodesOfData > confExecutors) {
       confExecutors
     } else if (confExecutors > nodesOfData) {
       var totalExecutorsToBeRequested = nodesOfData


### PR DESCRIPTION
Wrong number of executors requested when preferred locations are not obtained.
In case of groupby in subquery, we'll not get the preferred locations from the RDD as data is shuffled.
In such cases we need to use number of executors available.
This is applicable in case of dynamic executors