### PR TITLE
[CARBONDATA-633]Fixed offheap Query Crash issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/carbon/datastore/chunk/store/MeasureChunkStoreFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/carbon/datastore/chunk/store/MeasureChunkStoreFactory.java
@@ -62,7 +62,7 @@ public class MeasureChunkStoreFactory {
    * @return measure chunk store
    */
   public MeasureDataChunkStore getMeasureDataChunkStore(DataType dataType, int numberOfRows) {
-    if (isUnsafe) {
+    if (!isUnsafe) {
       switch (dataType) {
         case DATA_BYTE:
           return new SafeByteMeasureChunkStore(numberOfRows);

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.common.logging.impl.StandardLogService;
@@ -79,6 +80,12 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
    * holder for query properties which will be used to execute the query
    */
   protected QueryExecutorProperties queryProperties;
+
+  /**
+   * query result iterator which will execute the query
+   * and give the result
+   */
+  protected CarbonIterator queryIterator;
 
   public AbstractQueryExecutor() {
     queryProperties = new QueryExecutorProperties();
@@ -470,6 +477,9 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
    */
   @Override public void finish() throws QueryExecutionException {
     CarbonUtil.clearBlockCache(queryProperties.dataBlocks);
+    if(null != queryIterator) {
+      queryIterator.close();
+    }
     if (null != queryProperties.executorService) {
       queryProperties.executorService.shutdown();
       try {

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
@@ -39,11 +39,12 @@ public class DetailQueryExecutor extends AbstractQueryExecutor<BatchResult> {
   public CarbonIterator<BatchResult> execute(QueryModel queryModel)
       throws QueryExecutionException, IOException {
     List<BlockExecutionInfo> blockExecutionInfoList = getBlockExecutionInfos(queryModel);
-    return new DetailQueryResultIterator(
+    this.queryIterator = new DetailQueryResultIterator(
         blockExecutionInfoList,
         queryModel,
         queryProperties.executorService
     );
+    return queryIterator;
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/VectorDetailQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/VectorDetailQueryExecutor.java
@@ -36,11 +36,12 @@ public class VectorDetailQueryExecutor extends AbstractQueryExecutor<Object> {
   public CarbonIterator<Object> execute(QueryModel queryModel)
       throws QueryExecutionException, IOException {
     List<BlockExecutionInfo> blockExecutionInfoList = getBlockExecutionInfos(queryModel);
-    return new VectorDetailQueryResultIterator(
+    this.queryIterator = new VectorDetailQueryResultIterator(
         blockExecutionInfoList,
         queryModel,
         queryProperties.executorService
     );
+    return this.queryIterator;
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/scan/processor/AbstractDataBlockIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/processor/AbstractDataBlockIterator.java
@@ -76,14 +76,12 @@ public abstract class AbstractDataBlockIterator extends CarbonIterator<List<Obje
 
   protected AbstractScannedResult scannedResult;
 
-  public AbstractDataBlockIterator(BlockExecutionInfo blockExecutionInfo,
-      FileHolder fileReader, int batchSize, QueryStatisticsModel queryStatisticsModel) {
+  public AbstractDataBlockIterator(BlockExecutionInfo blockExecutionInfo, FileHolder fileReader,
+      int batchSize, QueryStatisticsModel queryStatisticsModel,
+      BlocksChunkHolder blockChunkHolder) {
     dataBlockIterator = new BlockletIterator(blockExecutionInfo.getFirstDataBlock(),
         blockExecutionInfo.getNumberOfBlockToScan());
-    blocksChunkHolder = new BlocksChunkHolder(blockExecutionInfo.getTotalNumberDimensionBlock(),
-        blockExecutionInfo.getTotalNumberOfMeasureBlock());
-    blocksChunkHolder.setFileReader(fileReader);
-
+    blocksChunkHolder = blockChunkHolder;
     if (blockExecutionInfo.getFilterExecuterTree() != null) {
       blockletScanner = new FilterScanner(blockExecutionInfo, queryStatisticsModel);
     } else {

--- a/core/src/main/java/org/apache/carbondata/scan/processor/impl/DataBlockIteratorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/processor/impl/DataBlockIteratorImpl.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsModel;
 import org.apache.carbondata.core.datastorage.store.FileHolder;
 import org.apache.carbondata.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.scan.processor.AbstractDataBlockIterator;
+import org.apache.carbondata.scan.processor.BlocksChunkHolder;
 import org.apache.carbondata.scan.result.vector.CarbonColumnarBatch;
 
 /**
@@ -37,8 +38,9 @@ public class DataBlockIteratorImpl extends AbstractDataBlockIterator {
    * @param blockExecutionInfo execution information
    */
   public DataBlockIteratorImpl(BlockExecutionInfo blockExecutionInfo, FileHolder fileReader,
-      int batchSize, QueryStatisticsModel queryStatisticsModel) {
-    super(blockExecutionInfo, fileReader, batchSize, queryStatisticsModel);
+      int batchSize, QueryStatisticsModel queryStatisticsModel,
+      BlocksChunkHolder blockChunkHolder) {
+    super(blockExecutionInfo, fileReader, batchSize, queryStatisticsModel, blockChunkHolder);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/scan/result/AbstractScannedResult.java
+++ b/core/src/main/java/org/apache/carbondata/scan/result/AbstractScannedResult.java
@@ -383,7 +383,6 @@ public abstract class AbstractScannedResult {
     if (rowCounter < this.totalNumberOfRows) {
       return true;
     }
-    CarbonUtil.freeMemory(dataChunks, measureDataChunks);
     return false;
   }
 

--- a/core/src/main/java/org/apache/carbondata/scan/scanner/impl/FilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/scan/scanner/impl/FilterScanner.java
@@ -134,6 +134,8 @@ public class FilterScanner extends AbstractBlockletScanner {
     if (bitSet.isEmpty()) {
       scannedResult.setNumberOfRows(0);
       scannedResult.setIndexes(new int[0]);
+      CarbonUtil.freeMemory(blocksChunkHolder.getDimensionDataChunk(),
+          blocksChunkHolder.getMeasureDataChunk());
       return;
     }
     // valid scanned blocklet


### PR DESCRIPTION
**Problem**
Query is failing sometime when number of 1 block contains more than one blocklet
**Reason**
 Offheap memory is getting clear before all the records are accessed 
**Solutiion**
Once all the records are accessed then clear the memory
