### PR TITLE
Fix compile issue for spark1.5 integration

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
@@ -25,9 +25,8 @@ import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.scan.filter.GenericQueryType;
 import org.apache.carbondata.core.scan.processor.BlocksChunkHolder;
 
-import org.apache.spark.sql.catalyst.util.GenericArrayData;
-import org.apache.spark.sql.types.ArrayType;
-import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.catalyst.util.*;
+import org.apache.spark.sql.types.*;
 
 public class ArrayQueryType extends ComplexQueryType implements GenericQueryType {
 


### PR DESCRIPTION
-Pspark-1.5 is compilation failed in carbon-core module because of the merging of V3 format, this PR fix it