### PR TITLE
[CARBONDATA-656]Simplify the carbon session creation.

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
@@ -42,7 +42,7 @@ object CarbonSessionExample {
     val spark = SparkSession
       .builder()
       .master("local")
-      .appName("CarbonExample")
+      .appName("CarbonSessionExample")
       .config("spark.sql.warehouse.dir", warehouse)
       .getOrCreateCarbonSession(storeLocation, metastoredb)
 

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
@@ -19,7 +19,6 @@ package org.apache.carbondata.examples
 
 import java.io.File
 
-import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -32,19 +31,10 @@ object CarbonSessionExample {
                             + "../../../..").getCanonicalPath
     val storeLocation = s"$rootPath/examples/spark2/target/store"
     val warehouse = s"$rootPath/examples/spark2/target/warehouse"
-    val metastoredb = s"$rootPath/examples/spark2/target/metastore_db"
-
-    // clean data folder
-    if (true) {
-      val clean = (path: String) => FileUtils.deleteDirectory(new File(path))
-      clean(storeLocation)
-      clean(warehouse)
-      clean(metastoredb)
-    }
+    val metastoredb = s"$rootPath/examples/spark2/target"
 
     CarbonProperties.getInstance()
       .addProperty("carbon.kettle.home", s"$rootPath/processing/carbonplugins")
-      .addProperty("carbon.storelocation", storeLocation)
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
 
     import org.apache.spark.sql.CarbonSession._
@@ -53,11 +43,8 @@ object CarbonSessionExample {
       .builder()
       .master("local")
       .appName("CarbonExample")
-      .enableHiveSupport()
       .config("spark.sql.warehouse.dir", warehouse)
-      .config("javax.jdo.option.ConnectionURL",
-    s"jdbc:derby:;databaseName=$metastoredb;create=true")
-      .getOrCreateCarbonSession()
+      .getOrCreateCarbonSession(storeLocation, metastoredb)
 
     spark.sparkContext.setLogLevel("WARN")
 

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/SparkSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/SparkSessionExample.scala
@@ -46,7 +46,7 @@ object SparkSessionExample {
     val spark = SparkSession
         .builder()
         .master("local")
-        .appName("CarbonExample")
+        .appName("SparkSessionExample")
         .enableHiveSupport()
         .config("spark.sql.warehouse.dir", warehouse)
         .config("javax.jdo.option.ConnectionURL",

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
@@ -45,7 +45,7 @@ object TestQueryExecutor {
   val resourcesPath = s"$integrationPath/spark-common-test/src/test/resources"
   val storeLocation = s"$integrationPath/spark-common/target/store"
   val warehouse = s"$integrationPath/spark-common/target/warehouse"
-  val metastoredb = s"$integrationPath/spark-common/target/metastore_db"
+  val metastoredb = s"$integrationPath/spark-common/target"
   val kettleHome = s"$projectPath/processing/carbonplugins"
   val timestampFormat = "dd-MM-yyyy"
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -49,7 +49,7 @@ object Spark2TestQueryExecutor {
   val spark = SparkSession
     .builder()
     .master("local[2]")
-    .appName("CarbonExample")
+    .appName("Spark2TestQueryExecutor")
     .enableHiveSupport()
     .config("spark.sql.warehouse.dir", TestQueryExecutor.warehouse)
     .getOrCreateCarbonSession(TestQueryExecutor.storeLocation, TestQueryExecutor.metastoredb)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -38,7 +38,6 @@ object Spark2TestQueryExecutor {
   private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
   LOGGER.info("use TestQueryExecutorImplV2")
   CarbonProperties.getInstance()
-    .addProperty(CarbonCommonConstants.STORE_LOCATION, TestQueryExecutor.storeLocation)
     .addProperty("carbon.kettle.home", TestQueryExecutor.kettleHome)
     .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
     .addProperty(CarbonCommonConstants.STORE_LOCATION_TEMP_PATH,
@@ -53,9 +52,7 @@ object Spark2TestQueryExecutor {
     .appName("CarbonExample")
     .enableHiveSupport()
     .config("spark.sql.warehouse.dir", TestQueryExecutor.warehouse)
-    .config("javax.jdo.option.ConnectionURL",
-      s"jdbc:derby:;databaseName=${TestQueryExecutor.metastoredb};create=true")
-    .getOrCreateCarbonSession()
+    .getOrCreateCarbonSession(TestQueryExecutor.storeLocation, TestQueryExecutor.metastoredb)
   spark.sparkContext.setLogLevel("ERROR")
 
 }


### PR DESCRIPTION
Following is the way of creating carbon session in java code and spark-shell

1. Spark Shell
  Start spark shell
  `$./spark-shell --jars <carbon-jar-path>`
 
  Just execute following commands to create carbon session
  ```
   scala>import org.apache.spark.sql.SparkSession
   scala>import org.apache.spark.sql.CarbonSession._
   scala> val carbon = SparkSession.builder().config(sc.getConf).getOrCreateCarbonSession()
  ```
 After executing above commands CarbonSession is created as carbon

2.  With Java Code
Please refer examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala