### PR TITLE
[CARBONDATA-622]unify file header reader

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
@@ -41,8 +41,7 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
       assert(false)
     } catch {
       case e: Exception =>
-        assert(e.getMessage.equals("DataLoad failure: CSV File provided is not proper. " +
-          "Column names in schema and csv header are not same. CSVFile Name : windows.csv"))
+        assert(e.getMessage.contains("CSV File provided is not proper. Column names in schema and csv header are not same."))
     }
   }
 
@@ -55,8 +54,7 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
       assert(false)
     } catch {
       case e: Exception =>
-        assert(e.getMessage.equals("DataLoad failure: CSV header provided in DDL is not proper. " +
-          "Column names in schema and CSV header are not the same."))
+        assert(e.getMessage.contains("CSV header provided in DDL is not proper. Column names in schema and CSV header are not the same"))
     }
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
@@ -41,7 +41,7 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
       assert(false)
     } catch {
       case e: Exception =>
-        assert(e.getMessage.contains("CSV File provided is not proper. Column names in schema and csv header are not same."))
+        assert(e.getMessage.contains("CSV header in input file is not proper. Column names in schema and csv header are not the same."))
     }
   }
 
@@ -54,7 +54,7 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
       assert(false)
     } catch {
       case e: Exception =>
-        assert(e.getMessage.contains("CSV header provided in DDL is not proper. Column names in schema and CSV header are not the same"))
+        assert(e.getMessage.contains("CSV header in DDL is not proper. Column names in schema and CSV header are not the same"))
     }
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithNotProperInputFile.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithNotProperInputFile.scala
@@ -35,10 +35,9 @@ class TestLoadDataWithNotProperInputFile extends QueryTest {
 
   test("test loading data with input path exists but has nothing") {
     try {
-      val carbonLoadModel: CarbonLoadModel = new CarbonLoadModel
       val dataPath = s"$resourcesPath/nullSample.csv"
-      carbonLoadModel.setFactFilePath(FileUtils.getPaths(dataPath))
-      GlobalDictionaryUtil.loadDataFrame(sqlContext, carbonLoadModel)
+      FileUtils.getPaths(dataPath)
+      assert(false)
     } catch {
       case e: Throwable =>
         assert(e.getMessage.contains("Please check your input path and make sure " +
@@ -48,24 +47,20 @@ class TestLoadDataWithNotProperInputFile extends QueryTest {
 
   test("test loading data with input file not ends with '.csv'") {
     try {
-      val carbonLoadModel: CarbonLoadModel = new CarbonLoadModel
       val dataPath = s"$resourcesPath/noneCsvFormat.cs"
-      carbonLoadModel.setFactFilePath(FileUtils.getPaths(dataPath))
-      GlobalDictionaryUtil.loadDataFrame(sqlContext, carbonLoadModel)
+      FileUtils.getPaths(dataPath)
+      assert(true)
     } catch {
       case e: Throwable =>
-        e.printStackTrace()
-        assert(e.getMessage.contains("Please check your input path and make sure " +
-          "that files end with '.csv' and content is not empty"))
+        assert(false)
     }
   }
 
   test("test loading data with input file does not exist") {
     try {
-      val carbonLoadModel: CarbonLoadModel = new CarbonLoadModel
       val dataPath = s"$resourcesPath/input_file_does_not_exist.csv"
-      carbonLoadModel.setFactFilePath(FileUtils.getPaths(dataPath))
-      GlobalDictionaryUtil.loadDataFrame(sqlContext, carbonLoadModel)
+      FileUtils.getPaths(dataPath)
+      assert(false)
     } catch {
       case e: Throwable =>
         assert(e.getMessage.contains("The input file does not exist"))

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -328,18 +328,18 @@ object CommonUtil {
     if (!CarbonDataProcessorUtil.isHeaderValid(carbonLoadModel.getTableName, csvColumns,
         carbonLoadModel.getCarbonDataLoadSchema)) {
       if (csvFile == null) {
-        LOGGER.error("CSV header provided in DDL is not proper."
+        LOGGER.error("CSV header in DDL is not proper."
                      + " Column names in schema and CSV header are not the same.")
         throw new CarbonDataLoadingException(
-          "CSV header provided in DDL is not proper. Column names in schema and CSV header are "
+          "CSV header in DDL is not proper. Column names in schema and CSV header are "
           + "not the same.")
       } else {
         LOGGER.error(
-          "CSV File provided is not proper. Column names in schema and csv header are not same. "
-          + "CSVFile Name : " + csvFile)
+          "CSV header in input file is not proper. Column names in schema and csv header are not "
+          + "the same. Input file : " + csvFile)
         throw new CarbonDataLoadingException(
-          "CSV File provided is not proper. Column names in schema and csv header are not same. "
-          + "CSVFile Name : " + csvFile)
+          "CSV header in input file is not proper. Column names in schema and csv header are not "
+          + "the same. Input file : " + csvFile)
       }
     }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -57,7 +57,7 @@ import org.apache.carbondata.processing.etl.DataLoadingException
 import org.apache.carbondata.processing.model.CarbonLoadModel
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 import org.apache.carbondata.spark.rdd.{CarbonDataRDDFactory, DataManagementFunc, DictionaryLoadModel}
-import org.apache.carbondata.spark.util.{CarbonScalaUtil, GlobalDictionaryUtil}
+import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil, GlobalDictionaryUtil}
 
 object Checker {
   def validateTableExists(
@@ -491,6 +491,7 @@ case class LoadTable(
         carbonLoadModel.setCsvHeader(fileHeader)
         carbonLoadModel.setColDictFilePath(columnDict)
         carbonLoadModel.setDirectLoad(true)
+        carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
         GlobalDictionaryUtil.updateTableMetadataFunc = updateTableMetadata
 
         if (carbonLoadModel.getUseOnePass) {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
@@ -64,6 +64,7 @@ class AllDictionaryTestCase extends QueryTest with BeforeAndAfterAll {
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
+    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
     carbonLoadModel
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
@@ -60,6 +60,7 @@ class AutoHighCardinalityIdentifyTestCase extends QueryTest with BeforeAndAfterA
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
+    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
     carbonLoadModel
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -62,7 +62,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     extColDictFilePath3 = s"channelsId:${resourcesPath}/channelsId.csv"
     header = "deviceInformationId,channelsId,ROMSize,purchasedate,mobile,MAC," +
       "locationinfo,proddate,gamePointId,contractNumber"
-    header2 = "deviceInformationId|channelsId|contractNumber"
+    header2 = "deviceInformationId,channelsId,contractNumber"
   }
 
   def buildTable() = {
@@ -145,6 +145,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
+    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
     carbonLoadModel
   }
 
@@ -230,7 +231,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     try {
       sql(s"""
       LOAD DATA LOCAL INPATH "$complexFilePath1" INTO TABLE loadSqlTest
-      OPTIONS('COLUMNDICT'='gamePointId:$filePath')
+      OPTIONS('FILEHEADER'='$header', 'COLUMNDICT'='gamePointId:$filePath')
       """)
       assert(false)
     } catch {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
@@ -63,6 +63,7 @@ class GlobalDictionaryUtilConcurrentTestCase extends QueryTest with BeforeAndAft
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
+    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
     carbonLoadModel
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
@@ -69,6 +69,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
+    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
     carbonLoadModel
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -54,7 +54,7 @@ import org.apache.carbondata.processing.etl.DataLoadingException
 import org.apache.carbondata.processing.model.CarbonLoadModel
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 import org.apache.carbondata.spark.rdd.{CarbonDataRDDFactory, DataManagementFunc, DictionaryLoadModel}
-import org.apache.carbondata.spark.util.{CarbonScalaUtil, CarbonSparkUtil, GlobalDictionaryUtil}
+import org.apache.carbondata.spark.util.{CarbonScalaUtil, CarbonSparkUtil, CommonUtil, GlobalDictionaryUtil}
 
 object Checker {
   def validateTableExists(
@@ -454,6 +454,7 @@ case class LoadTable(
         carbonLoadModel.setCsvHeader(fileHeader)
         carbonLoadModel.setColDictFilePath(columnDict)
         carbonLoadModel.setDirectLoad(true)
+        carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
         GlobalDictionaryUtil.updateTableMetadataFunc = LoadTable.updateTableMetadata
 
         val (dictionaryDataFrame, loadDataFrame) = if (updateModel.isDefined) {

--- a/processing/src/main/java/org/apache/carbondata/processing/model/CarbonLoadModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/model/CarbonLoadModel.java
@@ -64,6 +64,7 @@ public class CarbonLoadModel implements Serializable {
 
   private List<String> factFilesToProcess;
   private String csvHeader;
+  private String[] csvHeaderColumns;
   private String csvDelimiter;
   private String complexDelimiterLevel1;
   private String complexDelimiterLevel2;
@@ -250,6 +251,14 @@ public class CarbonLoadModel implements Serializable {
     this.csvHeader = csvHeader;
   }
 
+  public String[] getCsvHeaderColumns() {
+    return csvHeaderColumns;
+  }
+
+  public void setCsvHeaderColumns(String[] csvHeaderColumns) {
+    this.csvHeaderColumns = csvHeaderColumns;
+  }
+
   public void initPredefDictMap() {
     predefDictMap = new HashMap<>();
   }
@@ -398,6 +407,7 @@ public class CarbonLoadModel implements Serializable {
     copyObj.isRetentionRequest = isRetentionRequest;
     copyObj.carbonDataLoadSchema = carbonDataLoadSchema;
     copyObj.csvHeader = header;
+    copyObj.csvHeaderColumns = csvHeaderColumns;
     copyObj.factFilesToProcess = filesForPartition;
     copyObj.isDirectLoad = true;
     copyObj.csvDelimiter = delimiter;


### PR DESCRIPTION
Scenario:
We can get file header from DDL command and CSV file. 
1. If the file header comes from DDL command, should separate this file header by comma ","
2. if the file header comes from CSV file, should sparate this file header by specify delimiter in DDL command.

Changes:
Before data loading,  generate file header at first, both dict generation and dataloading can directly use this file header(exclude Kettle flow).
