### PR TITLE
[CARBONDATA-691] After Compaction records count are mismatched.

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputSplitTaskInfo.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputSplitTaskInfo.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.hadoop.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.carbondata.core.datastore.block.Distributable;
+import org.apache.carbondata.hadoop.CarbonInputSplit;
+
+public class CarbonInputSplitTaskInfo implements Distributable {
+
+  private final List<CarbonInputSplit> carbonBlockInfoList;
+
+  private final String taskId;
+
+  public String getTaskId() {
+    return taskId;
+  }
+
+  public List<CarbonInputSplit> getCarbonInputSplitList() {
+    return carbonBlockInfoList;
+  }
+
+  public CarbonInputSplitTaskInfo(String taskId, List<CarbonInputSplit> carbonSplitListInfo) {
+    this.taskId = taskId;
+    this.carbonBlockInfoList = carbonSplitListInfo;
+  }
+
+  @Override public String[] getLocations() {
+    Set<String> locations = new HashSet<String>();
+    for (CarbonInputSplit splitInfo : carbonBlockInfoList) {
+      try {
+        locations.addAll(Arrays.asList(splitInfo.getLocations()));
+      } catch (IOException e) {
+        throw new RuntimeException("Fail to get location of split: " + splitInfo, e);
+      }
+    }
+    locations.toArray(new String[locations.size()]);
+    List<String> nodes = CarbonInputSplitTaskInfo.maxNoNodes(carbonBlockInfoList);
+    return nodes.toArray(new String[nodes.size()]);
+  }
+
+  @Override public int compareTo(Distributable o) {
+    return taskId.compareTo(((CarbonInputSplitTaskInfo) o).getTaskId());
+  }
+
+  /**
+   * Finding which node has the maximum number of blocks for it.
+   *
+   * @param blockList
+   * @return
+   */
+  public static List<String> maxNoNodes(List<CarbonInputSplit> splitList) {
+    boolean useIndex = true;
+    Integer maxOccurence = 0;
+    String maxNode = null;
+    Map<String, Integer> nodeAndOccurenceMapping = new TreeMap<>();
+
+    // populate the map of node and number of occurences of that node.
+    for (CarbonInputSplit split : splitList) {
+      try {
+        for (String node : split.getLocations()) {
+          Integer nodeOccurence = nodeAndOccurenceMapping.get(node);
+          if (null == nodeOccurence) {
+            nodeAndOccurenceMapping.put(node, 1);
+          } else {
+            nodeOccurence++;
+          }
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Fail to get location of split: " + split, e);
+      }
+    }
+    Integer previousValueOccurence = null;
+
+    // check which node is occured maximum times.
+    for (Map.Entry<String, Integer> entry : nodeAndOccurenceMapping.entrySet()) {
+      // finding the maximum node.
+      if (entry.getValue() > maxOccurence) {
+        maxOccurence = entry.getValue();
+        maxNode = entry.getKey();
+      }
+      // first time scenario. initialzing the previous value.
+      if (null == previousValueOccurence) {
+        previousValueOccurence = entry.getValue();
+      } else {
+        // for the case where all the nodes have same number of blocks then
+        // we need to return complete list instead of max node.
+        if (!Objects.equals(previousValueOccurence, entry.getValue())) {
+          useIndex = false;
+        }
+      }
+    }
+
+    // if all the nodes have equal occurence then returning the complete key set.
+    if (useIndex) {
+      return new ArrayList<>(nodeAndOccurenceMapping.keySet());
+    }
+
+    // if any max node is found then returning the max node.
+    List<String> node = new ArrayList<>(1);
+    node.add(maxNode);
+    return node;
+  }
+
+}

--- a/integration/spark-common-test/src/test/resources/compaction/compactionIUD1.csv
+++ b/integration/spark-common-test/src/test/resources/compaction/compactionIUD1.csv
@@ -1,0 +1,6 @@
+FirstName,LastName,date,phonetype,serialname,ID,salary
+FirstOne,LastOne,07/24/2015, phone197,ASD69643,1,15000
+FirstSecond,LastSecond,07/24/2015,phone756,ASD42892,2,15001
+FirstThird,LastThird,07/25/2015,phone1904,ASD37014,3,15002
+FirstFour,LastFour,07/26/2015,phone2435,ASD66902,4,15003
+FirstFive,LastFive,07/27/2015,phone2441,ASD90633,5,15004

--- a/integration/spark-common-test/src/test/resources/compaction/compactionIUD2.csv
+++ b/integration/spark-common-test/src/test/resources/compaction/compactionIUD2.csv
@@ -1,0 +1,6 @@
+FirstName,LastName,date, phonetype,serialname,ID,salary
+FirstSix,LastSix,07/24/2015, phone197,ASD69643,6, 15000
+FirstSeven, LastSeven, 07/24/2015,phone756,ASD42892,7,15001
+FirstEight, LastEight, 07/25/2015,phone1904,ASD37014,8,15002
+FirstNine, LastNine, 07/26/2015,phone2435,ASD66902,9,15003
+FirstTen, LastTen, 07/27/2015,phone2441,ASD90633,10,15004

--- a/integration/spark-common-test/src/test/resources/compaction/compactionIUD3.csv
+++ b/integration/spark-common-test/src/test/resources/compaction/compactionIUD3.csv
@@ -1,0 +1,6 @@
+FirstName,LastName,date, phonetype,serialname,ID,salary
+FirstEleven,LastEleven,07/24/2015, phone197,ASD69643,11, 15000
+FirstTwelve, LastTwelve, 07/24/2015,phone756,ASD42892,12,15001
+FirstThirteen, LastThirteen, 07/25/2015,phone1904,ASD37014,13,15002
+FirstFourteen, LastFourteen, 07/26/2015,phone2435,ASD66902,14,15003
+FirstFifteen, LastFifteen, 07/27/2015,phone2441,ASD90633,15,15004

--- a/integration/spark-common-test/src/test/resources/compaction/compactionIUD4.csv
+++ b/integration/spark-common-test/src/test/resources/compaction/compactionIUD4.csv
@@ -1,0 +1,6 @@
+FirstName,LastName,date, phonetype,serialname,ID,salary
+FirstSixteen,LastSixteen,07/24/2015, phone197,ASD69643,16, 15000
+FirstSeventeen, LastSeventeen, 07/24/2015,phone756,ASD42892,17,15001
+FirstEighteen, LastEighteen, 07/25/2015,phone1904,ASD37014,18,15002
+FirstNineteen, LastNineteen, 07/26/2015,phone2435,ASD66902,19,15003
+FirstTwenty, LastTwenty, 07/27/2015,phone2441,ASD90633,20,15004

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionBlockletBoundryTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionBlockletBoundryTest.scala
@@ -34,7 +34,7 @@ class DataCompactionBlockletBoundryTest extends QueryTest with BeforeAndAfterAll
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "mm/dd/yyyy")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.BLOCKLET_SIZE,
-        "120")
+        "125")
     sql(
       "CREATE TABLE IF NOT EXISTS blocklettest (country String, ID String, date Timestamp, name " +
         "String, " +

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionCardinalityBoundryTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionCardinalityBoundryTest.scala
@@ -112,6 +112,7 @@ class DataCompactionCardinalityBoundryTest extends QueryTest with BeforeAndAfter
     )
   }
 
