### PR TITLE
[CARBONDATA-618] Added new profile to build all modules

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -127,10 +127,6 @@
   <profiles>
     <profile>
       <id>spark-1.5</id>
-      <!-- default -->
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>
@@ -141,6 +137,10 @@
     </profile>
     <profile>
       <id>spark-1.6</id>
+      <!-- default -->
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.carbondata</groupId>

--- a/examples/spark2/pom.xml
+++ b/examples/spark2/pom.xml
@@ -30,6 +30,9 @@
   <name>Apache CarbonData :: Spark2 Examples</name>
 
   <properties>
+    <spark.version>2.1.0</spark.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <scala.version>2.11.8</scala.version>
     <dev.path>${basedir}/../../dev</dev.path>
   </properties>
 

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -30,6 +30,9 @@
   <name>Apache CarbonData :: Spark2</name>
 
   <properties>
+    <spark.version>2.1.0</spark.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <scala.version>2.11.8</scala.version>
     <dev.path>${basedir}/../../dev</dev.path>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,6 @@
     <hadoop.version>2.2.0</hadoop.version>
     <kettle.version>4.4.0-stable</kettle.version>
     <use.kettle>true</use.kettle>
-    <spark.version>1.5.2</spark.version>
-    <scala.binary.version>2.10</scala.binary.version>
-    <scala.version>2.10.4</scala.version>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
     <spark.deps.scope>compile</spark.deps.scope>
     <scala.deps.scope>compile</scala.deps.scope>
@@ -293,9 +290,29 @@
 
   <profiles>
     <profile>
+      <!--This profile does not build spark module, so user should explicitly give spark profile also like spark-1.6 -->
       <id>build-with-format</id>
       <modules>
         <module>format</module>
+      </modules>
+    </profile>
+    <profile>
+      <!-- This profile only should be used for release prepare to cover all the modules -->
+      <id>build-all</id>
+      <properties>
+        <spark.version>1.6.2</spark.version>
+        <scala.binary.version>2.10</scala.binary.version>
+        <scala.version>2.10.4</scala.version>
+        <maven.test.skip>true</maven.test.skip>
+        <flink.version>1.1.4</flink.version>
+      </properties>
+      <modules>
+        <module>format</module>
+        <module>integration/spark</module>
+        <module>examples/spark</module>
+        <module>integration/spark2</module>
+        <module>examples/spark2</module>
+        <module>examples/flink</module>
       </modules>
     </profile>
     <profile>
@@ -313,9 +330,11 @@
     </profile>
     <profile>
       <id>spark-1.5</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
+      <properties>
+        <spark.version>1.5.2</spark.version>
+        <scala.binary.version>2.10</scala.binary.version>
+        <scala.version>2.10.4</scala.version>
+      </properties>
       <modules>
         <module>integration/spark</module>
         <module>examples/spark</module>
@@ -323,6 +342,9 @@
     </profile>
     <profile>
       <id>spark-1.6</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <spark.version>1.6.2</spark.version>
         <scala.binary.version>2.10</scala.binary.version>


### PR DESCRIPTION
Added new profile `build-all` to build all the modules, but this profile only should be used for release purpose.

And also `build-with-format` profile cannot be used alone as it cannot build integration/spark modules, so user should use spark profile as well like `spark-1.6` or `spark-2.1`.