### PR TITLE
[CARBONDATA-630]Fixed select query with expression issue in Spark 2.1 cluster mode

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -237,7 +237,7 @@ class CarbonDecoderRDD(
     output: Seq[Attribute])
     extends RDD[InternalRow](prev) {
 
-  val storepath = CarbonEnv.get.carbonMetastore.storePath
+  private val storepath = CarbonEnv.get.carbonMetastore.storePath
 
   def canBeDecoded(attr: Attribute): Boolean = {
     profile match {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -237,6 +237,8 @@ class CarbonDecoderRDD(
     output: Seq[Attribute])
     extends RDD[InternalRow](prev) {
 
+  val storepath = CarbonEnv.get.carbonMetastore.storePath
+
   def canBeDecoded(attr: Attribute): Boolean = {
     profile match {
       case ip: IncludeProfile if ip.attributes.nonEmpty =>
@@ -302,7 +304,6 @@ class CarbonDecoderRDD(
   }
 
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
-          val storepath = CarbonEnv.get.carbonMetastore.storePath
     val absoluteTableIdentifiers = relations.map { relation =>
       val carbonTable = relation.carbonRelation.carbonRelation.metaData.carbonTable
       (carbonTable.getFactTableName, carbonTable.getAbsoluteTableIdentifier)


### PR DESCRIPTION
This PR fixes select query with expression issue in Spark 2.1 cluster mode. Queries like `select lower(field) from carbon_table;` does not work as it should use CarbonDecoderRDD in plan. But in this RDD it uses storePath which is not not accessible to worker, so it throws exception. 