### PR TITLE
[CARBONDATA-629] Issue with database name case sensitivity

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithDatabaseNameCaseChange.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithDatabaseNameCaseChange.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.createTable
+
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * test functionality related the case change for database name
+ */
+class TestCreateTableWithDatabaseNameCaseChange extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("use default")
+    sql("drop database if exists dbCaseChange cascade")
+  }
+
+  test("test create table with database case name change") {
+    // this test case will test the creation of table for different case for database name.
+    // In hive dbName folder is always created with small case in HDFS. Carbon should behave
+    // the same way. If table creation fails during second time creation it means in HDFS
+    // separate folders are created for the matching case in commands executed.
+    sql("create database dbCaseChange")
+    sql("use DBCaseChanGe")
+    sql("create table carbonTable(a int, b string)stored by 'carbondata'")
+    sql("drop table carbonTable")
+    sql("use default")
+    sql("use dbcasechange")
+    try {
+      // table creation should be successful
+      sql("create table carbonTable(a int, b string)stored by 'carbondata'")
+      assert(true)
+    } catch {
+      case ex: Exception =>
+        assert(false)
+    }
+  }
+
+  override def afterAll {
+    sql("use default")
+    sql("drop database if exists dbCaseChange cascade")
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -644,10 +644,33 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         case Token(part, Nil) => cleanIdentifier(part)
       } match {
         case Seq(tableOnly) => (None, tableOnly)
-        case Seq(databaseName, table) => (Some(databaseName), table)
+        case Seq(databaseName, table) => (Some(convertDbNameToLowerCase(databaseName)), table)
       }
 
     (db, tableName)
+  }
+
+  /**
+   * This method will convert the database name to lower case
+   *
+   * @param dbName
+   * @return String
+   */
+  protected def convertDbNameToLowerCase(dbName: String) = {
+    dbName.toLowerCase
+  }
+
+  /**
+   * This method will convert the database name to lower case
+   *
+   * @param dbName
+   * @return Option of String
+   */
+  protected def convertDbNameToLowerCase(dbName: Option[String]): Option[String] = {
+    dbName match {
+      case Some(databaseName) => Some(convertDbNameToLowerCase(databaseName))
+      case None => dbName
+    }
   }
 
   protected def cleanIdentifier(ident: String): String = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -107,6 +107,13 @@ case class DropDatabase(dbName: String, isCascade: Boolean, sql: String)
   }
 }
 
+case class UseDatabase(sql: String) extends LogicalPlan with Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+  override def output: Seq[AttributeReference] = {
+    Seq()
+  }
+}
+
 case class ProjectForUpdate(
     table: UnresolvedRelation,
     columns: List[String],

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -291,6 +291,8 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
         } else {
           ExecutedCommand(DropDatabaseCommand(dbName, HiveNativeCommand(sql))) :: Nil
         }
+      case UseDatabase(sql) =>
+        ExecutedCommand(HiveNativeCommand(sql)) :: Nil
       case d: HiveNativeCommand =>
         try {
           val resolvedTable = sqlContext.executePlan(CarbonHiveSyntax.parse(d.sql)).optimizedPlan

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -148,7 +148,7 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       properties.foreach(tableProperties += _)
       // prepare table model of the collected tokens
       val tableModel: TableModel = parser.prepareTableModel(ifNotExists,
-        name.database,
+        convertDbNameToLowerCase(name.database),
         name.table.toLowerCase,
         fields,
         Seq(),
@@ -158,6 +158,19 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       CreateTable(tableModel)
     } else {
       super.visitCreateTable(ctx)
+    }
+  }
+
+  /**
+   * This method will convert the database name to lower case
+   *
+   * @param dbName
+   * @return Option of String
+   */
+  protected def convertDbNameToLowerCase(dbName: Option[String]): Option[String] = {
+    dbName match {
+      case Some(databaseName) => Some(databaseName.toLowerCase)
+      case None => dbName
     }
   }
 


### PR DESCRIPTION
**Analysis:** When database name is provided in any DDL/DML command, the database name is interpreted and used in the same case as provided by the user. This leads to different behavior in windows and unix systems as windows is case sensitive and linux systems are case insensitive.
Consider a case for create database. Lets say database name is "Carbon". While executing database name is provided as Carbon but while deleting or using or creating table the case is changed to "CARbOn". In these cases system will not behave correctly and if HDFS UI is checked the database Carbon will still exist even after dropping database as the case for database name was different in the 2 commands execution.

**Fix:** Always convert the database name to lower case for any DDL/DML operation while parsing so that the behavior remains consistent.