### PR TITLE
[Carbondata-591] Remove unused datatype conversion util in spark 2.x

### DIFF
--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
@@ -53,6 +53,11 @@ object AllDictionaryExample {
            SELECT * FROM t3
            """).show()
 
+    cc.sql("""
+           SELECT replace(country,"br","aa") FROM t3
+           """).show()
+
+
     cc.sql("DROP TABLE IF EXISTS t3")
 
     // clean local dictionary files

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
@@ -19,6 +19,12 @@ package org.apache.carbondata.examples
 
 import java.io.File
 
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.SparkSession
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
 object CarbonSessionExample {
 
   def main(args: Array[String]) {
@@ -40,6 +46,8 @@ object CarbonSessionExample {
       .addProperty("carbon.kettle.home", s"$rootPath/processing/carbonplugins")
       .addProperty("carbon.storelocation", storeLocation)
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+
+    import org.apache.spark.sql.CarbonSession._
 
     val spark = SparkSession
       .builder()

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
@@ -19,12 +19,6 @@ package org.apache.carbondata.examples
 
 import java.io.File
 
-import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.SparkSession
-
-import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.CarbonProperties
-
 object CarbonSessionExample {
 
   def main(args: Array[String]) {
@@ -47,8 +41,6 @@ object CarbonSessionExample {
       .addProperty("carbon.storelocation", storeLocation)
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
 
-    import org.apache.spark.sql.CarbonSession._
-
     val spark = SparkSession
       .builder()
       .master("local")
@@ -56,7 +48,7 @@ object CarbonSessionExample {
       .enableHiveSupport()
       .config("spark.sql.warehouse.dir", warehouse)
       .config("javax.jdo.option.ConnectionURL",
-    s"jdbc:derby:;databaseName=$metastoredb;create=true")
+        s"jdbc:derby:;databaseName=$metastoredb;create=true")
       .getOrCreateCarbonSession()
 
     spark.sparkContext.setLogLevel("WARN")
@@ -88,35 +80,41 @@ object CarbonSessionExample {
       s"""
          | LOAD DATA LOCAL INPATH '$path'
          | INTO TABLE carbon_table
-         | options('FILEHEADER'='shortField,intField,bigintField,doubleField,stringField,timestampField,decimalField,dateField,charField')
+         | options('FILEHEADER'='shortField,intField,bigintField,doubleField,stringField,
+         | timestampField,decimalField,dateField,charField')
        """.stripMargin)
     // scalastyle:on
 
-    spark.sql("""
+    spark.sql(
+      """
              SELECT *
              FROM carbon_table
              where stringfield = 'spark' and decimalField > 40
-              """).show
+      """).show
 
-    spark.sql("""
+    spark.sql(
+      """
              SELECT *
              FROM carbon_table where length(stringField) = 5
-              """).show
+      """).show
 
-    spark.sql("""
+    spark.sql(
+      """
              SELECT *
              FROM carbon_table where date_format(dateField, "yyyy-MM-dd") = "2015-07-23"
-              """).show
+      """).show
 
-    spark.sql("""
+    spark.sql(
+      """
              select count(stringField) from carbon_table
-              """.stripMargin).show
+      """.stripMargin).show
 
-    spark.sql("""
+    spark.sql(
+      """
            SELECT sum(intField), stringField
            FROM carbon_table
            GROUP BY stringField
-              """).show
+      """).show
 
     spark.sql(
       """
@@ -136,6 +134,9 @@ object CarbonSessionExample {
         |from t1, carbon_table t2
         |where t1.stringField = t2.stringField
       """.stripMargin).show
+
+    spark.sql(
+      """select replace(stringField,'s','S') as stringField from carbon_table""".stripMargin).show
 
     // Drop table
     spark.sql("DROP TABLE IF EXISTS carbon_table")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -36,30 +36,10 @@ object DataTypeConverterUtil {
       case "date" => DataType.DATE
       case "array" => DataType.ARRAY
       case "struct" => DataType.STRUCT
-      case _ => convertToCarbonTypeForSpark2(dataType)
-    }
-  }
-
-  def convertToCarbonTypeForSpark2(dataType: String): DataType = {
-    dataType.toLowerCase match {
-      case "stringtype" => DataType.STRING
-      case "inttype" => DataType.INT
-      case "integertype" => DataType.INT
-      case "tinyinttype" => DataType.SHORT
-      case "shorttype" => DataType.SHORT
-      case "longtype" => DataType.LONG
-      case "biginttype" => DataType.LONG
-      case "numerictype" => DataType.DOUBLE
-      case "doubletype" => DataType.DOUBLE
-      case "decimaltype" => DataType.DECIMAL
-      case "timestamptype" => DataType.TIMESTAMP
-      case "datetype" => DataType.DATE
-      case "arraytype" => DataType.ARRAY
-      case "structtype" => DataType.STRUCT
       case _ => sys.error(s"Unsupported data type: $dataType")
     }
   }
-
+  
   def convertToString(dataType: DataType): String = {
     dataType match {
       case DataType.STRING => "string"

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/FunctionRegistory.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/FunctionRegistory.scala
@@ -1,8 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.util
 
 object FunctionRegistory {
 
-  def replace = (value:String,orgString:String,replaceString:String) =>
-    value.replaceAll(orgString,replaceString)
+  def replace: (String, String, String) => String = {
+    (value: String, orgString: String, replaceString: String) =>
+      value.replaceAll(orgString, replaceString)
+  }
 
 }

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/FunctionRegistory.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/FunctionRegistory.scala
@@ -1,0 +1,8 @@
+package org.apache.spark.util
+
+object FunctionRegistory {
+
+  def replace = (value:String,orgString:String,replaceString:String) =>
+    value.replaceAll(orgString,replaceString)
+
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.ExtractPythonUDFs
 import org.apache.spark.sql.execution.datasources.{PreInsertCastAndRename, PreWriteCheck}
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.optimizer.CarbonOptimizer
+import org.apache.spark.util.FunctionRegistory
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.carbon.querystatistics.{QueryStatistic, QueryStatisticsConstants}
@@ -54,6 +55,7 @@ class CarbonContext(
       new File(CarbonCommonConstants.METASTORE_LOCATION_DEFAULT_VAL).getCanonicalPath)
   }
 
+  this.udf.register("replace", FunctionRegistory.replace)
   CarbonContext.addInstance(sc, this)
   CodeGenerateFactory.init(sc.version)
   CarbonEnv.init(this)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -24,7 +24,6 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession.Builder
 import org.apache.spark.sql.hive.CarbonSessionState
 import org.apache.spark.sql.internal.{SessionState, SharedState}
-
 import org.apache.spark.util.FunctionRegistory
 import org.apache.spark.util.Utils
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -16,6 +16,17 @@
  */
 package org.apache.spark.sql
 
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.SparkSession.Builder
+import org.apache.spark.sql.hive.CarbonSessionState
+import org.apache.spark.sql.internal.{SessionState, SharedState}
+import org.apache.spark.util.Utils
+import org.apache.spark.util.FunctionRegistory
+
 /**
  * Session implementation for {org.apache.spark.sql.SparkSession}
  * Implemented this class only to use our own SQL DDL commands.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -24,8 +24,10 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession.Builder
 import org.apache.spark.sql.hive.CarbonSessionState
 import org.apache.spark.sql.internal.{SessionState, SharedState}
-import org.apache.spark.util.Utils
+
 import org.apache.spark.util.FunctionRegistory
+import org.apache.spark.util.Utils
+
 
 /**
  * Session implementation for {org.apache.spark.sql.SparkSession}


### PR DESCRIPTION
- Remove unused code for datatype util conversion in spark 2.x
- Run unit test cases manually
- manually debug the code

