### PR TITLE
[CARBONDATA-700]corrected doc for ddl operation using no_inverted_index

### DIFF
--- a/docs/ddl-operation-on-carbondata.md
+++ b/docs/ddl-operation-on-carbondata.md
@@ -99,20 +99,20 @@ TBLPROPERTIES ("COLUMN_GROUPS"="(column1, column3),
 
 ### Example:
 ```
-   CREATE TABLE IF NOT EXISTS productSchema.productSalesTable (
-                                productNumber Int,
-                                productName String,
-                                storeCity String,
-                                storeProvince String,
-                                productCategory String,
-                                productBatch String,
-                                saleQuantity Int,
-                                revenue Int)
-   STORED BY 'carbondata'
-   TBLPROPERTIES ('COLUMN_GROUPS'='(productName,productCategory)',
-                  'DICTIONARY_EXCLUDE'='productName',
-                  'DICTIONARY_INCLUDE'='productNumber',
-                  'NO_INVERTED_INDEX'='productBatch')
+    CREATE TABLE IF NOT EXISTS productSchema.productSalesTable (
+                                   productNumber Int,
+                                   productName String,
+                                   storeCity String,
+                                   storeProvince String,
+                                   productCategory String,
+                                   productBatch String,
+                                   saleQuantity Int,
+                                   revenue Int)
+      STORED BY 'carbondata'
+      TBLPROPERTIES ('COLUMN_GROUPS'='(productNumber,productName)',
+                     'DICTIONARY_EXCLUDE'='storeCity',
+                     'DICTIONARY_INCLUDE'='productNumber',
+                     'NO_INVERTED_INDEX'='productBatch')
 ```
 
 ## SHOW TABLE


### PR DESCRIPTION
example given in carbon docs ddl is wrong

0: jdbc:hive2://localhost:10000> CREATE TABLE IF NOT EXISTS productSchema.productSalesTable ( productNumber Int, productName String, storeCity String, storeProvince String, productCategory String, productBatch String, saleQuantity Int, revenue Int) STORED BY 'carbondata' TBLPROPERTIES ('COLUMN_GROUPS'='(productName,productCategory)', 'DICTIONARY_EXCLUDE'='productName', 'DICTIONARY_INCLUDE'='productNumber', 'NO_INVERTED_INDEX'='productBatch');
Error: org.apache.carbondata.spark.exception.MalformedCarbonCommandException: Column group is not supported for no dictionary columns:productname (state=,code=0)

