### PR TITLE
[CARBONDATA-606] Add Flink example to read CarbonData files

### DIFF
--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -62,6 +62,7 @@
   </dependencies>
 
   <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.carbondata</groupId>
+    <artifactId>carbondata-parent</artifactId>
+    <version>1.0.0-incubating-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>carbondata-examples-flink</artifactId>
+  <name>Apache CarbonData :: Flink Examples</name>
+
+  <properties>
+    <dev.path>${basedir}/../../dev</dev.path>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-java</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-clients_${scala.binary.version}</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-hadoop</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-examples-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
@@ -44,7 +44,8 @@ object DataFrameAPIExample {
     // use SQL to read
     cc.sql("SELECT c1, count(c3) FROM carbon1 where c3 > 500 group by c1 limit 10").show
 
-    cc.sql("DROP TABLE IF EXISTS carbon1")
+    // delete carbondata file
+    ExampleUtils.cleanSampleCarbonFile(cc, "carbon1")
   }
 }
 // scalastyle:on println

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DatasourceExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DatasourceExample.scala
@@ -37,5 +37,8 @@ object DatasourceExample {
         | OPTIONS (path '${cc.storePath}/default/table1')
       """.stripMargin)
     sqlContext.sql("SELECT c1, c2, count(*) FROM source WHERE c3 > 100 GROUP BY c1, c2").show
+
+    // delete carbondata file
+    ExampleUtils.cleanSampleCarbonFile(cc, "table1")
   }
 }

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
@@ -40,5 +40,8 @@ object DirectSQLExample {
         | WHERE c3 > 100
         | GROUP BY c1, c2
       """.stripMargin).show
+
+    // delete carbondata file
+    ExampleUtils.cleanSampleCarbonFile(cc, "table1")
   }
 }

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
@@ -56,17 +56,21 @@ object ExampleUtils {
   /**
    * This func will write a sample CarbonData file containing following schema:
    * c1: String, c2: String, c3: Double
+   * Returns table path
    */
-  def writeSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): Unit = {
+  def writeSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): String = {
     cc.sql(s"DROP TABLE IF EXISTS $tableName")
     writeDataframe(cc, tableName, numRows, SaveMode.Overwrite)
+    s"$storeLocation/default/$tableName"
   }
 
   /**
    * This func will append data to the CarbonData file
+   * Returns table path
    */
-  def appendSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): Unit = {
+  def appendSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): String = {
     writeDataframe(cc, tableName, numRows, SaveMode.Append)
+    s"$storeLocation/default/$tableName"
   }
 
   /**
@@ -81,15 +85,6 @@ object ExampleUtils {
         .map(x => ("a", "b", x))
         .toDF("c1", "c2", "c3")
 
-    // save dataframe to carbon file:(df->csv->carbon file)
-    df.write
-        .format("carbondata")
-        .option("tableName", tableName)
-        .option("compress", "true")
-        .option("useKettle", "false")
-        .mode(mode)
-        .save()
-
     // save dataframe directl to carbon file without tempCSV
     df.write
       .format("carbondata")
@@ -99,7 +94,10 @@ object ExampleUtils {
       .option("tempCSV", "false")
       .mode(mode)
       .save()
+  }
 
+  def cleanSampleCarbonFile(cc: CarbonContext, tableName: String): Unit = {
+    cc.sql(s"DROP TABLE IF EXISTS $tableName")
   }
 }
 // scalastyle:on println

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
     <profile>
       <id>flink</id>
       <properties>
-        <flink.version>1.1.3</flink.version>
+        <flink.version>1.1.4</flink.version>
         <scala.binary.version>2.10</scala.binary.version>
       </properties>
       <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,16 @@
       </modules>
     </profile>
     <profile>
+      <id>flink</id>
+      <properties>
+        <flink.version>1.1.3</flink.version>
+        <scala.binary.version>2.10</scala.binary.version>
+      </properties>
+      <modules>
+        <module>examples/flink</module>
+      </modules>
+    </profile>
+    <profile>
       <id>findbugs</id>
       <build>
         <plugins>


### PR DESCRIPTION
A new example module is added for Flink. The example is to show how to use Flink to read CarbonData files written by Spark