### PR TITLE
[CARBONDATA-734] Support the syntax of 'STORED BY PARQUET/ORC' in CarbonSession

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -63,7 +63,14 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
 
   override def visitCreateTable(ctx: CreateTableContext): LogicalPlan = {
     val fileStorage = Option(ctx.createFileFormat) match {
-      case Some(value) => value.storageHandler().STRING().getSymbol.getText
+      case Some(value) => {
+        if (value.children.get(1).getText.equalsIgnoreCase("by")) {
+          value.storageHandler().STRING().getSymbol.getText
+        } else {
+          // The case of "STORED AS PARQUET/ORC"
+          ""
+        }
+      }
       case _ => ""
     }
     if (fileStorage.equalsIgnoreCase("'carbondata'") ||

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -63,14 +63,13 @@ class CarbonSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
 
   override def visitCreateTable(ctx: CreateTableContext): LogicalPlan = {
     val fileStorage = Option(ctx.createFileFormat) match {
-      case Some(value) => {
+      case Some(value) =>
         if (value.children.get(1).getText.equalsIgnoreCase("by")) {
           value.storageHandler().STRING().getSymbol.getText
         } else {
           // The case of "STORED AS PARQUET/ORC"
           ""
         }
-      }
       case _ => ""
     }
     if (fileStorage.equalsIgnoreCase("'carbondata'") ||

--- a/integration/spark2/src/test/scala/org/apache/spark/SparkCommandSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/SparkCommandSuite.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class SparkCommandSuite extends QueryTest with BeforeAndAfterAll {
+  override def beforeAll(): Unit = {
+    sql("DROP TABLE IF EXISTS src_pqt")
+    sql("DROP TABLE IF EXISTS src_orc")
+  }
+
+  override def afterAll(): Unit = {
+    sql("DROP TABLE IF EXISTS src_pqt")
+    sql("DROP TABLE IF EXISTS src_orc")
+  }
+
+  test("CARBONDATA-734: Support the syntax of 'STORED BY PARQUET/ORC'") {
+    sql("CREATE TABLE src_pqt(key INT, value STRING) STORED AS PARQUET")
+    sql("CREATE TABLE src_orc(key INT, value STRING) STORED AS ORC")
+  }
+}


### PR DESCRIPTION
When I create parquet table with the command below:
```shell
import org.apache.spark.sql.SparkSession 
import org.apache.spark.sql.CarbonSession._
val carbon = SparkSession.builder().config(sc.getConf).getOrCreateCarbonSession("hdfs://100.0.0.4:9000/user/hive/warehouse/carbon.store")
carbon.sql("create table src(key int, value string) stored as parquet")
```

It will failed with the error info below:
```shell
java.lang.RuntimeException: [1.1] failure: identifier matching regex (?i)ALTER expected

create table src(key int, value string) stored as parquet
^
  at scala.sys.package$.error(package.scala:27)
  at org.apache.spark.sql.parser.CarbonSpark2SqlParser.parse(CarbonSpark2SqlParser.scala:45)
  at org.apache.spark.sql.parser.CarbonSparkSqlParser.parsePlan(CarbonSparkSqlParser.scala:51)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:592)
  ... 50 elided
```

The reason is if we use `STORED AS`, the value of `value.storageHandler()` will be null(because it is a fileFormat, not storageHandler), so if we still invoke `STRING()`, it will throw NPE.

cc @jackylk 