### PR TITLE
[CARBONDATA-609]Fixed carbondata file version issue in carbon.properites

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -375,7 +375,8 @@ public final class CarbonProperties {
       return getDefaultFormatVersion();
     } else {
       try {
-        return ColumnarFormatVersion.valueOf(versionStr);
+        short version = Short.parseShort(versionStr);
+        return ColumnarFormatVersion.valueOf(version);
       } catch (IllegalArgumentException e) {
         return getDefaultFormatVersion();
       }

--- a/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
+++ b/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
@@ -62,7 +62,7 @@ public class BlockIndexStoreTest extends TestCase {
   @BeforeClass public void setUp() {
 	property = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION);
 	
-	CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "V1");
+	CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "1");
     StoreCreator.createCarbonStore();
     CarbonProperties.getInstance().
         addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "10");


### PR DESCRIPTION
**Problem:** Data file version is always taking latest version even if version is set to 1, This is because in carbon.properties we are calling valueof with string parameter and it is throwing illegalArugumentExcemption
**Solution:** Need to parse the string value to short and then call valueof method