### PR TITLE
[CARBONDATA-440] IUD TestCase Fix for spark 1.6 

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -421,7 +421,7 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
           case Some(cond) =>
             "select tupleId from " + tableName  + " " + alias + " where " + cond
           case _ =>
-            "select tupleId from " + tableName
+            "select tupleId from " + tableName + " " + alias
         }
         DeleteRecords(stmt, table)
     }


### PR DESCRIPTION
Fixing the test case failure of "Delete" query when an alias is used with the table. There was a parser issue where the code was unable to recognise the alias name. Fix the syntax and currently test cases are passing. 