### PR TITLE
[CARBONDATA-621]Fixed compaction with multiple blocklet issue

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionBlockletBoundryTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionBlockletBoundryTest.scala
@@ -36,7 +36,7 @@ class DataCompactionBlockletBoundryTest extends QueryTest with BeforeAndAfterAll
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "mm/dd/yyyy")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.BLOCKLET_SIZE,
-        "55")
+        "120")
     sql(
       "CREATE TABLE IF NOT EXISTS blocklettest (country String, ID String, date Timestamp, name " +
         "String, " +

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -318,7 +318,10 @@ class CarbonMergerRDD[K, V](
 
     // prepare the details required to extract the segment properties using last segment.
     if (null != carbonInputSplits && carbonInputSplits.nonEmpty) {
-      val carbonInputSplit = carbonInputSplits.last
+      // taking head as scala sequence is use and while adding it will add at first
+      // so as we need to update the update the key of older segments with latest keygenerator
+      // we need to take the top of the split
+      val carbonInputSplit = carbonInputSplits.head
       var dataFileFooter: DataFileFooter = null
 
       try {


### PR DESCRIPTION
Problem: Compaction is failing in case of multiple blocklet and when each segment dictionary column size is changing
Reason: this is because during compaction we need to update the dictionary byte value with last segment key generator, in carbon merge rdd we are passing the oldest segment cardinality value we need to pass latest segment cardinality
Solution: Pass the latest segment cardinality.