### PR TITLE
[CARBONDATA-702] Created carbondata repository and added repository URL to pom file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
       <id>pentaho-releases</id>
       <url>http://repository.pentaho.org/artifactory/repo/</url>
     </repository>
+    <repository>
+      <id>carbondata-releases</id>
+      <url>http://136.243.101.176:9091/repository/carbondata/</url>
+    </repository>
   </repositories>
 
   <dependencyManagement>


### PR DESCRIPTION
New repository http://136.243.101.176:9091/ is created, and url is added to pom file.
At the time of IPMC voting it can fetch from carbondata repository.

Admin can upload the format jar using following command.

First update maven settings.xml file,
```
<server>
      <id>apache1</id>
      <username>carbondata</username>
      <password>******</password>
    </server>
```
And use following command to upload format jar.
```
mvn  deploy:deploy-file -DpomFile=/home/root1/carbon/incubator-carbondata/format/pom.xml -Dfile=/home/root1/carbon/incubator-carbondata/core/target/carbondata-format-1.1.0-incubating.jar -DrepositoryId=apache1 -Durl=http://136.243.101.176:9091/repository/carbondata/
```
