### PR TITLE
[CARBONDATA-705]Make partition distribution as configurable

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -143,14 +143,12 @@ class CarbonScanRDD(
         }
         noOfNodes = nodeBlockMapping.size
       } else {
-        var i = 0
-        splits.asScala.foreach { s =>
+        splits.asScala.zipWithIndex.foreach { splitWithIndex =>
           val multiBlockSplit =
             new CarbonMultiBlockSplit(identifier,
-              Seq(s.asInstanceOf[CarbonInputSplit]).asJava,
-              s.getLocations)
-          val partition = new CarbonSparkPartition(id, i, multiBlockSplit)
-          i += 1
+              Seq(splitWithIndex._1.asInstanceOf[CarbonInputSplit]).asJava,
+              splitWithIndex._1.getLocations)
+          val partition = new CarbonSparkPartition(id, splitWithIndex._2, multiBlockSplit)
           result.add(partition)
         }
       }


### PR DESCRIPTION
Make the partition distribution as configurable and keep spark distribution as default.

User can use `spark.carbon.custom.distribution=true` to use carbon's custom partition distribution.
By default this configuration is false, so it uses sparks distribution.