### PR TITLE
[CARBONDATA-584]added validation for table is not empty 

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -109,14 +109,14 @@ class CarbonSource extends CreatableRelationProvider
       dataSchema: StructType): String = {
 
     val dbName: String = parameters.getOrElse("dbName", CarbonCommonConstants.DATABASE_DEFAULT_NAME)
-    val emptyTableName: String = parameters.getOrElse("tableName", "default_table")
-    if (StringUtils.isBlank(emptyTableName)) {
-      throw new MalformedCarbonCommandException("INVALID TABLE NAME")
+    val tableName: String = parameters.getOrElse("tableName", "default_table")
+    if (StringUtils.isBlank(tableName)) {
+      throw new MalformedCarbonCommandException("The Specified Table Name is Blank")
     }
     val options = new CarbonOption(parameters)
     try {
-      CarbonEnv.get.carbonMetastore.lookupRelation(Option(dbName), emptyTableName)(sparkSession)
-      CarbonEnv.get.carbonMetastore.storePath + s"/$dbName/$emptyTableName"
+      CarbonEnv.get.carbonMetastore.lookupRelation(Option(dbName), tableName)(sparkSession)
+      CarbonEnv.get.carbonMetastore.storePath + s"/$dbName/$tableName"
     } catch {
       case ex: NoSuchTableException =>
         val fields = dataSchema.map { col =>
@@ -145,9 +145,9 @@ class CarbonSource extends CreatableRelationProvider
           }
         }
         val cm = TableCreator.prepareTableModel(false, Option(dbName),
-          emptyTableName, fields, Nil, bucketFields, map)
+          tableName, fields, Nil, bucketFields, map)
         CreateTable(cm, false).run(sparkSession)
-        CarbonEnv.get.carbonMetastore.storePath + s"/$dbName/$emptyTableName"
+        CarbonEnv.get.carbonMetastore.storePath + s"/$dbName/$tableName"
       case ex: Exception =>
         throw new Exception("do not have dbname and tablename for carbon table", ex)
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -20,15 +20,19 @@ package org.apache.spark.sql
 import java.io.File
 
 import scala.language.implicitConversions
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.execution.CarbonLateDecodeStrategy
 import org.apache.spark.sql.execution.command.{BucketFields, CreateTable, Field}
 import org.apache.spark.sql.optimizer.CarbonLateDecodeRule
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DecimalType, StructType}
+
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
+
 import org.apache.carbondata.spark.CarbonOption
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
@@ -107,7 +111,7 @@ class CarbonSource extends CreatableRelationProvider
 
     val dbName: String = parameters.getOrElse("dbName", CarbonCommonConstants.DATABASE_DEFAULT_NAME)
     val tableName: String = parameters.getOrElse("tableName", "default_table")
-    if(tableName.isEmpty || tableName.contains("")){
+    if(tableName.isEmpty || tableName.contains("")) {
       throw new MalformedCarbonCommandException("INVALID TABLE NAME")
     }
     val options = new CarbonOption(parameters)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -34,7 +34,6 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.CarbonOption
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
-
 import org.apache.commons.lang.StringUtils
 /**
  * Carbon relation provider compliant to data source api.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql
 import java.io.File
 
 import scala.language.implicitConversions
-
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.execution.CarbonLateDecodeStrategy
@@ -28,10 +27,10 @@ import org.apache.spark.sql.execution.command.{BucketFields, CreateTable, Field}
 import org.apache.spark.sql.optimizer.CarbonLateDecodeRule
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DecimalType, StructType}
-
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.CarbonOption
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
 /**
  * Carbon relation provider compliant to data source api.
@@ -108,6 +107,9 @@ class CarbonSource extends CreatableRelationProvider
 
     val dbName: String = parameters.getOrElse("dbName", CarbonCommonConstants.DATABASE_DEFAULT_NAME)
     val tableName: String = parameters.getOrElse("tableName", "default_table")
+    if(tableName.isEmpty || tableName.contains("")){
+      throw new MalformedCarbonCommandException("INVALID TABLE NAME")
+    }
     val options = new CarbonOption(parameters)
     try {
       CarbonEnv.get.carbonMetastore.lookupRelation(Option(dbName), tableName)(sparkSession)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -110,7 +110,8 @@ class CarbonSource extends CreatableRelationProvider
 
     val dbName: String = parameters.getOrElse("dbName", CarbonCommonConstants.DATABASE_DEFAULT_NAME)
     val tableName: String = parameters.getOrElse("tableName", "default_table")
-    if(org.apache.commons.lang.StringUtils.isBlank(tableName) || org.apache.commons.lang.StringUtils.isWhitespace(tableName)) {
+    if(org.apache.commons.lang.StringUtils.isBlank(tableName) ||
+       org.apache.commons.lang.StringUtils.isWhitespace(tableName)) {
       throw new MalformedCarbonCommandException("INVALID TABLE NAME")
     }
     val options = new CarbonOption(parameters)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -22,8 +22,8 @@ import java.io.File
 import scala.language.implicitConversions
 
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.execution.CarbonLateDecodeStrategy
 import org.apache.spark.sql.execution.command.{BucketFields, CreateTable, Field}
 import org.apache.spark.sql.optimizer.CarbonLateDecodeRule
@@ -32,7 +32,6 @@ import org.apache.spark.sql.types.{DecimalType, StructType}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
-
 import org.apache.carbondata.spark.CarbonOption
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
@@ -111,7 +110,7 @@ class CarbonSource extends CreatableRelationProvider
 
     val dbName: String = parameters.getOrElse("dbName", CarbonCommonConstants.DATABASE_DEFAULT_NAME)
     val tableName: String = parameters.getOrElse("tableName", "default_table")
-    if(tableName.isEmpty || tableName.contains("")) {
+    if(org.apache.commons.lang.StringUtils.isBlank(tableName) || org.apache.commons.lang.StringUtils.isWhitespace(tableName)) {
       throw new MalformedCarbonCommandException("INVALID TABLE NAME")
     }
     val options = new CarbonOption(parameters)


### PR DESCRIPTION
    when using either the carbon session or spark source it allows to create bucketed table even if table name in options is empty in this i am correcting this bug by validating table name