### PR TITLE
[CARBONDATA-591] Remove unused code for dataype conversion for spark 2.x

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -39,7 +39,7 @@ object DataTypeConverterUtil {
       case _ => sys.error(s"Unsupported data type: $dataType")
     }
   }
-  
+
   def convertToString(dataType: DataType): String = {
     dataType match {
       case DataType.STRING => "string"

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -36,30 +36,10 @@ object DataTypeConverterUtil {
       case "date" => DataType.DATE
       case "array" => DataType.ARRAY
       case "struct" => DataType.STRUCT
-      case _ => convertToCarbonTypeForSpark2(dataType)
-    }
-  }
-
-  def convertToCarbonTypeForSpark2(dataType: String): DataType = {
-    dataType.toLowerCase match {
-      case "stringtype" => DataType.STRING
-      case "inttype" => DataType.INT
-      case "integertype" => DataType.INT
-      case "tinyinttype" => DataType.SHORT
-      case "shorttype" => DataType.SHORT
-      case "longtype" => DataType.LONG
-      case "biginttype" => DataType.LONG
-      case "numerictype" => DataType.DOUBLE
-      case "doubletype" => DataType.DOUBLE
-      case "decimaltype" => DataType.DECIMAL
-      case "timestamptype" => DataType.TIMESTAMP
-      case "datetype" => DataType.DATE
-      case "arraytype" => DataType.ARRAY
-      case "structtype" => DataType.STRUCT
       case _ => sys.error(s"Unsupported data type: $dataType")
     }
   }
-
+  
   def convertToString(dataType: DataType): String = {
     dataType match {
       case DataType.STRING => "string"


### PR DESCRIPTION
- Remove unused code for dataype conversion for spark 2.x
- Run all unit test cases 
- Manually debug the code for unused code