### PR TITLE
[CARBONDATA-716] fix invalid hdfs lock path if config viewfs

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -135,6 +135,10 @@ public final class CarbonCommonConstants {
    */
   public static final String HDFSURL_PREFIX = "hdfs://";
   /**
+   * VIEWFSURL_PREFIX
+   */
+  public static final String VIEWFSURL_PREFIX = "viewfs://";
+  /**
    * FS_DEFAULT_FS
    */
   public static final String FS_DEFAULT_FS = "fs.defaultFS";

--- a/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
@@ -54,7 +54,8 @@ public class HdfsFileLock extends AbstractCarbonLock {
     // If can not get the STORE_LOCATION, then use hadoop.tmp.dir .
     tmpPath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION,
                System.getProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION));
-    if (!tmpPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX)) {
+    if (!tmpPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX)
+          && !tmpPath.startsWith(CarbonCommonConstants.VIEWFSURL_PREFIX)) {
       tmpPath = hdfsPath + tmpPath;
     }
   }


### PR DESCRIPTION
It generates an invalid table metadata lock path when load data if run CarbonData on viewfs/federation. just since HdfsFileLock just check `hdfs://` URI but not `viewfs://`