### PR TITLE
[CARBONDATA-582] bugfix of negative number in bucketnumber

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -264,7 +264,7 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
                 }
                 if (totalNumberOfBuckets.getText.contains("-") || totalNumberOfBuckets.getText.contains("+")) {
                   throw new MalformedCarbonCommandException(
-                    "INVALID NUMBER OF BUCKETS SPECIFIED IT CAN NOT BE A NEGATIVE NUMBER "
+                    "INVALID NUMBER OF BUCKETS SPECIFIED "
                       + numberOfBuckets.head.getText)
                 }
                 else {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -257,8 +257,16 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
             Token("TOK_TABCOLNAME", list)::numberOfBuckets) =>
               val cols = list.map(_.getText)
               if (cols != null) {
-                bucketFields = Some(BucketFields(cols,
-                  numberOfBuckets.head.getText.toInt))
+                val totalNumberOfBuckets = numberOfBuckets.headOption.fold(throw new Exception("ParsingException")) {
+                  totalNumberOfBuckets => totalNumberOfBuckets
+                }
+                if (totalNumberOfBuckets.getText.contains("-")) {
+                  throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED IT CAN NOT BE A NEGATIVE NUMBER " + numberOfBuckets.head.getText)
+                }
+                else {
+                  bucketFields =  Some(BucketFields(cols,
+                    totalNumberOfBuckets.getText.toInt))
+                }
               }
 
             case _ => // Unsupport features

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -257,11 +257,14 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
             Token("TOK_TABCOLNAME", list)::numberOfBuckets) =>
               val cols = list.map(_.getText)
               if (cols != null) {
-                val totalNumberOfBuckets = numberOfBuckets.headOption.fold(throw new Exception("ParsingException")) {
+                val totalNumberOfBuckets = numberOfBuckets.headOption.fold(
+                  throw new Exception("ParsingException")) {
                   totalNumberOfBuckets => totalNumberOfBuckets
                 }
                 if (totalNumberOfBuckets.getText.contains("-")) {
-                  throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED IT CAN NOT BE A NEGATIVE NUMBER " + numberOfBuckets.head.getText)
+                  throw new MalformedCarbonCommandException(
+                    "INVALID NUMBER OF BUCKETS SPECIFIED IT CAN NOT BE A NEGATIVE NUMBER "
+                      + numberOfBuckets.head.getText)
                 }
                 else {
                   bucketFields =  Some(BucketFields(cols,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -261,7 +262,7 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
                   throw new Exception("ParsingException")) {
                   totalNumberOfBuckets => totalNumberOfBuckets
                 }
-                if (totalNumberOfBuckets.getText.contains("-")) {
+                if (totalNumberOfBuckets.getText.contains("-") || totalNumberOfBuckets.getText.contains("+")) {
                   throw new MalformedCarbonCommandException(
                     "INVALID NUMBER OF BUCKETS SPECIFIED IT CAN NOT BE A NEGATIVE NUMBER "
                       + numberOfBuckets.head.getText)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -132,7 +132,7 @@ class CarbonSource extends CreatableRelationProvider
         parameters.foreach { parameter => map.put(parameter._1, parameter._2) }
         val bucketFields = {
           if (options.isBucketingEnabled) {
-            if (options.bucketNumber.toString.contains("-")) {
+            if (options.bucketNumber.toString.contains("-") || options.bucketNumber.toString.contains("+") ) {
               throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED IT CAN NOT BE A NEGATIVE NUMBER " + options.bucketNumber.toString)
             }
             else {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql
 
-import java.io.File
-
-import scala.language.implicitConversions
-
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.spark.CarbonOption
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.execution.CarbonLateDecodeStrategy
@@ -29,16 +29,14 @@ import org.apache.spark.sql.optimizer.CarbonLateDecodeRule
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DecimalType, StructType}
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.CarbonProperties
-import org.apache.carbondata.spark.CarbonOption
+import scala.language.implicitConversions
 
 /**
- * Carbon relation provider compliant to data source api.
- * Creates carbon relations
- */
+  * Carbon relation provider compliant to data source api.
+  * Creates carbon relations
+  */
 class CarbonSource extends CreatableRelationProvider
-    with SchemaRelationProvider with DataSourceRegister {
+  with SchemaRelationProvider with DataSourceRegister {
 
   override def shortName(): String = "carbondata"
 
@@ -52,13 +50,13 @@ class CarbonSource extends CreatableRelationProvider
     // User should not specify path since only one store is supported in carbon currently,
     // after we support multi-store, we can remove this limitation
     require(!parameters.contains("path"), "'path' should not be specified, " +
-        "the path to store carbon file is the 'storePath' specified when creating CarbonContext")
+      "the path to store carbon file is the 'storePath' specified when creating CarbonContext")
 
     val options = new CarbonOption(parameters)
     val storePath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION)
     val tablePath = new Path(storePath + "/" + options.dbName + "/" + options.tableName)
     val isExists = tablePath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
-        .exists(tablePath)
+      .exists(tablePath)
     val (doSave, doAppend) = (mode, isExists) match {
       case (SaveMode.ErrorIfExists, true) =>
         sys.error(s"ErrorIfExists mode, path $storePath already exists.")
@@ -131,10 +129,15 @@ class CarbonSource extends CreatableRelationProvider
           f
         }
         val map = scala.collection.mutable.Map[String, String]()
-        parameters.foreach { x => map.put(x._1, x._2) }
+        parameters.foreach { parameter => map.put(parameter._1, parameter._2) }
         val bucketFields = {
           if (options.isBucketingEnabled) {
-            Some(BucketFields(options.bucketColumns.split(","), options.bucketNumber))
+            if (options.bucketNumber.toString.contains("-")) {
+              throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED IT CAN NOT BE A NEGATIVE NUMBER " + options.bucketNumber.toString)
+            }
+            else {
+              Some(BucketFields(options.bucketColumns.split(","), options.bucketNumber))
+            }
           } else {
             None
           }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -138,6 +138,11 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       val options = new CarbonOption(properties)
       val bucketFields = {
         if (options.isBucketingEnabled) {
+          if(options.bucketNumber == -1){
+            throw new ParseException("INVALID NUMBER OF BUCKETS SPECIFIED. " +
+              "PARSING ERROR", ctx)
+          }
+          else
           Some(BucketFields(options.bucketColumns.split(","), options.bucketNumber))
         } else {
           None

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -138,7 +138,7 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       val options = new CarbonOption(properties)
       val bucketFields = {
         if (options.isBucketingEnabled) {
-          if(options.bucketNumber == -1){
+          if(options.bucketNumber.toString.contains("-")){
             throw new ParseException("INVALID NUMBER OF BUCKETS SPECIFIED. " +
               "PARSING ERROR", ctx)
           }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -138,7 +138,7 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       val options = new CarbonOption(properties)
       val bucketFields = {
         if (options.isBucketingEnabled) {
-          if(options.bucketNumber.toString.contains("-")){
+          if (options.bucketNumber.toString.contains("-") || options.bucketNumber.toString.contains("+") ){
             throw new ParseException("INVALID NUMBER OF BUCKETS SPECIFIED. " +
               "PARSING ERROR", ctx)
           }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -42,6 +42,8 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS t6")
     sql("DROP TABLE IF EXISTS t7")
     sql("DROP TABLE IF EXISTS t8")
+    sql("DROP TABLE IF EXISTS t1")
+
   }
 
   test("test create table with buckets") {
@@ -60,6 +62,23 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
       assert(true)
     } else {
       assert(false, "Bucketing info does not exist")
+    }
+  }
+
+  test("must not be able to create create table if number of bucket specified is negative") {
+    try {
+      spark.sql(
+        """
+           CREATE TABLE t4
+           (ID Int, date Timestamp, country String,
+           name String, phonetype String, serialname String, salary Int)
+           USING org.apache.spark.sql.CarbonSource
+           OPTIONS("bucketnumber"="-1", "bucketcolumns"="name", "tableName"="t4")
+        """)
+          assert(false)
+    }
+    catch {
+      case malformedCarbonCommandException: MalformedCarbonCommandException => assert(true)
     }
   }
 


### PR DESCRIPTION
jira issue [CARBONDATA-582]
In carbon data i create a table with number of buckets specified as a negative number
here are the logs
jdbc:hive2://localhost:10000> 
CREATE TABLE BucketTest1111352983(name int,ID string)USING org.apache.spark.sql.CarbonSource OPTIONS("bucketnumber"="-1", "bucketcolumns"="name1");
---------+
Result
---------+
---------+
No rows selected (0.277 seconds)
this is because there is no check whether the bucket number given is positive or not
in hive it gives a error
here are the logs in hive
hive> CREATE TABLE BucketTest1111352983(name int,ID string)USING org.apache.spark.sql.CarbonSource OPTIONS("bucketnumber"="-1", "bucketcolumns"="name1");
---------+
Result
---------+
---------+
No rows selected (0.277 seconds)
in carbon data as well it should not allow this