### PR TITLE
[CARBONDATA-611] Make the default maven command work with build-with-format profile

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -34,6 +34,9 @@
     <carbondata.jar.dir>scala-${scala.binary.version}</carbondata.jar.dir>
     <carbondata.jar.basename>carbondata_${scala.binary.version}-${project.version}-shade-hadoop${hadoop.version}.jar</carbondata.jar.basename>
     <carbondata.jar>${project.build.directory}/${carbondata.jar.dir}/${carbondata.jar.basename}</carbondata.jar>
+    <hadoop.deps.scope>provided</hadoop.deps.scope>
+    <spark.deps.scope>provided</spark.deps.scope>
+    <scala.deps.scope>provided</scala.deps.scope>
     <dev.path>${basedir}/../dev</dev.path>
   </properties>
 
@@ -128,11 +131,6 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-      <properties>
-        <hadoop.deps.scope>provided</hadoop.deps.scope>
-        <spark.deps.scope>provided</spark.deps.scope>
-        <scala.deps.scope>provided</scala.deps.scope>
-      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>
@@ -143,11 +141,6 @@
     </profile>
     <profile>
       <id>spark-1.6</id>
-      <properties>
-        <hadoop.deps.scope>provided</hadoop.deps.scope>
-        <spark.deps.scope>provided</spark.deps.scope>
-        <scala.deps.scope>provided</scala.deps.scope>
-      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>
@@ -158,11 +151,6 @@
     </profile>
     <profile>
       <id>spark-2.1</id>
-      <properties>
-        <hadoop.deps.scope>provided</hadoop.deps.scope>
-        <spark.deps.scope>provided</spark.deps.scope>
-        <scala.deps.scope>provided</scala.deps.scope>
-      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -128,6 +128,11 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <hadoop.deps.scope>provided</hadoop.deps.scope>
+        <spark.deps.scope>provided</spark.deps.scope>
+        <scala.deps.scope>provided</scala.deps.scope>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>
@@ -138,6 +143,11 @@
     </profile>
     <profile>
       <id>spark-1.6</id>
+      <properties>
+        <hadoop.deps.scope>provided</hadoop.deps.scope>
+        <spark.deps.scope>provided</spark.deps.scope>
+        <scala.deps.scope>provided</scala.deps.scope>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>
@@ -148,6 +158,11 @@
     </profile>
     <profile>
       <id>spark-2.1</id>
+      <properties>
+        <hadoop.deps.scope>provided</hadoop.deps.scope>
+        <spark.deps.scope>provided</spark.deps.scope>
+        <scala.deps.scope>provided</scala.deps.scope>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>
@@ -155,17 +170,6 @@
           <version>${project.version}</version>
         </dependency>
       </dependencies>
-    </profile>
-    <profile>
-      <id>provided</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <hadoop.deps.scope>provided</hadoop.deps.scope>
-        <spark.deps.scope>provided</spark.deps.scope>
-        <scala.deps.scope>provided</scala.deps.scope>
-      </properties>
     </profile>
     <profile>
       <id>include-all</id>

--- a/pom.xml
+++ b/pom.xml
@@ -316,11 +316,6 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-      <properties>
-        <spark.version>1.5.2</spark.version>
-        <scala.binary.version>2.10</scala.binary.version>
-        <scala.version>2.10.4</scala.version>
-      </properties>
       <modules>
         <module>integration/spark</module>
         <module>examples/spark</module>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,11 @@
   <profiles>
     <profile>
       <id>build-with-format</id>
+      <properties>
+        <spark.version>1.5.2</spark.version>
+        <scala.binary.version>2.10</scala.binary.version>
+        <scala.version>2.10.4</scala.version>
+      </properties>
       <modules>
         <module>format</module>
       </modules>
@@ -384,9 +389,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>provided</id>
     </profile>
     <profile>
       <id>include-all</id>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,9 @@
     <hadoop.version>2.2.0</hadoop.version>
     <kettle.version>4.4.0-stable</kettle.version>
     <use.kettle>true</use.kettle>
+    <spark.version>1.5.2</spark.version>
+    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.10.4</scala.version>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
     <spark.deps.scope>compile</spark.deps.scope>
     <scala.deps.scope>compile</scala.deps.scope>
@@ -291,11 +294,6 @@
   <profiles>
     <profile>
       <id>build-with-format</id>
-      <properties>
-        <spark.version>1.5.2</spark.version>
-        <scala.binary.version>2.10</scala.binary.version>
-        <scala.version>2.10.4</scala.version>
-      </properties>
       <modules>
         <module>format</module>
       </modules>


### PR DESCRIPTION
Currently `mvn clean -Pbuild-with-format package` does not work, so this PR fixes it, And also by default the assembly jar includes all spark and hadoop jars, this PR removes these dependencies from the assembly jar by default.