### PR TITLE
[CARBONDATA-619] give error if compaction type is not minor or major

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1125,6 +1125,10 @@ public final class CarbonCommonConstants {
    */
   public static final String USE_PREFETCH_WHILE_LOADING_DEFAULT = "false";
 
+  public static final String MINOR = "minor";
+
+  public static final String MAJOR = "major";
+
   private CarbonCommonConstants() {
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/Compaction.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/Compaction.scala
@@ -19,6 +19,9 @@ package org.apache.spark.util
 import org.apache.spark.sql.{CarbonEnv, SparkSession}
 import org.apache.spark.sql.execution.command.{AlterTableCompaction, AlterTableModel}
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.spark.merger.CompactionType
+
 /**
  * table compaction api
  */
@@ -28,12 +31,19 @@ object Compaction {
   def compaction(spark: SparkSession, dbName: String, tableName: String,
       compactionType: String): Unit = {
     TableAPIUtil.validateTableExists(spark, dbName, tableName)
-    AlterTableCompaction(AlterTableModel(Some(dbName),
-      tableName,
-      None,
-      compactionType,
-      Some(System.currentTimeMillis()),
-      "")).run(spark)
+    if (compactionType.equalsIgnoreCase(CarbonCommonConstants.MAJOR) ||
+        compactionType.equalsIgnoreCase(CarbonCommonConstants.MINOR)) {
+      AlterTableCompaction(AlterTableModel(Some(dbName),
+        tableName,
+        None,
+        compactionType,
+        Some(System.currentTimeMillis()),
+        "")).run(spark)
+    }
+    else {
+      sys.error("Compaction type is wrong. Please select minor or major.")
+    }
+
   }
 
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
Scenario : in spark 2.1 API support for compaction is provided. 
in this API if the compaction type is anything other than the valid values(minor/major)  still the compaction is success taking the minor as type.


Solution : if the user enters wrong value then the error message should be shown to the user. 
