### PR TITLE
[CARBONDATA-685]added vaidation for table name with spaces IN tableName option using carbon source

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -112,6 +112,9 @@ class CarbonSource extends CreatableRelationProvider
     if (StringUtils.isBlank(tableName)) {
       throw new MalformedCarbonCommandException("The Specified Table Name is Blank")
     }
+    if (tableName.contains(" ")) {
+      throw new MalformedCarbonCommandException("Table Name Should not have spaces ")
+    }
     val options = new CarbonOption(parameters)
     try {
       CarbonEnv.get.carbonMetastore.lookupRelation(Option(dbName), tableName)(sparkSession)


### PR DESCRIPTION
when using carbon source i am able to create table with spaces
logs====
0: jdbc:hive2://localhost:10000> CREATE TABLE table (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary Int) USING org.apache.spark.sql.CarbonSource OPTIONS("tableName"="t a b l e ");
---------+
Result
---------+
---------+
No rows select
here table with empty spaces is created in hdfs
it should not allow this
 
with this pr this check will be validated 
