### PR TITLE
[CARBONDATA-641]supported date type for dictionary_exclude

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithoutDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithoutDataLoad.scala
@@ -33,7 +33,7 @@ class TestQueryWithoutDataLoad extends QueryTest with BeforeAndAfterAll {
     sql("""
         CREATE TABLE no_load(imei string, age int, productdate timestamp, gamePointId double)
         STORED BY 'org.apache.carbondata.format'
-        TBLPROPERTIES('DICTIONARY_EXCLUDE'='productdate', 'DICTIONARY_INCLUDE'='gamePointId')
+        TBLPROPERTIES('DICTIONARY_INCLUDE'='gamePointId')
       """)
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datetype/DateTypeTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datetype/DateTypeTest.scala
@@ -1,0 +1,73 @@
+package org.apache.carbondata.spark.testsuite.datetype
+
+import org.apache.spark.sql.common.util.QueryTest
+
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+
+
+class DateTypeTest extends QueryTest {
+
+
+  test("must throw exception for date data type in dictionary_exclude") {
+    try {
+      sql(
+        "create table if not exists Carbon_automation_testdate (imei string,doj Date," +
+        "deviceInformationId int,MAC string,deviceColor string,device_backColor string,modelId " +
+        "string,marketName string,AMSize string,ROMSize string,CUPAudit string,CPIClocked string," +
+        "series string,productionDate timestamp,bomCode string,internalModels string, " +
+        "deliveryTime string, channelsId string, channelsName string , deliveryAreaId string, " +
+        "deliveryCountry string, deliveryProvince string, deliveryCity string,deliveryDistrict " +
+        "string, deliveryStreet string, oxSingleNumber string, ActiveCheckTime string, " +
+        "ActiveAreaId string, ActiveCountry string, ActiveProvince string, Activecity string, " +
+        "ActiveDistrict string, ActiveStreet string, ActiveOperatorId string, Active_releaseId " +
+        "string, Active_EMUIVersion string, Active_operaSysVersion string, Active_BacVerNumber " +
+        "string, Active_BacFlashVer string, Active_webUIVersion string, Active_webUITypeCarrVer " +
+        "string,Active_webTypeDataVerNumber string, Active_operatorsVersion string, " +
+        "Active_phonePADPartitionedVersions string, Latest_YEAR int, Latest_MONTH int, Latest_DAY" +
+        " int, Latest_HOUR string, Latest_areaId string, Latest_country string, Latest_province " +
+        "string, Latest_city string, Latest_district string, Latest_street string, " +
+        "Latest_releaseId string, Latest_EMUIVersion string, Latest_operaSysVersion string, " +
+        "Latest_BacVerNumber string, Latest_BacFlashVer string, Latest_webUIVersion string, " +
+        "Latest_webUITypeCarrVer string, Latest_webTypeDataVerNumber string, " +
+        "Latest_operatorsVersion string, Latest_phonePADPartitionedVersions string, " +
+        "Latest_operatorId string, gamePointDescription string, gamePointId int,contractNumber " +
+        "int) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES('DICTIONARY_EXCLUDE'='doj')")
+
+      assert(false)
+    }
+    catch {
+      case exception: MalformedCarbonCommandException => assert(true)
+    }
+  }
+  test("must throw exception for timestamp data type in dictionary_exclude") {
+    try {
+      sql(
+        "create table if not exists Carbon_automation_testtimestamp (imei string,doj timestamp," +
+        "deviceInformationId int,MAC string,deviceColor string,device_backColor string,modelId " +
+        "string,marketName string,AMSize string,ROMSize string,CUPAudit string,CPIClocked string," +
+        "series string,productionDate timestamp,bomCode string,internalModels string, " +
+        "deliveryTime string, channelsId string, channelsName string , deliveryAreaId string, " +
+        "deliveryCountry string, deliveryProvince string, deliveryCity string,deliveryDistrict " +
+        "string, deliveryStreet string, oxSingleNumber string, ActiveCheckTime string, " +
+        "ActiveAreaId string, ActiveCountry string, ActiveProvince string, Activecity string, " +
+        "ActiveDistrict string, ActiveStreet string, ActiveOperatorId string, Active_releaseId " +
+        "string, Active_EMUIVersion string, Active_operaSysVersion string, Active_BacVerNumber " +
+        "string, Active_BacFlashVer string, Active_webUIVersion string, Active_webUITypeCarrVer " +
+        "string,Active_webTypeDataVerNumber string, Active_operatorsVersion string, " +
+        "Active_phonePADPartitionedVersions string, Latest_YEAR int, Latest_MONTH int, Latest_DAY" +
+        " int, Latest_HOUR string, Latest_areaId string, Latest_country string, Latest_province " +
+        "string, Latest_city string, Latest_district string, Latest_street string, " +
+        "Latest_releaseId string, Latest_EMUIVersion string, Latest_operaSysVersion string, " +
+        "Latest_BacVerNumber string, Latest_BacFlashVer string, Latest_webUIVersion string, " +
+        "Latest_webUITypeCarrVer string, Latest_webTypeDataVerNumber string, " +
+        "Latest_operatorsVersion string, Latest_phonePADPartitionedVersions string, " +
+        "Latest_operatorId string, gamePointDescription string, gamePointId int,contractNumber " +
+        "int) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES('DICTIONARY_EXCLUDE'='doj')")
+
+      assert(false)
+    }
+    catch {
+      case exception: MalformedCarbonCommandException => assert(true)
+    }
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -591,7 +591,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    * detects whether double or decimal column is part of dictionary_exclude
    */
   def isStringAndTimestampColDictionaryExclude(columnDataType: String): Boolean = {
-    val dataTypes = Array("string", "timestamp", "date")
+    val dataTypes = Array("string")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -591,7 +591,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    * detects whether double or decimal column is part of dictionary_exclude
    */
   def isStringAndTimestampColDictionaryExclude(columnDataType: String): Boolean = {
-    val dataTypes = Array("string", "timestamp","date")
+    val dataTypes = Array("string", "timestamp", "date")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -503,7 +503,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
               val errormsg = "DICTIONARY_EXCLUDE is unsupported for complex datatype column: " +
                              dictExcludeCol
               throw new MalformedCarbonCommandException(errormsg)
-            } else if (!isStringAndTimestampColDictionaryExclude(dataType)) {
+            } else if (!isDataTypeSupportedForDictionary_Exclude(dataType)) {
               val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
                              " data type column: " + dictExcludeCol
               throw new MalformedCarbonCommandException(errorMsg)
@@ -588,9 +588,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   }
 
   /**
-   * detects whether double or decimal column is part of dictionary_exclude
+   * detects whether datatype is part of dictionary_exclude
    */
-  def isStringAndTimestampColDictionaryExclude(columnDataType: String): Boolean = {
+  def isDataTypeSupportedForDictionary_Exclude(columnDataType: String): Boolean = {
     val dataTypes = Array("string")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -591,7 +591,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    * detects whether double or decimal column is part of dictionary_exclude
    */
   def isStringAndTimestampColDictionaryExclude(columnDataType: String): Boolean = {
-    val dataTypes = Array("string", "timestamp")
+    val dataTypes = Array("string", "timestamp","date")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -26,7 +26,6 @@ import org.apache.hadoop.hive.ql.parse._
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.CarbonTableIdentifierImplicit._
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.ExplainCommand
 import org.apache.spark.sql.execution.command._
@@ -285,7 +284,6 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
           CreateTable(tableModel)
         } catch {
           case ce: MalformedCarbonCommandException =>
-
             val message = if (tableName.isEmpty) {
               "Create table command failed. "
             }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -260,7 +260,6 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
             Token("TOK_TABCOLNAME", list) :: numberOfBuckets) =>
               val cols = list.map(_.getText)
               if (cols != null) {
-                throw new MalformedCarbonCommandException("Bucketing Is not Supported in spark 1.6 yet")
                 bucketFields = Some(BucketFields(cols,
                   numberOfBuckets.head.getText.toInt))
               }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.ql.parse._
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.CarbonTableIdentifierImplicit._
 import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.ExplainCommand
 import org.apache.spark.sql.execution.command._
@@ -259,6 +260,7 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
             Token("TOK_TABCOLNAME", list) :: numberOfBuckets) =>
               val cols = list.map(_.getText)
               if (cols != null) {
+                throw new MalformedCarbonCommandException("Bucketing Is not Supported in spark 1.6 yet")
                 bucketFields = Some(BucketFields(cols,
                   numberOfBuckets.head.getText.toInt))
               }
@@ -284,6 +286,7 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
           CreateTable(tableModel)
         } catch {
           case ce: MalformedCarbonCommandException =>
+
             val message = if (tableName.isEmpty) {
               "Create table command failed. "
             }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/TableCreator.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/TableCreator.scala
@@ -37,9 +37,9 @@ object TableCreator {
     dimensionType.exists(x => x.equalsIgnoreCase(dimensionDataType))
   }
 
-  // detects whether double or decimal column is part of dictionary_exclude
-  def isStringAndTimestampColDictionaryExclude(columnDataType: String): Boolean = {
-    val dataTypes = Array("string", "timestamp", "date", "stringtype", "timestamptype", "datetype")
+  // detects whether datatype is part of dictionary_exclude
+  def isDataTypeSupportedForDictionary_Exclude(columnDataType: String): Boolean = {
+    val dataTypes = Array("string")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 
@@ -76,7 +76,7 @@ object TableCreator {
               val errormsg = "DICTIONARY_EXCLUDE is unsupported for complex datatype column: " +
                 dictExcludeCol
               throw new MalformedCarbonCommandException(errormsg)
-            } else if (!isStringAndTimestampColDictionaryExclude(dataType)) {
+            } else if (!isDataTypeSupportedForDictionary_Exclude(dataType)) {
               val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
                 " data type column: " + dictExcludeCol
               throw new MalformedCarbonCommandException(errorMsg)


### PR DESCRIPTION
DICTIONARY_EXCLUDE is not working with 'DATE' column

I am trying to create a table with "DICTIONARY_EXCLUDE" and this property is not working for "DATE" Data Type.
Query : CREATE TABLE uniqdata_date_dictionary (CUST_ID int,CUST_NAME string,ACTIVE_EMUI_VERSION string, DOB date, DOJ date, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES ("TABLE_BLOCKSIZE"= "256 MB","DICTIONARY_EXCLUDE"="DOB,DOJ");
Expected Result : Table created.
Actual Result : Error: org.apache.carbondata.spark.exception.MalformedCarbonCommandException: DICTIONARY_EXCLUDE is unsupported for date data type column: dob (state=,code=0)

