### PR TITLE
[CARBONDATA-582]added validation for bucket number is not negative

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.types.{DecimalType, StructType}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.CarbonOption
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
 /**
  * Carbon relation provider compliant to data source api.
@@ -134,7 +135,13 @@ class CarbonSource extends CreatableRelationProvider
         parameters.foreach { x => map.put(x._1, x._2) }
         val bucketFields = {
           if (options.isBucketingEnabled) {
-            Some(BucketFields(options.bucketColumns.split(","), options.bucketNumber))
+            if (options.bucketNumber.toString.contains("-") || options.bucketNumber.toString.contains("+") ) {
+              throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED" +
+                                                        options.bucketNumber.toString)
+            }
+            else {
+              Some(BucketFields(options.bucketColumns.split(","), options.bucketNumber))
+            }
           } else {
             None
           }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -132,9 +132,8 @@ class CarbonSource extends CreatableRelationProvider
           f
         }
         val map = scala.collection.mutable.Map[String, String]()
-        parameters.foreach { x => map.put(x._1, x._2) }
-        val bucketFields = {
-          if (options.isBucketingEnabled) {
+        parameters.foreach { parameter => map.put(parameter._1, parameter._2) }
+        val bucketFields = if (options.isBucketingEnabled) {
             if (options.bucketNumber.toString.contains("-") ||
                 options.bucketNumber.toString.contains("+") ) {
               throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED" +
@@ -146,7 +145,7 @@ class CarbonSource extends CreatableRelationProvider
           } else {
             None
           }
-        }
+
         val cm = TableCreator.prepareTableModel(false, Option(dbName),
           tableName, fields, Nil, bucketFields, map)
         CreateTable(cm, false).run(sparkSession)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -135,7 +135,8 @@ class CarbonSource extends CreatableRelationProvider
         parameters.foreach { x => map.put(x._1, x._2) }
         val bucketFields = {
           if (options.isBucketingEnabled) {
-            if (options.bucketNumber.toString.contains("-") || options.bucketNumber.toString.contains("+") ) {
+            if (options.bucketNumber.toString.contains("-") ||
+                options.bucketNumber.toString.contains("+") ) {
               throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED" +
                                                         options.bucketNumber.toString)
             }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -138,7 +138,8 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       val options = new CarbonOption(properties)
       val bucketFields = {
         if (options.isBucketingEnabled) {
-          if(options.bucketNumber.toString.contains("-") || options.bucketNumber.toString.contains("+")){
+          if (options.bucketNumber.toString.contains("-") ||
+             options.bucketNumber.toString.contains("+")) {
             throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED")
           }
             else {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.parser.ParserUtils._
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{CreateTableContext,
 TablePropertyListContext}
 import org.apache.spark.sql.catalyst.parser.{AbstractSqlParser, ParseException, SqlBaseParser}
+
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.execution.SparkSqlAstBuilder

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -138,7 +138,12 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       val options = new CarbonOption(properties)
       val bucketFields = {
         if (options.isBucketingEnabled) {
-          Some(BucketFields(options.bucketColumns.split(","), options.bucketNumber))
+          if(options.bucketNumber.toString.contains("-") || options.bucketNumber.toString.contains("+")){
+            throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED")
+          }
+            else {
+              Some(BucketFields(options.bucketColumns.split(","), options.bucketNumber))
+            }
         } else {
           None
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -19,11 +19,9 @@ package org.apache.spark.sql.parser
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.parser.ParserUtils._
-import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{CreateTableContext,
-TablePropertyListContext}
 import org.apache.spark.sql.catalyst.parser.{AbstractSqlParser, ParseException, SqlBaseParser}
-
+import org.apache.spark.sql.catalyst.parser.ParserUtils._
+import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{CreateTableContext, TablePropertyListContext}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.execution.SparkSqlAstBuilder

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.carbon.metadata.CarbonMetadata
 import org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
 class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
 
@@ -42,6 +43,7 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS t6")
     sql("DROP TABLE IF EXISTS t7")
     sql("DROP TABLE IF EXISTS t8")
+    sql("DROP TABLE IF EXISTS t9")
   }
 
   test("test create table with buckets") {
@@ -60,6 +62,23 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
       assert(true)
     } else {
       assert(false, "Bucketing info does not exist")
+    }
+  }
+
+  test("must be unable to create if number of buckets is in negative number"){
+    try {
+      sql(
+        """
+           CREATE TABLE t6
+           (ID Int, date Timestamp, country String,
+           name String, phonetype String, serialname String, salary Int)
+           USING org.apache.spark.sql.CarbonSource
+           OPTIONS("bucketnumber"="-1", "bucketcolumns"="name", "tableName"="t6")
+      """)
+      assert(false)
+      }
+    catch {
+      case malformedCarbonCommandException:MalformedCarbonCommandException =>assert(true)
     }
   }
 

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -65,7 +65,7 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  test("must be unable to create if number of buckets is in negative number"){
+  test("must be unable to create if number of buckets is in negative number") {
     try {
       sql(
         """
@@ -74,11 +74,11 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
            name String, phonetype String, serialname String, salary Int)
            USING org.apache.spark.sql.CarbonSource
            OPTIONS("bucketnumber"="-1", "bucketcolumns"="name", "tableName"="t9")
-      """)
+        """)
       assert(false)
-      }
+    }
     catch {
-      case malformedCarbonCommandException:MalformedCarbonCommandException =>assert(true)
+      case malformedCarbonCommandException: MalformedCarbonCommandException => assert(true)
     }
   }
 

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -69,11 +69,11 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
     try {
       sql(
         """
-           CREATE TABLE t6
+           CREATE TABLE t9
            (ID Int, date Timestamp, country String,
            name String, phonetype String, serialname String, salary Int)
            USING org.apache.spark.sql.CarbonSource
-           OPTIONS("bucketnumber"="-1", "bucketcolumns"="name", "tableName"="t6")
+           OPTIONS("bucketnumber"="-1", "bucketcolumns"="name", "tableName"="t9")
       """)
       assert(false)
       }


### PR DESCRIPTION
when we create table with bucket number is specified in negative it creates table

CREATE TABLE BucketTest1111352983(name int,ID string)USING org.apache.spark.sql.CarbonSource OPTIONS("bucketnumber"="-1", "bucketcolumns"="name1");
+---------+--+
| Result  |
+---------+--+
+---------+--+
No rows selected (0.277 seconds)

this is because there is no check whether the bucket number given is positive or not 

in hive it gives a error

here are the logs in hive

hive> CREATE TABLE BucketTest1111352983(name int,ID string)USING org.apache.spark.sql.CarbonSource OPTIONS("bucketnumber"="-1", "bucketcolumns"="name1");
+---------+--+
| Result  |
+---------+--+
+---------+--+
No rows selected (0.277 seconds)
 in carbon data as well it should not allow this

in this pr we resolved this issue
 