### PR TITLE
[CARBONDATA-628] Fixed measure selection with out table order gives wrong result with vectorized reader enabled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -101,7 +101,6 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
     complexInfo = complexList.toArray(new ColumnVectorInfo[complexList.size()]);
     Arrays.sort(dictionaryInfo);
     Arrays.sort(noDictionaryInfo);
-    Arrays.sort(measureInfo);
     Arrays.sort(complexInfo);
   }
 

--- a/core/src/main/java/org/apache/carbondata/scan/processor/AbstractDataBlockIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/processor/AbstractDataBlockIterator.java
@@ -90,15 +90,15 @@ public abstract class AbstractDataBlockIterator extends CarbonIterator<List<Obje
       blockletScanner = new NonFilterScanner(blockExecutionInfo, queryStatisticsModel);
     }
     if (blockExecutionInfo.isRawRecordDetailQuery()) {
-      LOGGER.audit("Row based raw collector is used to scan and collect the data");
+      LOGGER.info("Row based raw collector is used to scan and collect the data");
       this.scannerResultAggregator =
           new RawBasedResultCollector(blockExecutionInfo);
     } else if (blockExecutionInfo.isVectorBatchCollector()) {
-      LOGGER.audit("Vector based dictionary collector is used to scan and collect the data");
+      LOGGER.info("Vector based dictionary collector is used to scan and collect the data");
       this.scannerResultAggregator =
           new DictionaryBasedVectorResultCollector(blockExecutionInfo);
     } else {
-      LOGGER.audit("Row based dictionary collector is used to scan and collect the data");
+      LOGGER.info("Row based dictionary collector is used to scan and collect the data");
       this.scannerResultAggregator =
           new DictionaryBasedResultCollector(blockExecutionInfo);
     }

--- a/core/src/main/java/org/apache/carbondata/scan/processor/AbstractDataBlockIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/processor/AbstractDataBlockIterator.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.carbondata.common.CarbonIterator;
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.carbon.datastore.DataRefNode;
 import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsModel;
 import org.apache.carbondata.core.datastorage.store.FileHolder;
@@ -42,6 +44,9 @@ import org.apache.carbondata.scan.scanner.impl.NonFilterScanner;
  * Block iterator.
  */
 public abstract class AbstractDataBlockIterator extends CarbonIterator<List<Object[]>> {
+
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(AbstractDataBlockIterator.class.getName());
 
   /**
    * iterator which will be used to iterate over data blocks
@@ -85,12 +90,15 @@ public abstract class AbstractDataBlockIterator extends CarbonIterator<List<Obje
       blockletScanner = new NonFilterScanner(blockExecutionInfo, queryStatisticsModel);
     }
     if (blockExecutionInfo.isRawRecordDetailQuery()) {
+      LOGGER.audit("Row based raw collector is used to scan and collect the data");
       this.scannerResultAggregator =
           new RawBasedResultCollector(blockExecutionInfo);
     } else if (blockExecutionInfo.isVectorBatchCollector()) {
+      LOGGER.audit("Vector based dictionary collector is used to scan and collect the data");
       this.scannerResultAggregator =
           new DictionaryBasedVectorResultCollector(blockExecutionInfo);
     } else {
+      LOGGER.audit("Row based dictionary collector is used to scan and collect the data");
       this.scannerResultAggregator =
           new DictionaryBasedResultCollector(blockExecutionInfo);
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
@@ -463,13 +463,13 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
   def supportBatchedDataSource(sqlContext: SQLContext, cols: Seq[Attribute]): Boolean = {
     val enableReader = {
       if (sqlContext.sparkSession.conf.contains(CarbonCommonConstants.ENABLE_VECTOR_READER)) {
-        sqlContext.sparkSession.conf.get(CarbonCommonConstants.ENABLE_VECTOR_READER).toBoolean
+        sqlContext.sparkSession.conf.get(CarbonCommonConstants.ENABLE_VECTOR_READER)
       } else {
         System.getProperty(CarbonCommonConstants.ENABLE_VECTOR_READER,
-          CarbonCommonConstants.ENABLE_VECTOR_READER_DEFAULT).toBoolean
+          CarbonCommonConstants.ENABLE_VECTOR_READER_DEFAULT)
       }
     }
-    sqlContext.conf.wholeStageEnabled && enableReader &&
+    sqlContext.conf.wholeStageEnabled && enableReader.toBoolean &&
       cols.forall(_.dataType.isInstanceOf[AtomicType])
   }
 }


### PR DESCRIPTION
If the table is created with measure order like m1, m2 and user selects the measures m2, m1 then it returns wrong result with vectorized reader enabled