### PR TITLE
[CARBONDATA-690]Fix load fail with unsafe enabled and with bigdecimal datatypes

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/bigdecimal/TestDimensionWithDecimalDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/bigdecimal/TestDimensionWithDecimalDataType.scala
@@ -39,10 +39,16 @@ class TestDimensionWithDecimalDataType extends QueryTest with BeforeAndAfterAll 
     sql(s"LOAD DATA local inpath '$resourcesPath/decimalDataWithoutHeader.csv' INTO table hiveTable")
   }
 
-//  test("test detail query on dimension column with decimal data type") {
-//    checkAnswer(sql("select salary from carbonTable order by salary"),
-//      sql("select salary from hiveTable order by salary"))
-//  }
+  test("test unsafe with bigdecimal") {
+    sql("drop table if exists unsafecarbonTable")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, "true")
+    sql("CREATE TABLE IF NOT EXISTS unsafecarbonTable (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary Decimal(19,2))STORED BY 'org.apache.carbondata.format'")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/decimalDataWithHeader.csv' into table unsafecarbonTable")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, "false")
+    sql("drop table if exists unsafecarbonTable")
+  }
 
   test("test aggregate query on dimension column with decimal data type") {
     checkAnswer(sql("select sum(salary) from carbonTable"),

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeCarbonRowPage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeCarbonRowPage.java
@@ -196,9 +196,8 @@ public class UnsafeCarbonRowPage {
           size += 2;
           CarbonUnsafe.unsafe.copyMemory(baseObject, address + size, bigDecimalInBytes,
               CarbonUnsafe.BYTE_ARRAY_OFFSET, bigDecimalInBytes.length);
-          BigDecimal val = DataTypeUtil.byteToBigDecimal(bigDecimalInBytes);
           size += bigDecimalInBytes.length;
-          rowToFill[dimensionSize + mesCount] = val;
+          rowToFill[dimensionSize + mesCount] = bigDecimalInBytes;
         }
       } else {
         rowToFill[dimensionSize + mesCount] = null;

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
@@ -34,7 +34,6 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
-import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.newflow.sort.unsafe.UnsafeCarbonRowPage;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.NewRowComparator;
@@ -331,7 +330,7 @@ public class UnsafeSortTempFileChunkHolder implements SortTempChunkHolder {
             short aShort = stream.readShort();
             byte[] bigDecimalInBytes = new byte[aShort];
             stream.readFully(bigDecimalInBytes);
-            row[dimensionCount + mesCount] = DataTypeUtil.byteToBigDecimal(bigDecimalInBytes);
+            row[dimensionCount + mesCount] = bigDecimalInBytes;
           }
         }
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateFileMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateFileMerger.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.AbstractQueue;
 import java.util.Arrays;
@@ -34,7 +33,6 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonUtil;
-import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.newflow.sort.unsafe.UnsafeCarbonRowPage;
 import org.apache.carbondata.processing.newflow.sort.unsafe.holder.SortTempChunkHolder;
 import org.apache.carbondata.processing.newflow.sort.unsafe.holder.UnsafeSortTempFileChunkHolder;
@@ -320,8 +318,7 @@ public class UnsafeIntermediateFileMerger implements Callable<Void> {
           rowData.putLong(size, val);
           size += 8;
         } else if (aggType[mesCount] == CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
-          BigDecimal val = (BigDecimal) value;
-          byte[] bigDecimalInBytes = DataTypeUtil.bigDecimalToByte(val);
+          byte[] bigDecimalInBytes = (byte[]) value;
           rowData.putShort(size, (short)bigDecimalInBytes.length);
           size += 2;
           for (int i = 0; i < bigDecimalInBytes.length; i++) {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -1540,6 +1540,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
         blockletDataHolder.put(nodeHolder, indexInNodeHolderArray);
         return null;
       } catch (Throwable throwable) {
+        LOGGER.error(throwable, "Error in producer");
         consumerExecutorService.shutdownNow();
         resetBlockletProcessingCount();
         throw new CarbonDataWriterException(throwable.getMessage(), throwable);


### PR DESCRIPTION
Load fails when columns have big decimal datatypes in unsafe mode. This PR fixes it.