### PR TITLE
[CARBONDATA-634] Load Query options invalid values are not consistent behavior.

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
@@ -46,6 +46,7 @@ class BadRecordLoggerTest extends QueryTest with BeforeAndAfterAll {
       sql("drop table IF EXISTS emptyColumnValues_false")
       sql("drop table IF EXISTS empty_timestamp")
       sql("drop table IF EXISTS empty_timestamp_false")
+      sql("drop table IF EXISTS dataloadOptionTests")
       sql(
         """CREATE TABLE IF NOT EXISTS sales(ID BigInt, date Timestamp, country String,
           actual_price Double, Quantity int, sold_price Decimal(19,2)) STORED BY 'carbondata'""")
@@ -237,6 +238,22 @@ class BadRecordLoggerTest extends QueryTest with BeforeAndAfterAll {
     )
   }
 
+  test("test load ddl command") {
+    sql(
+      """CREATE TABLE IF NOT EXISTS dataloadOptionTests(ID BigInt, date Timestamp, country
+           String,
+          actual_price Double, Quantity int, sold_price Decimal(19,2)) STORED BY 'carbondata'
+      """)
+    val csvFilePath = s"$resourcesPath/badrecords/emptyTimeStampValue.csv"
+    try {
+      sql("LOAD DATA local inpath '" + csvFilePath + "' INTO TABLE dataloadOptionTests OPTIONS"
+          + "('bad_records_action'='FORCA', 'DELIMITER'= ',', 'QUOTECHAR'= '\"')");
+    } catch {
+      case ex: Exception =>
+        assert("option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT"
+          .equals(ex.getMessage))
+    }
+  }
 
   override def afterAll {
     sql("drop table sales")
@@ -248,6 +265,7 @@ class BadRecordLoggerTest extends QueryTest with BeforeAndAfterAll {
     sql("drop table emptyColumnValues_false")
     sql("drop table empty_timestamp")
     sql("drop table empty_timestamp_false")
+    sql("drop table dataloadOptionTests")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
   }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -34,6 +34,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.datatype.DataType
 import org.apache.carbondata.core.util.DataTypeUtil
+import org.apache.carbondata.processing.constants.LoggerAction
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 import org.apache.carbondata.spark.util.CommonUtil
 
@@ -779,6 +780,18 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         case ex: NumberFormatException =>
           throw new MalformedCarbonCommandException(
             "option MAXCOLUMNS can only contain integer values")
+      }
+    }
+
+    if (options.exists(_._1.equalsIgnoreCase("BAD_RECORDS_ACTION"))) {
+      val optionValue: String = options.get("bad_records_action").get.head._2
+      try {
+        LoggerAction.valueOf(optionValue.toUpperCase)
+      }
+      catch {
+        case e: IllegalArgumentException =>
+          throw new MalformedCarbonCommandException(
+            "option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT")
       }
     }
 


### PR DESCRIPTION
By default if no value is set by default BAD_RECORDS_ACTION will be initialized with FORCE.
But if the value for BAD_RECORDS_ACTION is set then the the value should be validated.
