### PR TITLE
[CARBONDATA-712]resolve the bug for bad records not written in csv file when 'BAD_RECORDS_ACTION'='REDIRECT'

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
@@ -85,7 +85,6 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
         }
         return childIter.hasNext();
       }
-
       @Override public CarbonRowBatch next() {
         return processRowBatch(childIter.next(), localConverter);
       }
@@ -163,6 +162,7 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
   @Override
   public void close() {
     if (!closed) {
+      createBadRecordLogger().closeStreams();
       super.close();
       if (converters != null) {
         for (RowConverter converter : converters) {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorWithBucketingStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorWithBucketingStepImpl.java
@@ -190,6 +190,7 @@ public class DataConverterProcessorWithBucketingStepImpl extends AbstractDataLoa
   public void close() {
     if (!closed) {
       super.close();
+      createBadRecordLogger().closeStreams();
       if (converters != null) {
         for (RowConverter converter : converters) {
           converter.finish();

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
@@ -179,6 +179,7 @@ public class BadRecordsLogger {
 
       }
       bufferedWriter.write(logStrings.toString());
+      bufferedWriter.flush();
       bufferedWriter.newLine();
     } catch (FileNotFoundException e) {
       LOGGER.error("Bad Log Files not found");
@@ -221,6 +222,7 @@ public class BadRecordsLogger {
 
       }
       bufferedCSVWriter.write(logStrings.toString());
+      bufferedCSVWriter.flush();
       bufferedCSVWriter.newLine();
     } catch (FileNotFoundException e) {
       LOGGER.error("Bad record csv Files not found");

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
@@ -179,7 +179,6 @@ public class BadRecordsLogger {
 
       }
       bufferedWriter.write(logStrings.toString());
-      bufferedWriter.flush();
       bufferedWriter.newLine();
     } catch (FileNotFoundException e) {
       LOGGER.error("Bad Log Files not found");
@@ -222,7 +221,6 @@ public class BadRecordsLogger {
 
       }
       bufferedCSVWriter.write(logStrings.toString());
-      bufferedCSVWriter.flush();
       bufferedCSVWriter.newLine();
     } catch (FileNotFoundException e) {
       LOGGER.error("Bad record csv Files not found");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CARBONDATA-712

The bad_records are also not loading in the BAD_RECORS_LOCATION when using 'BAD_RECORDS_ACTION'='REDIRECT' at load time
both inprogress file and log file is empty

Because nothing in the I/O path guarantees that your data has reached disk,When you write data to a stream, it is not written immediately, and it is buffered. So we should use flush() when need to be sure that all your data from buffer is writte

so when we are using  bufferedCSVWriter.write(logStrings.toString()),it must be followed by
 bufferedCSVWriter.flush();