+
   override def afterAll {
     sql("drop table if exists  cardinalityTest")
     CarbonProperties.getInstance()

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonIUDMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonIUDMergerRDD.scala
@@ -81,13 +81,12 @@ class CarbonIUDMergerRDD[K, V](
     // group blocks by segment.
     val splitsGroupedMySegment = carbonInputSplits.groupBy(_.getSegmentId)
 
-    var i = 0
+    var i = -1
 
     // No need to get a new SegmentUpdateStatus Manager as the Object is passed
     // in CarbonLoadModel.
     // val manager = new SegmentUpdateStatusManager(absoluteTableIdentifier)
     val updateStatusManager = carbonLoadModel.getSegmentUpdateStatusManager
-
 
     // make one spark partition for one segment
     val resultSplits = splitsGroupedMySegment.map(entry => {
@@ -100,6 +99,7 @@ class CarbonIUDMergerRDD[K, V](
 
       if (!validSplits.isEmpty) {
         val locations = validSplits(0).getLocations
+        i += 1
         new CarbonSparkPartition(id, i,
           new CarbonMultiBlockSplit(absoluteTableIdentifier, validSplits.asJava, locations))
       }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -77,7 +77,21 @@ object CarbonDataRDDFactory {
     if (alterTableModel.compactionType.equalsIgnoreCase("major")) {
       compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MAJOR_COMPACTION)
       compactionType = CompactionType.MAJOR_COMPACTION
-    } else {
+    } else if (alterTableModel.compactionType
+      .equalsIgnoreCase(CompactionType.IUD_UPDDEL_DELTA_COMPACTION.toString)) {
+      compactionType = CompactionType.IUD_UPDDEL_DELTA_COMPACTION
+      if (alterTableModel.segmentUpdateStatusManager.get != None) {
+        carbonLoadModel
+          .setSegmentUpdateStatusManager((alterTableModel.segmentUpdateStatusManager.get))
+        carbonLoadModel
+          .setSegmentUpdateDetails(alterTableModel.segmentUpdateStatusManager.get
+            .getUpdateStatusDetails.toList.asJava)
+        carbonLoadModel
+          .setLoadMetadataDetails(alterTableModel.segmentUpdateStatusManager.get
+            .getLoadMetadataDetails.toList.asJava)
+      }
+    }
+    else {
       compactionType = CompactionType.MINOR_COMPACTION
     }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/IUDCompactionTestCases.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/IUDCompactionTestCases.scala
@@ -127,7 +127,7 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     )
     sql("""drop table dest2""").show()
   }
-/*
+
 
   test("test IUD Horizontal Compaction Delete") {
     sql("""drop database if exists iud4 cascade""").show()
@@ -136,15 +136,15 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""load data local inpath './src/test/resources/IUD/comp1.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp2.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp3.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
     sql("""select * from dest2""").show()
     sql(
       """create table source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""LOAD DATA LOCAL INPATH './src/test/resources/IUD/source3.csv' INTO table source2""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""").show()
     sql("""select * from source2""").show()
     sql("""delete from dest2 where (c2 < 3) or (c2 > 10 and c2 < 13) or (c2 > 20 and c2 < 23) or (c2 > 30 and c2 < 33)""").show()
     sql("""select * from dest2 order by 2""").show()
@@ -185,14 +185,14 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""load data local inpath './src/test/resources/IUD/comp1.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp2.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp3.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
     sql(
       """create table source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""LOAD DATA LOCAL INPATH './src/test/resources/IUD/source3.csv' INTO table source2""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and s.c22 < 3 or (s.c22 > 10 and s.c22 < 13) or (s.c22 > 20 and s.c22 < 23) or (s.c22 > 30 and s.c22 < 33))""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c11,s.c66 from source2 s where d.c1 = s.c11 and s.c22 < 3 or (s.c22 > 10 and s.c22 < 13) or (s.c22 > 20 and s.c22 < 23) or (s.c22 > 30 and s.c22 < 33))""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and (s.c22 > 3 and s.c22 < 5) or (s.c22 > 13 and s.c22 < 15) or (s.c22 > 23 and s.c22 < 25) or (s.c22 > 33 and s.c22 < 35))""").show()
@@ -254,14 +254,14 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""load data local inpath './src/test/resources/IUD/comp1.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp2.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp3.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
     sql(
       """create table source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""LOAD DATA LOCAL INPATH './src/test/resources/IUD/source3.csv' INTO table source2""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and s.c22 < 3 or (s.c22 > 10 and s.c22 < 13) or (s.c22 > 20 and s.c22 < 23) or (s.c22 > 30 and s.c22 < 33))""").show()
     sql("""delete from dest2 where (c2 < 2) or (c2 > 10 and c2 < 13) or (c2 > 20 and c2 < 23) or (c2 > 30 and c2 < 33)""").show()
     sql("""delete from dest2 where (c2 > 3 and c2 < 5) or (c2 > 13 and c2 < 15) or (c2 > 23 and c2 < 25) or (c2 > 33 and c2 < 35)""").show()
@@ -301,7 +301,7 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """create table T_Carbn01(Active_status String,Item_type_cd INT,Qty_day_avg INT,Qty_total INT,Sell_price BIGINT,Sell_pricep DOUBLE,Discount_price DOUBLE,Profit DECIMAL(3,2),Item_code String,Item_name String,Outlet_name String,Update_time TIMESTAMP,Create_date String)STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""LOAD DATA LOCAL INPATH './src/test/resources/IUD/T_Hive1.csv' INTO table t_carbn01 options ('BAD_RECORDS_LOGGER_ENABLE' = 'FALSE', 'BAD_RECORDS_ACTION' = 'FORCE','DELIMITER'=',', 'QUOTECHAR'='\', 'FILEHEADER'='Active_status,Item_type_cd,Qty_day_avg,Qty_total,Sell_price,Sell_pricep,Discount_price,Profit,Item_code,Item_name,Outlet_name,Update_time,Create_date')""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/T_Hive1.csv' INTO table t_carbn01 options ('BAD_RECORDS_LOGGER_ENABLE' = 'FALSE', 'BAD_RECORDS_ACTION' = 'FORCE','DELIMITER'=',', 'QUOTECHAR'='\', 'FILEHEADER'='Active_status,Item_type_cd,Qty_day_avg,Qty_total,Sell_price,Sell_pricep,Discount_price,Profit,Item_code,Item_name,Outlet_name,Update_time,Create_date')""").show()
     sql("""update t_carbn01 set (item_code) = ('Orange') where item_type_cd = 14""").show()
     sql("""update t_carbn01 set (item_code) = ('Banana') where item_type_cd = 2""").show()
     sql("""delete from t_carbn01 where item_code in ('RE3423ee','Orange','Banana')""").show()
@@ -325,15 +325,15 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""load data local inpath './src/test/resources/IUD/comp1.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp2.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp3.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
     sql(
       """delete from dest2 where (c2 < 3) or (c2 > 10 and c2 < 13) or (c2 > 20 and c2 < 23) or (c2 > 30 and c2 < 33)""")
 
       .show()
-    sql("""delete from table dest2 where segment.id IN(0)""").show()
+    sql("""DELETE SEGMENT 0 FROM TABLE dest2""").show()
     sql("""clean files for table dest2""").show()
     sql(
       """update dest2 set (c5) = ('8RAM size') where (c2 > 3 and c2 < 5) or (c2 > 13 and c2 < 15) or (c2 > 23 and c2 < 25) or (c2 > 33 and c2 < 35)""")
@@ -352,10 +352,10 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       .show()
-    sql("""load data local inpath './src/test/resources/IUD/comp1.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp2.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp3.csv' INTO table dest2""").show()
-    sql("""load data local inpath './src/test/resources/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
     sql("""delete from dest2 where c2 < 41""").show()
     sql("""alter table dest2 compact 'major'""").show()
     checkAnswer(
@@ -364,7 +364,7 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     )
     sql("""drop table dest2""").show()
   }
-*/
+
 
   override def afterAll {
     sql("use default")


### PR DESCRIPTION
**Problem** : After Compaction record count mismatches with actual count. 

**Analysis** :The Partitioning method of compaction was wrong. In getPartition method of CarbonScanRDD.scala supposed to make a list all the blocks of all the segments that needs to be merged and then make the partition based on taskNo.  Then each partitioned list is given to each executor. But currently after partitioning the complete list of blocks are being send to each executor for merging. As each executors merging all the blocks of all the segments, multiple executors doubles the data. 

**Fix** : Fix the getPartition method logic to process proper list of blocks to executors.
             Fix Horizontal Partitioning which merged with IUD.  