### PR TITLE
[CARBONDATA-742] Added batch sort to improve the loading performance

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1172,6 +1172,19 @@ public final class CarbonCommonConstants {
 
   public static final String CARBON_BAD_RECORDS_ACTION_DEFAULT = "FORCE";
 
+  /**
+   * Sorts the data in batches and writes the batch data to store with index file.
+   */
+  public static final String LOAD_USE_BATCH_SORT = "carbon.load.use.batch.sort";
+
+  public static final String LOAD_USE_BATCH_SORT_DEFAULT = "true";
+
+  /**
+   * Size of batch data to keep in memory, as a thumb rule it supposed
+   * to be less than 45% of sort.inmemory.size.inmb otherwise it may spill intermediate data to disk
+   */
+  public static final String LOAD_BATCH_SORT_SIZE_INMB = "carbon.load.batch.sort.size.inmb";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1095,6 +1095,25 @@ public final class CarbonCommonConstants {
 
   public static final String IN_MEMORY_FOR_SORT_DATA_IN_MB_DEFAULT = "1024";
 
+  /**
+   * Sorts the data in batches and writes the batch data to store with index file.
+   */
+  public static final String LOAD_USE_BATCH_SORT = "carbon.load.use.batch.sort";
+
+  /**
+   * If set to true, the sorting scope is smaller and more index tree will be created,
+   * thus loading is faster but query maybe slower.
+   * If set to false, the sorting scope is bigger and one index tree per data node will be created,
+   * thus loading is slower but query is faster.
+   */
+  public static final String LOAD_USE_BATCH_SORT_DEFAULT = "false";
+
+  /**
+   * Size of batch data to keep in memory, as a thumb rule it supposed
+   * to be less than 45% of sort.inmemory.size.inmb otherwise it may spill intermediate data to disk
+   */
+  public static final String LOAD_BATCH_SORT_SIZE_INMB = "carbon.load.batch.sort.size.inmb";
+
   public static final String ENABLE_VECTOR_READER = "carbon.enable.vector.reader";
 
   public static final String ENABLE_VECTOR_READER_DEFAULT = "false";
@@ -1171,19 +1190,6 @@ public final class CarbonCommonConstants {
   public static final String CARBON_BAD_RECORDS_ACTION = "carbon.bad.records.action";
 
   public static final String CARBON_BAD_RECORDS_ACTION_DEFAULT = "FORCE";
-
-  /**
-   * Sorts the data in batches and writes the batch data to store with index file.
-   */
-  public static final String LOAD_USE_BATCH_SORT = "carbon.load.use.batch.sort";
-
-  public static final String LOAD_USE_BATCH_SORT_DEFAULT = "true";
-
-  /**
-   * Size of batch data to keep in memory, as a thumb rule it supposed
-   * to be less than 45% of sort.inmemory.size.inmb otherwise it may spill intermediate data to disk
-   */
-  public static final String LOAD_BATCH_SORT_SIZE_INMB = "carbon.load.batch.sort.size.inmb";
 
   private CarbonCommonConstants() {
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
+import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.core.util.path.CarbonTablePath.DataFileUtil;
 
@@ -212,10 +213,10 @@ public class TableBlockInfo implements Distributable, Serializable {
     // offset of
     // the file
     if (CarbonTablePath.isCarbonDataFile(filePath)) {
-      int firstTaskId = Integer.parseInt(DataFileUtil.getTaskNo(filePath));
-      int otherTaskId = Integer.parseInt(DataFileUtil.getTaskNo(((TableBlockInfo) other).filePath));
-      if (firstTaskId != otherTaskId) {
-        return firstTaskId - otherTaskId;
+      int compare = ByteUtil.compare(DataFileUtil.getTaskNo(filePath).getBytes(),
+          DataFileUtil.getTaskNo(((TableBlockInfo) other).filePath).getBytes());
+      if (compare != 0) {
+        return compare;
       }
       // compare the part no of both block info
       int firstPartNo = Integer.parseInt(DataFileUtil.getPartNo(filePath));

--- a/core/src/main/java/org/apache/carbondata/core/memory/CarbonUnsafe.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/CarbonUnsafe.java
@@ -18,6 +18,7 @@
 package org.apache.carbondata.core.memory;
 
 import java.lang.reflect.Field;
+import java.nio.ByteOrder;
 
 import sun.misc.Unsafe;
 
@@ -33,6 +34,9 @@ public final class CarbonUnsafe {
   public static final int LONG_ARRAY_OFFSET;
 
   public static final int DOUBLE_ARRAY_OFFSET;
+
+  public static final boolean LITTLEENDIAN =
+      ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
 
   public static Unsafe unsafe;
 

--- a/core/src/main/java/org/apache/carbondata/core/memory/CarbonUnsafe.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/CarbonUnsafe.java
@@ -35,7 +35,7 @@ public final class CarbonUnsafe {
 
   public static final int DOUBLE_ARRAY_OFFSET;
 
-  public static final boolean LITTLEENDIAN =
+  public static final boolean ISLITTLEENDIAN =
       ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
 
   public static Unsafe unsafe;

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -407,7 +407,8 @@ public class CarbonUpdateUtil {
     int max = 0;
     if (null != dataFiles) {
       for (CarbonFile file : dataFiles) {
-        int taskNumber = Integer.parseInt(CarbonTablePath.DataFileUtil.getTaskNo(file.getName()));
+        int taskNumber =
+            Integer.parseInt(CarbonTablePath.DataFileUtil.getTaskNo(file.getName()).split("_")[0]);
         if (taskNumber > max) {
           max = taskNumber;
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -17,13 +17,10 @@
 
 package org.apache.carbondata.core.util;
 
-import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.memory.CarbonUnsafe;
 
 /**
  * Util class for byte comparision
@@ -106,43 +103,6 @@ public final class ByteUtil {
     INSTANCE;
 
     /**
-     * unsafe .
-     */
-    static final sun.misc.Unsafe THEUNSAFE;
-
-    /**
-     * The offset to the first element in a byte array.
-     */
-    static final int BYTE_ARRAY_BASE_OFFSET;
-    static final boolean LITTLEENDIAN = ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
-
-    static {
-      THEUNSAFE = (sun.misc.Unsafe) AccessController.doPrivileged(new PrivilegedAction<Object>() {
-        @Override public Object run() {
-          try {
-            Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-            f.setAccessible(true);
-            return f.get(null);
-          } catch (NoSuchFieldException e) {
-            // It doesn't matter what we throw;
-            // it's swallowed in getBestComparer().
-            throw new Error();
-          } catch (IllegalAccessException e) {
-            throw new Error();
-          }
-        }
-      });
-
-      BYTE_ARRAY_BASE_OFFSET = THEUNSAFE.arrayBaseOffset(byte[].class);
-
-      // sanity check - this should never fail
-      if (THEUNSAFE.arrayIndexScale(byte[].class) != 1) {
-        throw new AssertionError();
-      }
-
-    }
-
-    /**
      * Returns true if x1 is less than x2, when both values are treated as
      * unsigned.
      */
@@ -169,8 +129,8 @@ public final class ByteUtil {
       }
       int minLength = Math.min(length1, length2);
       int minWords = minLength / SIZEOF_LONG;
-      int offset1Adj = offset1 + BYTE_ARRAY_BASE_OFFSET;
-      int offset2Adj = offset2 + BYTE_ARRAY_BASE_OFFSET;
+      int offset1Adj = offset1 + CarbonUnsafe.BYTE_ARRAY_OFFSET;
+      int offset2Adj = offset2 + CarbonUnsafe.BYTE_ARRAY_OFFSET;
 
       /*
        * Compare 8 bytes at a time. Benchmarking shows comparing 8 bytes
@@ -178,12 +138,12 @@ public final class ByteUtil {
        * 32-bit. On the other hand, it is substantially faster on 64-bit.
        */
       for (int i = 0; i < minWords * SIZEOF_LONG; i += SIZEOF_LONG) {
-        long lw = THEUNSAFE.getLong(buffer1, offset1Adj + (long) i);
-        long rw = THEUNSAFE.getLong(buffer2, offset2Adj + (long) i);
+        long lw = CarbonUnsafe.unsafe.getLong(buffer1, offset1Adj + (long) i);
+        long rw = CarbonUnsafe.unsafe.getLong(buffer2, offset2Adj + (long) i);
         long diff = lw ^ rw;
 
         if (diff != 0) {
-          if (!LITTLEENDIAN) {
+          if (!CarbonUnsafe.LITTLEENDIAN) {
             return lessThanUnsigned(lw, rw) ? -1 : 1;
           }
 
@@ -231,8 +191,11 @@ public final class ByteUtil {
       int len1 = buffer1.length;
       int len2 = buffer2.length;
       int minLength = (len1 <= len2) ? len1 : len2;
-      int minWords = 0;
+      return compareTo(buffer1, buffer2, len1, len2, minLength);
+    }
 
+    public int compareTo(byte[] buffer1, byte[] buffer2, int len1, int len2, int minLength) {
+      int minWords = 0;
       /*
        * Compare 8 bytes at a time. Benchmarking shows comparing 8 bytes
        * at a time is no slower than comparing 4 bytes at a time even on
@@ -241,12 +204,12 @@ public final class ByteUtil {
       if (minLength > 7) {
         minWords = minLength / SIZEOF_LONG;
         for (int i = 0; i < minWords * SIZEOF_LONG; i += SIZEOF_LONG) {
-          long lw = THEUNSAFE.getLong(buffer1, BYTE_ARRAY_BASE_OFFSET + (long) i);
-          long rw = THEUNSAFE.getLong(buffer2, BYTE_ARRAY_BASE_OFFSET + (long) i);
+          long lw = CarbonUnsafe.unsafe.getLong(buffer1, CarbonUnsafe.BYTE_ARRAY_OFFSET + (long) i);
+          long rw = CarbonUnsafe.unsafe.getLong(buffer2, CarbonUnsafe.BYTE_ARRAY_OFFSET + (long) i);
           long diff = lw ^ rw;
 
           if (diff != 0) {
-            if (!LITTLEENDIAN) {
+            if (!CarbonUnsafe.LITTLEENDIAN) {
               return lessThanUnsigned(lw, rw) ? -1 : 1;
             }
 
@@ -285,15 +248,78 @@ public final class ByteUtil {
       return len1 - len2;
     }
 
+    public int compareUnsafeTo(Object baseObject1, Object baseObject2, long address1, long address2,
+        int len1, int len2, int minLength) {
+
+      int minWords = 0;
+
+      /*
+       * Compare 8 bytes at a time. Benchmarking shows comparing 8 bytes
+       * at a time is no slower than comparing 4 bytes at a time even on
+       * 32-bit. On the other hand, it is substantially faster on 64-bit.
+       */
+      if (minLength > 7) {
+        minWords = minLength / SIZEOF_LONG;
+        for (int i = 0; i < minWords * SIZEOF_LONG; i += SIZEOF_LONG) {
+          long lw = CarbonUnsafe.unsafe
+              .getLong(baseObject1, CarbonUnsafe.BYTE_ARRAY_OFFSET + (long) i + address1);
+          long rw = CarbonUnsafe.unsafe
+              .getLong(baseObject2, CarbonUnsafe.BYTE_ARRAY_OFFSET + (long) i + address2);
+          long diff = lw ^ rw;
+
+          if (diff != 0) {
+            if (!CarbonUnsafe.LITTLEENDIAN) {
+              return lessThanUnsigned(lw, rw) ? -1 : 1;
+            }
+
+            // Use binary search
+            int k = 0;
+            int y;
+            int x = (int) diff;
+            if (x == 0) {
+              x = (int) (diff >>> 32);
+              k = 32;
+            }
+            y = x << 16;
+            if (y == 0) {
+              k += 16;
+            } else {
+              x = y;
+            }
+
+            y = x << 8;
+            if (y == 0) {
+              k += 8;
+            }
+            return (int) (((lw >>> k) & 0xFFL) - ((rw >>> k) & 0xFFL));
+          }
+        }
+      }
+
+      // The epilogue to cover the last (minLength % 8) elements.
+      for (int i = minWords * SIZEOF_LONG; i < minLength; i++) {
+        int a =
+            (CarbonUnsafe.unsafe.getByte(baseObject1, CarbonUnsafe.BYTE_ARRAY_OFFSET + i + address1)
+                & 0xff);
+        int b =
+            (CarbonUnsafe.unsafe.getByte(baseObject2, CarbonUnsafe.BYTE_ARRAY_OFFSET + i + address2)
+                & 0xff);
+        if (a != b) {
+          return a - b;
+        }
+      }
+      return len1 - len2;
+    }
+
     public boolean equals(byte[] buffer1, byte[] buffer2) {
       if (buffer1.length != buffer2.length) {
         return false;
       }
       int len = buffer1.length / 8;
-      long currentOffset = BYTE_ARRAY_BASE_OFFSET;
+      long currentOffset = CarbonUnsafe.BYTE_ARRAY_OFFSET;
       for (int i = 0; i < len; i++) {
-        long lw = THEUNSAFE.getLong(buffer1, currentOffset);
-        long rw = THEUNSAFE.getLong(buffer2, currentOffset);
+        long lw = CarbonUnsafe.unsafe.getLong(buffer1, currentOffset);
+        long rw = CarbonUnsafe.unsafe.getLong(buffer2, currentOffset);
         if (lw != rw) {
           return false;
         }
@@ -302,8 +328,8 @@ public final class ByteUtil {
       len = buffer1.length % 8;
       if (len > 0) {
         for (int i = 0; i < len; i += 1) {
-          long lw = THEUNSAFE.getByte(buffer1, currentOffset);
-          long rw = THEUNSAFE.getByte(buffer2, currentOffset);
+          long lw = CarbonUnsafe.unsafe.getByte(buffer1, currentOffset);
+          long rw = CarbonUnsafe.unsafe.getByte(buffer2, currentOffset);
           if (lw != rw) {
             return false;
           }

--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -143,7 +143,7 @@ public final class ByteUtil {
         long diff = lw ^ rw;
 
         if (diff != 0) {
-          if (!CarbonUnsafe.LITTLEENDIAN) {
+          if (!CarbonUnsafe.ISLITTLEENDIAN) {
             return lessThanUnsigned(lw, rw) ? -1 : 1;
           }
 
@@ -209,7 +209,7 @@ public final class ByteUtil {
           long diff = lw ^ rw;
 
           if (diff != 0) {
-            if (!CarbonUnsafe.LITTLEENDIAN) {
+            if (!CarbonUnsafe.ISLITTLEENDIAN) {
               return lessThanUnsigned(lw, rw) ? -1 : 1;
             }
 
@@ -268,7 +268,7 @@ public final class ByteUtil {
           long diff = lw ^ rw;
 
           if (diff != 0) {
-            if (!CarbonUnsafe.LITTLEENDIAN) {
+            if (!CarbonUnsafe.ISLITTLEENDIAN) {
               return lessThanUnsigned(lw, rw) ? -1 : 1;
             }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -46,6 +46,7 @@ public class CarbonTablePath extends Path {
   protected static final String CARBON_DELTE_DELTA_EXT = ".deletedelta";
   protected static final String CARBON_UPDATE_DELTA_EXT = ".updatedelta";
   protected static final String DATA_PART_PREFIX = "part-";
+  protected static final String BATCH_PREFIX = "_batchno";
   protected static final String INDEX_FILE_EXT = ".carbonindex";
   protected static final String DELETE_DELTA_FILE_EXT = ".deletedelta";
 
@@ -236,9 +237,9 @@ public class CarbonTablePath extends Path {
    * @return absolute path of data file stored in carbon data format
    */
   public String getCarbonDataFilePath(String partitionId, String segmentId, Integer filePartNo,
-      Integer taskNo, int taskExtension, int bucketNumber, String factUpdateTimeStamp) {
+      Integer taskNo, int batchNo, int bucketNumber, String factUpdateTimeStamp) {
     return getSegmentDir(partitionId, segmentId) + File.separator + getCarbonDataFileName(
-        filePartNo, taskNo, bucketNumber, taskExtension, factUpdateTimeStamp);
+        filePartNo, taskNo, bucketNumber, batchNo, factUpdateTimeStamp);
   }
 
   /**
@@ -352,9 +353,9 @@ public class CarbonTablePath extends Path {
    * @return gets data file name only with out path
    */
   public String getCarbonDataFileName(Integer filePartNo, Integer taskNo, int bucketNumber,
-      int taskExtension, String factUpdateTimeStamp) {
-    return DATA_PART_PREFIX + filePartNo + "-" + taskNo + "_" + taskExtension + "-" + bucketNumber
-        + "-" + factUpdateTimeStamp + CARBON_DATA_EXT;
+      int batchNo, String factUpdateTimeStamp) {
+    return DATA_PART_PREFIX + filePartNo + "-" + taskNo + BATCH_PREFIX + batchNo + "-"
+        + bucketNumber + "-" + factUpdateTimeStamp + CARBON_DATA_EXT;
   }
 
   /**
@@ -364,9 +365,9 @@ public class CarbonTablePath extends Path {
    * @param factUpdatedTimeStamp time stamp
    * @return filename
    */
-  public String getCarbonIndexFileName(int taskNo, int bucketNumber, int taskExtension,
+  public String getCarbonIndexFileName(int taskNo, int bucketNumber, int batchNo,
       String factUpdatedTimeStamp) {
-    return taskNo + "_" + taskExtension + "-" + bucketNumber + "-" + factUpdatedTimeStamp
+    return taskNo + BATCH_PREFIX + batchNo + "-" + bucketNumber + "-" + factUpdatedTimeStamp
         + INDEX_FILE_EXT;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -236,9 +236,9 @@ public class CarbonTablePath extends Path {
    * @return absolute path of data file stored in carbon data format
    */
   public String getCarbonDataFilePath(String partitionId, String segmentId, Integer filePartNo,
-      Integer taskNo, int bucketNumber, String factUpdateTimeStamp) {
+      Integer taskNo, int taskExtension, int bucketNumber, String factUpdateTimeStamp) {
     return getSegmentDir(partitionId, segmentId) + File.separator + getCarbonDataFileName(
-        filePartNo, taskNo, bucketNumber, factUpdateTimeStamp);
+        filePartNo, taskNo, bucketNumber, taskExtension, factUpdateTimeStamp);
   }
 
   /**
@@ -352,9 +352,9 @@ public class CarbonTablePath extends Path {
    * @return gets data file name only with out path
    */
   public String getCarbonDataFileName(Integer filePartNo, Integer taskNo, int bucketNumber,
-      String factUpdateTimeStamp) {
-    return DATA_PART_PREFIX + filePartNo + "-" + taskNo + "-" + bucketNumber + "-"
-        + factUpdateTimeStamp + CARBON_DATA_EXT;
+      int taskExtension, String factUpdateTimeStamp) {
+    return DATA_PART_PREFIX + filePartNo + "-" + taskNo + "_" + taskExtension + "-" + bucketNumber
+        + "-" + factUpdateTimeStamp + CARBON_DATA_EXT;
   }
 
   /**
@@ -364,8 +364,10 @@ public class CarbonTablePath extends Path {
    * @param factUpdatedTimeStamp time stamp
    * @return filename
    */
-  public String getCarbonIndexFileName(int taskNo, int bucketNumber, String factUpdatedTimeStamp) {
-    return taskNo + "-" + bucketNumber + "-" + factUpdatedTimeStamp + INDEX_FILE_EXT;
+  public String getCarbonIndexFileName(int taskNo, int bucketNumber, int taskExtension,
+      String factUpdatedTimeStamp) {
+    return taskNo + "_" + taskExtension + "-" + bucketNumber + "-" + factUpdatedTimeStamp
+        + INDEX_FILE_EXT;
   }
 
   /**

--- a/core/src/test/java/org/apache/carbondata/core/datastore/block/TableBlockInfoTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/block/TableBlockInfoTest.java
@@ -131,7 +131,7 @@ public class TableBlockInfoTest {
 
     TableBlockInfo tableBlockInfo = new TableBlockInfo("difffilepaths", 6, "5", null, 3, ColumnarFormatVersion.V1);
     int res = tableBlockInfos.compareTo(tableBlockInfo);
-    int expectedResult = -5;
+    int expectedResult = 7;
     assertEquals(res, expectedResult);
 
     TableBlockInfo tableBlockInfo1 = new TableBlockInfo("filepath", 6, "5", null, 3, ColumnarFormatVersion.V1);

--- a/core/src/test/java/org/apache/carbondata/core/util/path/CarbonFormatDirectoryStructureTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/path/CarbonFormatDirectoryStructureTest.java
@@ -50,8 +50,8 @@ public class CarbonFormatDirectoryStructureTest {
         .equals(CARBON_STORE + "/d1/t1/Metadata/t1_c1.dictmeta"));
     assertTrue(carbonTablePath.getSortIndexFilePath("t1_c1").replace("\\", "/")
         .equals(CARBON_STORE + "/d1/t1/Metadata/t1_c1.sortindex"));
-    assertTrue(carbonTablePath.getCarbonDataFilePath("1", "2", 3, 4, 0, "999").replace("\\", "/")
-        .equals(CARBON_STORE + "/d1/t1/Fact/Part1/Segment_2/part-3-4-0-999.carbondata"));
+    assertTrue(carbonTablePath.getCarbonDataFilePath("1", "2", 3, 4,  0, 0, "999").replace("\\", "/")
+        .equals(CARBON_STORE + "/d1/t1/Fact/Part1/Segment_2/part-3-4_0-0-999.carbondata"));
   }
 
   /**

--- a/core/src/test/java/org/apache/carbondata/core/util/path/CarbonFormatDirectoryStructureTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/path/CarbonFormatDirectoryStructureTest.java
@@ -51,7 +51,7 @@ public class CarbonFormatDirectoryStructureTest {
     assertTrue(carbonTablePath.getSortIndexFilePath("t1_c1").replace("\\", "/")
         .equals(CARBON_STORE + "/d1/t1/Metadata/t1_c1.sortindex"));
     assertTrue(carbonTablePath.getCarbonDataFilePath("1", "2", 3, 4,  0, 0, "999").replace("\\", "/")
-        .equals(CARBON_STORE + "/d1/t1/Fact/Part1/Segment_2/part-3-4_0-0-999.carbondata"));
+        .equals(CARBON_STORE + "/d1/t1/Fact/Part1/Segment_2/part-3-4_batchno0-0-999.carbondata"));
   }
 
   /**

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/merger/TupleConversionAdapter.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/merger/TupleConversionAdapter.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 /**
  * This class will be used to convert the Result into the format used in data writer.
@@ -67,7 +67,7 @@ class TupleConversionAdapter {
       for (int i = 0; i < noDicCount; i++) {
         noDicByteArr.add(((ByteArrayWrapper) carbonTuple[0]).getNoDictionaryKeyByIndex(i));
       }
-      byte[] singleByteArr = RemoveDictionaryUtil.convertListByteArrToSingleArr(noDicByteArr);
+      byte[] singleByteArr = NonDictionaryUtil.convertListByteArrToSingleArr(noDicByteArr);
 
       row[index++] = singleByteArr;
     }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -704,7 +704,7 @@ object CarbonDataRDDFactory {
               val index = taskNo + 1
               uniqueLoadStatusId = carbonLoadModel.getTableName +
                                    CarbonCommonConstants.UNDERSCORE +
-                                   index
+                                   (index + "_0")
 
               // convert timestamp
               val timeStampInLong = updateModel.get.updatedTimeStamp + ""

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -712,7 +712,7 @@ object CarbonDataRDDFactory {
               val index = taskNo + 1
               uniqueLoadStatusId = carbonLoadModel.getTableName +
                                    CarbonCommonConstants.UNDERSCORE +
-                                   index
+                                   (index + "_0")
 
               // convert timestamp
               val timeStampInLong = updateModel.get.updatedTimeStamp + ""

--- a/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/graphgenerator/GraphGenerator.java
@@ -54,7 +54,7 @@ import org.apache.carbondata.processing.sortandgroupby.sortdatastep.SortKeyStepM
 import org.apache.carbondata.processing.surrogatekeysgenerator.csvbased.CarbonCSVBasedSeqGenMeta;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 import org.apache.carbondata.processing.util.CarbonSchemaParser;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -605,7 +605,7 @@ public class GraphGenerator {
   private StepMeta getMDKeyStep(GraphConfigurationInfo graphConfiguration) {
     MDKeyGenStepMeta carbonMdKey = new MDKeyGenStepMeta();
     carbonMdKey.setIsUseInvertedIndex(
-        RemoveDictionaryUtil.convertBooleanArrToString(graphConfiguration.getIsUseInvertedIndex()));
+        NonDictionaryUtil.convertBooleanArrToString(graphConfiguration.getIsUseInvertedIndex()));
     carbonMdKey.setPartitionID(partitionID);
     carbonMdKey.setSegmentId(segmentId);
     carbonMdKey.setNumberOfCores(graphConfiguration.getNumberOfCores());
@@ -616,7 +616,7 @@ public class GraphGenerator {
     carbonMdKey.setAggregateLevels(CarbonDataProcessorUtil
         .getLevelCardinalitiesString(graphConfiguration.getDimCardinalities(),
             graphConfiguration.getDimensions()));
-    carbonMdKey.setNoDictionaryDimsMapping(RemoveDictionaryUtil
+    carbonMdKey.setNoDictionaryDimsMapping(NonDictionaryUtil
         .convertBooleanArrToString(graphConfiguration.getIsNoDictionaryDimMapping()));
     carbonMdKey.setMeasureCount(graphConfiguration.getMeasureCount() + "");
     carbonMdKey.setColumnGroupsString(graphConfiguration.getColumnGroupsString());
@@ -766,7 +766,7 @@ public class GraphGenerator {
     sortRowsMeta.setMeasureCount(graphConfiguration.getMeasureCount() + "");
     sortRowsMeta.setNoDictionaryDims(graphConfiguration.getNoDictionaryDims());
     sortRowsMeta.setMeasureDataType(graphConfiguration.getMeasureDataTypeInfo());
-    sortRowsMeta.setNoDictionaryDimsMapping(RemoveDictionaryUtil
+    sortRowsMeta.setNoDictionaryDimsMapping(NonDictionaryUtil
         .convertBooleanArrToString(graphConfiguration.getIsNoDictionaryDimMapping()));
 
     StepMeta sortRowsStep = new StepMeta(

--- a/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStep.java
@@ -54,7 +54,7 @@ import org.apache.carbondata.processing.store.CarbonFactHandler;
 import org.apache.carbondata.processing.store.SingleThreadFinalSortFilesMerger;
 import org.apache.carbondata.processing.store.writer.exception.CarbonDataWriterException;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMeta;
@@ -267,9 +267,9 @@ public class MDKeyGenStep extends BaseStep {
             String.valueOf(meta.getTaskNo()), meta.getPartitionID(), meta.getSegmentId() + "",
             false);
     isNoDictionaryDimension =
-        RemoveDictionaryUtil.convertStringToBooleanArr(meta.getNoDictionaryDimsMapping());
+        NonDictionaryUtil.convertStringToBooleanArr(meta.getNoDictionaryDimsMapping());
     isUseInvertedIndex =
-        RemoveDictionaryUtil.convertStringToBooleanArr(meta.getIsUseInvertedIndex());
+        NonDictionaryUtil.convertStringToBooleanArr(meta.getIsUseInvertedIndex());
     fileManager = new FileManager();
     fileManager.setName(CarbonCommonConstants.LOAD_FOLDER + meta.getSegmentId()
         + CarbonCommonConstants.FILE_INPROGRESS_STATUS);
@@ -280,7 +280,7 @@ public class MDKeyGenStep extends BaseStep {
     }
 
     this.meta.setNoDictionaryCount(
-        RemoveDictionaryUtil.extractNoDictionaryCount(this.meta.getNoDictionaryDims()));
+        NonDictionaryUtil.extractNoDictionaryCount(this.meta.getNoDictionaryDims()));
 
     String levelCardinalityFilePath = storeLocation + File.separator +
         CarbonCommonConstants.LEVEL_METADATA_FILE + meta.getTableName()
@@ -460,18 +460,18 @@ public class MDKeyGenStep extends BaseStep {
     int index = 0;
     for (int i = 0; i < measureCount; i++) {
       if (aggType[i] == CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
-        outputRow[l++] = RemoveDictionaryUtil.getMeasure(index++, row);
+        outputRow[l++] = NonDictionaryUtil.getMeasure(index++, row);
       } else if (aggType[i] == CarbonCommonConstants.BIG_INT_MEASURE) {
-        outputRow[l++] = (Long) RemoveDictionaryUtil.getMeasure(index++, row);
+        outputRow[l++] = (Long) NonDictionaryUtil.getMeasure(index++, row);
       } else {
-        outputRow[l++] = (Double) RemoveDictionaryUtil.getMeasure(index++, row);
+        outputRow[l++] = (Double) NonDictionaryUtil.getMeasure(index++, row);
       }
     }
-    outputRow[l] = RemoveDictionaryUtil.getByteArrayForNoDictionaryCols(row);
+    outputRow[l] = NonDictionaryUtil.getByteArrayForNoDictionaryCols(row);
 
     int[] highCardExcludedRows = new int[segmentProperties.getDimColumnsCardinality().length];
     for (int i = 0; i < highCardExcludedRows.length; i++) {
-      Object key = RemoveDictionaryUtil.getDimension(i, row);
+      Object key = NonDictionaryUtil.getDimension(i, row);
       highCardExcludedRows[i] = (Integer) key;
     }
     try {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/CarbonDataLoadConfiguration.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/CarbonDataLoadConfiguration.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.BucketingInfo;
+import org.apache.carbondata.processing.newflow.converter.DictionaryCardinalityFinder;
 
 public class CarbonDataLoadConfiguration {
 
@@ -72,6 +73,8 @@ public class CarbonDataLoadConfiguration {
    * schema updated time stamp to be used for restructure scenarios
    */
   private long schemaUpdatedTimeStamp;
+
+  private DictionaryCardinalityFinder cardinalityFinder;
 
   public CarbonDataLoadConfiguration() {
   }
@@ -244,5 +247,13 @@ public class CarbonDataLoadConfiguration {
 
   public void setSchemaUpdatedTimeStamp(long schemaUpdatedTimeStamp) {
     this.schemaUpdatedTimeStamp = schemaUpdatedTimeStamp;
+  }
+
+  public DictionaryCardinalityFinder getCardinalityFinder() {
+    return cardinalityFinder;
+  }
+
+  public void setCardinalityFinder(DictionaryCardinalityFinder cardinalityFinder) {
+    this.cardinalityFinder = cardinalityFinder;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadProcessBuilder.java
@@ -37,6 +37,7 @@ import org.apache.carbondata.processing.model.CarbonLoadModel;
 import org.apache.carbondata.processing.newflow.constants.DataLoadProcessorConstants;
 import org.apache.carbondata.processing.newflow.steps.DataConverterProcessorStepImpl;
 import org.apache.carbondata.processing.newflow.steps.DataConverterProcessorWithBucketingStepImpl;
+import org.apache.carbondata.processing.newflow.steps.DataWriterBatchProcessorStepImpl;
 import org.apache.carbondata.processing.newflow.steps.DataWriterProcessorStepImpl;
 import org.apache.carbondata.processing.newflow.steps.InputProcessorStepImpl;
 import org.apache.carbondata.processing.newflow.steps.SortProcessorStepImpl;
@@ -52,10 +53,15 @@ public final class DataLoadProcessBuilder {
 
   public AbstractDataLoadProcessorStep build(CarbonLoadModel loadModel, String storeLocation,
       CarbonIterator[] inputIterators) throws Exception {
+    boolean batchSort = Boolean.parseBoolean(CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.LOAD_USE_BATCH_SORT,
+            CarbonCommonConstants.LOAD_USE_BATCH_SORT_DEFAULT));
     CarbonDataLoadConfiguration configuration =
         createConfiguration(loadModel, storeLocation);
     if (configuration.getBucketingInfo() != null) {
       return buildInternalForBucketing(inputIterators, configuration);
+    } else if (batchSort) {
+      return buildInternalForBatchSort(inputIterators, configuration);
     } else {
       return buildInternal(inputIterators, configuration);
     }
@@ -76,6 +82,24 @@ public final class DataLoadProcessBuilder {
     // 4. Writes the sorted data in carbondata format.
     AbstractDataLoadProcessorStep writerProcessorStep =
         new DataWriterProcessorStepImpl(configuration, sortProcessorStep);
+    return writerProcessorStep;
+  }
+
+  private AbstractDataLoadProcessorStep buildInternalForBatchSort(CarbonIterator[] inputIterators,
+      CarbonDataLoadConfiguration configuration) {
+    // 1. Reads the data input iterators and parses the data.
+    AbstractDataLoadProcessorStep inputProcessorStep =
+        new InputProcessorStepImpl(configuration, inputIterators);
+    // 2. Converts the data like dictionary or non dictionary or complex objects depends on
+    // data types and configurations.
+    AbstractDataLoadProcessorStep converterProcessorStep =
+        new DataConverterProcessorStepImpl(configuration, inputProcessorStep);
+    // 3. Sorts the data which are part of key (all dimensions except complex types)
+    AbstractDataLoadProcessorStep sortProcessorStep =
+        new SortProcessorStepImpl(configuration, converterProcessorStep);
+    // 4. Writes the sorted data in carbondata format.
+    AbstractDataLoadProcessorStep writerProcessorStep =
+        new DataWriterBatchProcessorStepImpl(configuration, sortProcessorStep);
     return writerProcessorStep;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/DictionaryCardinalityFinder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/DictionaryCardinalityFinder.java
@@ -15,25 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.carbondata.processing.newflow.constants;
+package org.apache.carbondata.processing.newflow.converter;
 
 /**
- * Constants used in data loading.
+ * Finds the current cardinality of dimensions.
  */
-public final class DataLoadProcessorConstants {
+public interface DictionaryCardinalityFinder {
 
-  public static final String FACT_TIME_STAMP = "FACT_TIME_STAMP";
-
-  public static final String COMPLEX_DELIMITERS = "COMPLEX_DELIMITERS";
-
-  public static final String SERIALIZATION_NULL_FORMAT = "SERIALIZATION_NULL_FORMAT";
-
-  public static final String BAD_RECORDS_LOGGER_ENABLE = "BAD_RECORDS_LOGGER_ENABLE";
-
-  public static final String BAD_RECORDS_LOGGER_ACTION = "BAD_RECORDS_LOGGER_ACTION";
-
-  public static final String IS_EMPTY_DATA_BAD_RECORD = "IS_EMPTY_DATA_BAD_RECORD";
-
-  public static final String FACT_FILE_PATH = "FACT_FILE_PATH";
-
+  int[] getCardinality();
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/RowConverter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/RowConverter.java
@@ -24,7 +24,7 @@ import org.apache.carbondata.processing.newflow.row.CarbonRow;
 /**
  * convert the row
  */
-public interface RowConverter {
+public interface RowConverter extends DictionaryCardinalityFinder {
 
   void initialize() throws IOException;
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/RowConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/RowConverterImpl.java
@@ -171,22 +171,6 @@ public class RowConverterImpl implements RowConverter {
 
   @Override
   public void finish() {
-    List<Integer> dimCardinality = new ArrayList<>();
-    if (fieldConverters != null) {
-      for (int i = 0; i < fieldConverters.length; i++) {
-        if (fieldConverters[i] instanceof AbstractDictionaryFieldConverterImpl) {
-          ((AbstractDictionaryFieldConverterImpl) fieldConverters[i])
-              .fillColumnCardinality(dimCardinality);
-        }
-      }
-    }
-    int[] cardinality = new int[dimCardinality.size()];
-    for (int i = 0; i < dimCardinality.size(); i++) {
-      cardinality[i] = dimCardinality.get(i);
-    }
-    // Set the cardinality to configuration, it will be used by further step for mdk key.
-    configuration.setDataLoadProperty(DataLoadProcessorConstants.DIMENSION_LENGTHS, cardinality);
-
     // close dictionary client when finish write
     if (configuration.getUseOnePass()) {
       for (DictionaryClient client : dictClients) {
@@ -229,4 +213,20 @@ public class RowConverterImpl implements RowConverter {
     return converter;
   }
 
+  @Override public int[] getCardinality() {
+    List<Integer> dimCardinality = new ArrayList<>();
+    if (fieldConverters != null) {
+      for (int i = 0; i < fieldConverters.length; i++) {
+        if (fieldConverters[i] instanceof AbstractDictionaryFieldConverterImpl) {
+          ((AbstractDictionaryFieldConverterImpl) fieldConverters[i])
+              .fillColumnCardinality(dimCardinality);
+        }
+      }
+    }
+    int[] cardinality = new int[dimCardinality.size()];
+    for (int i = 0; i < dimCardinality.size(); i++) {
+      cardinality[i] = dimCardinality.get(i);
+    }
+    return cardinality;
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/row/CarbonRowBatch.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/row/CarbonRowBatch.java
@@ -17,12 +17,12 @@
 
 package org.apache.carbondata.processing.newflow.row;
 
-import java.util.Iterator;
+import org.apache.carbondata.common.CarbonIterator;
 
 /**
  * Batch of rows.
  */
-public class CarbonRowBatch implements Iterator<CarbonRow> {
+public class CarbonRowBatch extends CarbonIterator<CarbonRow> {
 
   private CarbonRow[] rowBatch;
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/row/CarbonSortBatch.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/row/CarbonSortBatch.java
@@ -14,26 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.carbondata.processing.newflow.row;
 
-package org.apache.carbondata.processing.newflow.constants;
+import org.apache.carbondata.processing.newflow.sort.unsafe.merger.UnsafeSingleThreadFinalSortFilesMerger;
 
 /**
- * Constants used in data loading.
+ * Batch of sorted rows which are ready to be processed by
  */
-public final class DataLoadProcessorConstants {
+public class CarbonSortBatch extends CarbonRowBatch {
 
-  public static final String FACT_TIME_STAMP = "FACT_TIME_STAMP";
+  private UnsafeSingleThreadFinalSortFilesMerger iterator;
 
-  public static final String COMPLEX_DELIMITERS = "COMPLEX_DELIMITERS";
+  public CarbonSortBatch(UnsafeSingleThreadFinalSortFilesMerger iterator) {
+    super(0);
+    this.iterator = iterator;
+  }
 
-  public static final String SERIALIZATION_NULL_FORMAT = "SERIALIZATION_NULL_FORMAT";
+  @Override public boolean hasNext() {
+    return iterator.hasNext();
+  }
 
-  public static final String BAD_RECORDS_LOGGER_ENABLE = "BAD_RECORDS_LOGGER_ENABLE";
+  @Override public CarbonRow next() {
+    return new CarbonRow(iterator.next());
+  }
 
-  public static final String BAD_RECORDS_LOGGER_ACTION = "BAD_RECORDS_LOGGER_ACTION";
-
-  public static final String IS_EMPTY_DATA_BAD_RECORD = "IS_EMPTY_DATA_BAD_RECORD";
-
-  public static final String FACT_FILE_PATH = "FACT_FILE_PATH";
-
+  @Override public void close() {
+    iterator.close();
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.processing.newflow.sort.impl;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.carbondata.common.CarbonIterator;
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
+import org.apache.carbondata.processing.newflow.exception.CarbonDataLoadingException;
+import org.apache.carbondata.processing.newflow.row.CarbonRow;
+import org.apache.carbondata.processing.newflow.row.CarbonRowBatch;
+import org.apache.carbondata.processing.newflow.row.CarbonSortBatch;
+import org.apache.carbondata.processing.newflow.sort.Sorter;
+import org.apache.carbondata.processing.newflow.sort.unsafe.UnsafeCarbonRowPage;
+import org.apache.carbondata.processing.newflow.sort.unsafe.UnsafeSortDataRows;
+import org.apache.carbondata.processing.newflow.sort.unsafe.merger.UnsafeIntermediateMerger;
+import org.apache.carbondata.processing.newflow.sort.unsafe.merger.UnsafeSingleThreadFinalSortFilesMerger;
+import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
+import org.apache.carbondata.processing.sortandgroupby.sortdata.SortParameters;
+import org.apache.carbondata.processing.store.writer.exception.CarbonDataWriterException;
+
+/**
+ * It parallely reads data from array of iterates and do merge sort.
+ * It sorts data in batches and send to the next step.
+ */
+public class UnsafeBatchParallelReadMergeSorterImpl implements Sorter {
+
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(UnsafeBatchParallelReadMergeSorterImpl.class.getName());
+
+  private SortParameters sortParameters;
+
+  private ExecutorService executorService;
+
+  private AtomicLong rowCounter;
+
+  public UnsafeBatchParallelReadMergeSorterImpl(AtomicLong rowCounter) {
+    this.rowCounter = rowCounter;
+  }
+
+  @Override public void initialize(SortParameters sortParameters) {
+    this.sortParameters = sortParameters;
+
+  }
+
+  @Override public Iterator<CarbonRowBatch>[] sort(Iterator<CarbonRowBatch>[] iterators)
+      throws CarbonDataLoadingException {
+    this.executorService = Executors.newFixedThreadPool(iterators.length);
+    int batchSize = CarbonProperties.getInstance().getBatchSize();
+    final SortBatchHolder sortBatchHolder = new SortBatchHolder(sortParameters, iterators.length);
+
+    try {
+      for (int i = 0; i < iterators.length; i++) {
+        executorService
+            .submit(new SortIteratorThread(iterators[i], sortBatchHolder, batchSize, rowCounter));
+      }
+    } catch (Exception e) {
+      throw new CarbonDataLoadingException("Problem while shutdown the server ", e);
+    }
+
+    // Creates the iterator to read from merge sorter.
+    Iterator<CarbonSortBatch> batchIterator = new CarbonIterator<CarbonSortBatch>() {
+
+      @Override public boolean hasNext() {
+        return sortBatchHolder.hasNext();
+      }
+
+      @Override public CarbonSortBatch next() {
+        return new CarbonSortBatch(sortBatchHolder.next());
+      }
+    };
+    return new Iterator[] { batchIterator };
+  }
+
+  @Override public void close() {
+    executorService.shutdown();
+    try {
+      executorService.awaitTermination(2, TimeUnit.DAYS);
+    } catch (InterruptedException e) {
+      LOGGER.error(e);
+    }
+  }
+
+  /**
+   * This thread iterates the iterator and adds the rows
+   */
+  private static class SortIteratorThread implements Callable<Void> {
+
+    private Iterator<CarbonRowBatch> iterator;
+
+    private SortBatchHolder sortDataRows;
+
+    private Object[][] buffer;
+
+    private AtomicLong rowCounter;
+
+    public SortIteratorThread(Iterator<CarbonRowBatch> iterator, SortBatchHolder sortDataRows,
+        int batchSize, AtomicLong rowCounter) {
+      this.iterator = iterator;
+      this.sortDataRows = sortDataRows;
+      this.buffer = new Object[batchSize][];
+      this.rowCounter = rowCounter;
+    }
+
+    @Override public Void call() throws CarbonDataLoadingException {
+      try {
+        while (iterator.hasNext()) {
+          CarbonRowBatch batch = iterator.next();
+          int i = 0;
+          while (batch.hasNext()) {
+            CarbonRow row = batch.next();
+            if (row != null) {
+              buffer[i++] = row.getData();
+            }
+          }
+          if (i > 0) {
+            sortDataRows.getSortDataRow().addRowBatch(buffer, i);
+            rowCounter.getAndAdd(i);
+            synchronized (sortDataRows) {
+              if (!sortDataRows.getSortDataRow().canAdd()) {
+                sortDataRows.finish();
+                sortDataRows.createSortDataRows();
+              }
+            }
+          }
+        }
+      } catch (Exception e) {
+        LOGGER.error(e);
+        throw new CarbonDataLoadingException(e);
+      } finally {
+        sortDataRows.finishThread();
+      }
+      return null;
+    }
+
+  }
+
+  private static class SortBatchHolder
+      extends CarbonIterator<UnsafeSingleThreadFinalSortFilesMerger> {
+
+    private SortParameters sortParameters;
+
+    private UnsafeSingleThreadFinalSortFilesMerger finalMerger;
+
+    private UnsafeIntermediateMerger unsafeIntermediateFileMerger;
+
+    private UnsafeSortDataRows sortDataRow;
+
+    private final BlockingQueue<UnsafeSingleThreadFinalSortFilesMerger> mergerQueue;
+
+    private AtomicInteger iteratorCount;
+
+    public SortBatchHolder(SortParameters sortParameters, int numberOfThreads) {
+      this.sortParameters = sortParameters;
+      this.iteratorCount = new AtomicInteger(numberOfThreads);
+      this.mergerQueue = new LinkedBlockingQueue<>();
+      createSortDataRows();
+    }
+
+    private void createSortDataRows() {
+      this.finalMerger = new UnsafeSingleThreadFinalSortFilesMerger(sortParameters);
+      unsafeIntermediateFileMerger = new UnsafeIntermediateMerger(sortParameters);
+      sortDataRow = new UnsafeSortDataRows(sortParameters, unsafeIntermediateFileMerger);
+
+      try {
+        sortDataRow.initialize();
+      } catch (CarbonSortKeyAndGroupByException e) {
+        throw new CarbonDataLoadingException(e);
+      }
+    }
+
+    @Override public UnsafeSingleThreadFinalSortFilesMerger next() {
+      try {
+        return mergerQueue.take();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public UnsafeSortDataRows getSortDataRow() {
+      return sortDataRow;
+    }
+
+    public void finish() {
+      try {
+        processRowToNextStep(sortDataRow, sortParameters);
+        unsafeIntermediateFileMerger.finish();
+        List<UnsafeCarbonRowPage> rowPages = unsafeIntermediateFileMerger.getRowPages();
+        finalMerger.startFinalMerge(rowPages.toArray(new UnsafeCarbonRowPage[rowPages.size()]),
+            unsafeIntermediateFileMerger.getMergedPages());
+        unsafeIntermediateFileMerger.close();
+        mergerQueue.offer(finalMerger);
+        sortDataRow = null;
+        unsafeIntermediateFileMerger = null;
+        finalMerger = null;
+      } catch (CarbonDataWriterException e) {
+        throw new CarbonDataLoadingException(e);
+      } catch (CarbonSortKeyAndGroupByException e) {
+        throw new CarbonDataLoadingException(e);
+      }
+    }
+
+    public synchronized void finishThread() {
+      if (iteratorCount.decrementAndGet() <= 0) {
+        finish();
+      }
+    }
+
+    public synchronized boolean hasNext() {
+      return iteratorCount.get() > 0 || !mergerQueue.isEmpty();
+    }
+
+    /**
+     * Below method will be used to process data to next step
+     */
+    private boolean processRowToNextStep(UnsafeSortDataRows sortDataRows, SortParameters parameters)
+        throws CarbonDataLoadingException {
+      if (null == sortDataRows) {
+        LOGGER.info("Record Processed For table: " + parameters.getTableName());
+        LOGGER.info("Number of Records was Zero");
+        String logMessage = "Summary: Carbon Sort Key Step: Read: " + 0 + ": Write: " + 0;
+        LOGGER.info(logMessage);
+        return false;
+      }
+
+      try {
+        // start sorting
+        sortDataRows.startSorting();
+
+        // check any more rows are present
+        LOGGER.info("Record Processed For table: " + parameters.getTableName());
+        CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
+            .recordSortRowsStepTotalTime(parameters.getPartitionID(), System.currentTimeMillis());
+        CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
+            .recordDictionaryValuesTotalTime(parameters.getPartitionID(),
+                System.currentTimeMillis());
+        return false;
+      } catch (InterruptedException e) {
+        throw new CarbonDataLoadingException(e);
+      }
+    }
+
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeCarbonRowPage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeCarbonRowPage.java
@@ -66,10 +66,11 @@ public class UnsafeCarbonRowPage {
     sizeToBeUsed = dataBlock.size() - (dataBlock.size() * 5) / 100;
   }
 
-  public void addRow(Object[] row) {
+  public int addRow(Object[] row) {
     int size = addRow(row, dataBlock.getBaseOffset() + lastSize);
     buffer.set(lastSize);
     lastSize = lastSize + size;
+    return size;
   }
 
   private int addRow(Object[] row, long address) {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeMemoryManager.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeMemoryManager.java
@@ -97,4 +97,8 @@ public class UnsafeMemoryManager {
   public boolean isMemoryAvailable() {
     return getAvailableMemory() > minimumMemory;
   }
+
+  public long getUsableMemory() {
+    return totalMemory - minimumMemory;
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/comparator/UnsafeRowComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/comparator/UnsafeRowComparator.java
@@ -50,23 +50,20 @@ public class UnsafeRowComparator implements Comparator<UnsafeCarbonRow> {
     for (boolean isNoDictionary : noDictionaryColMaping) {
       if (isNoDictionary) {
         short aShort1 = CarbonUnsafe.unsafe.getShort(baseObject, rowA + sizeA);
-        byte[] byteArr1 = new byte[aShort1];
         sizeA += 2;
-        CarbonUnsafe.unsafe.copyMemory(baseObject, rowA + sizeA, byteArr1,
-            CarbonUnsafe.BYTE_ARRAY_OFFSET, aShort1);
-        sizeA += aShort1;
 
         short aShort2 = CarbonUnsafe.unsafe.getShort(baseObject, rowB + sizeB);
-        byte[] byteArr2 = new byte[aShort2];
         sizeB += 2;
-        CarbonUnsafe.unsafe.copyMemory(baseObject, rowB + sizeB, byteArr2,
-            CarbonUnsafe.BYTE_ARRAY_OFFSET, aShort2);
-        sizeB += aShort2;
+        int minLength = (aShort1 <= aShort2) ? aShort1 : aShort2;
+        int difference = UnsafeComparer.INSTANCE
+            .compareUnsafeTo(baseObject, baseObject, rowA + sizeA, rowB + sizeB, aShort1, aShort2,
+                minLength);
 
-        int difference = UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
         if (difference != 0) {
           return difference;
         }
+        sizeA += aShort1;
+        sizeB += aShort2;
       } else {
         int dimFieldA = CarbonUnsafe.unsafe.getInt(baseObject, rowA + sizeA);
         sizeA += 4;
@@ -95,25 +92,22 @@ public class UnsafeRowComparator implements Comparator<UnsafeCarbonRow> {
     for (boolean isNoDictionary : noDictionaryColMaping) {
       if (isNoDictionary) {
         short aShort1 = CarbonUnsafe.unsafe.getShort(baseObjectL, rowA + sizeA);
-        byte[] byteArr1 = new byte[aShort1];
         sizeA += 2;
-        CarbonUnsafe.unsafe
-            .copyMemory(baseObjectL, rowA + sizeA, byteArr1, CarbonUnsafe.BYTE_ARRAY_OFFSET,
-                aShort1);
-        sizeA += aShort1;
 
         short aShort2 = CarbonUnsafe.unsafe.getShort(baseObjectR, rowB + sizeB);
-        byte[] byteArr2 = new byte[aShort2];
         sizeB += 2;
-        CarbonUnsafe.unsafe
-            .copyMemory(baseObjectR, rowB + sizeB, byteArr2, CarbonUnsafe.BYTE_ARRAY_OFFSET,
-                aShort2);
-        sizeB += aShort2;
 
-        int difference = UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
+        int minLength = (aShort1 <= aShort2) ? aShort1 : aShort2;
+
+        int difference = UnsafeComparer.INSTANCE
+            .compareUnsafeTo(baseObjectL, baseObjectR, rowA + sizeA, rowB + sizeB, aShort1, aShort2,
+                minLength);
+
         if (difference != 0) {
           return difference;
         }
+        sizeA += aShort1;
+        sizeB += aShort2;
       } else {
         int dimFieldA = CarbonUnsafe.unsafe.getInt(baseObjectL, rowA + sizeA);
         sizeA += 4;

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateFileMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateFileMerger.java
@@ -293,7 +293,8 @@ public class UnsafeIntermediateFileMerger implements Callable<Void> {
     }
 
     // write complex dimensions here.
-    int dimensionSize = mergerParameters.getDimColCount();
+    int dimensionSize =
+        mergerParameters.getDimColCount() + mergerParameters.getComplexDimColCount();
     int measureSize = mergerParameters.getMeasureColCount();
     for (; dimCount < dimensionSize; dimCount++) {
       byte[] col = (byte[]) row[dimCount];

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeSingleThreadFinalSortFilesMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeSingleThreadFinalSortFilesMerger.java
@@ -33,7 +33,7 @@ import org.apache.carbondata.processing.newflow.sort.unsafe.holder.UnsafeInmemor
 import org.apache.carbondata.processing.newflow.sort.unsafe.holder.UnsafeSortTempFileChunkHolder;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortParameters;
 import org.apache.carbondata.processing.store.writer.exception.CarbonDataWriterException;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 public class UnsafeSingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
   /**
@@ -125,7 +125,8 @@ public class UnsafeSingleThreadFinalSortFilesMerger extends CarbonIterator<Objec
       for (final UnsafeCarbonRowPage rowPage : rowPages) {
 
         SortTempChunkHolder sortTempFileChunkHolder = new UnsafeInmemoryHolder(rowPage,
-            parameters.getDimColCount() + parameters.getMeasureColCount());
+            parameters.getDimColCount() + parameters.getComplexDimColCount() + parameters
+                .getMeasureColCount());
 
         // initialize
         sortTempFileChunkHolder.readRow();
@@ -137,7 +138,8 @@ public class UnsafeSingleThreadFinalSortFilesMerger extends CarbonIterator<Objec
 
         SortTempChunkHolder sortTempFileChunkHolder =
             new UnsafeFinalMergePageHolder(merger, parameters.getNoDictionaryDimnesionColumn(),
-                parameters.getDimColCount() + parameters.getMeasureColCount());
+                parameters.getDimColCount() + parameters.getComplexDimColCount() + parameters
+                    .getMeasureColCount());
 
         // initialize
         sortTempFileChunkHolder.readRow();
@@ -284,7 +286,7 @@ public class UnsafeSingleThreadFinalSortFilesMerger extends CarbonIterator<Objec
         allCount++;
       }
 
-      RemoveDictionaryUtil.prepareOutObj(holder, dim, nonDicArray, measures);
+      NonDictionaryUtil.prepareOutObj(holder, dim, nonDicArray, measures);
 
       // increment number if record read
     } catch (Exception e) {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
@@ -64,6 +64,7 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
     badRecordLogger = createBadRecordLogger();
     RowConverter converter =
         new RowConverterImpl(child.getOutput(), configuration, badRecordLogger);
+    configuration.setCardinalityFinder(converter);
     converters.add(converter);
     converter.initialize();
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorWithBucketingStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorWithBucketingStepImpl.java
@@ -71,6 +71,7 @@ public class DataConverterProcessorWithBucketingStepImpl extends AbstractDataLoa
     badRecordLogger = createBadRecordLogger();
     RowConverter converter =
         new RowConverterImpl(child.getOutput(), configuration, badRecordLogger);
+    configuration.setCardinalityFinder(converter);
     converters.add(converter);
     converter.initialize();
     List<Integer> indexes = new ArrayList<>();

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/SortProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/SortProcessorStepImpl.java
@@ -62,13 +62,12 @@ public class SortProcessorStepImpl extends AbstractDataLoadProcessorStep {
     boolean batchSort = Boolean.parseBoolean(CarbonProperties.getInstance()
         .getProperty(CarbonCommonConstants.LOAD_USE_BATCH_SORT,
             CarbonCommonConstants.LOAD_USE_BATCH_SORT_DEFAULT));
-    if (offheapsort) {
+    if (batchSort) {
+      sorter = new UnsafeBatchParallelReadMergeSorterImpl(rowCounter);
+    } else if (offheapsort) {
       sorter = new UnsafeParallelReadMergeSorterImpl(rowCounter);
     } else {
       sorter = new ParallelReadMergeSorterImpl(rowCounter);
-    }
-    if (batchSort) {
-      sorter = new UnsafeBatchParallelReadMergeSorterImpl(rowCounter);
     }
     if (configuration.getBucketingInfo() != null) {
       sorter = new ParallelReadMergeSorterWithBucketingImpl(rowCounter,

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/IntermediateFileMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/IntermediateFileMerger.java
@@ -32,7 +32,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 public class IntermediateFileMerger implements Callable<Void> {
   /**
@@ -334,30 +334,30 @@ public class IntermediateFileMerger implements Callable<Void> {
       char[] aggType = mergerParameters.getAggType();
 
       for (int counter = 0; counter < mergerParameters.getDimColCount(); counter++) {
-        stream.writeInt((Integer) RemoveDictionaryUtil.getDimension(fieldIndex++, row));
+        stream.writeInt((Integer) NonDictionaryUtil.getDimension(fieldIndex++, row));
       }
 
       // added for high card also
       if ((mergerParameters.getNoDictionaryCount() + mergerParameters
           .getComplexDimColCount()) > 0) {
-        stream.write(RemoveDictionaryUtil.getByteArrayForNoDictionaryCols(row));
+        stream.write(NonDictionaryUtil.getByteArrayForNoDictionaryCols(row));
       }
 
       fieldIndex = 0;
       for (int counter = 0; counter < mergerParameters.getMeasureColCount(); counter++) {
-        if (null != RemoveDictionaryUtil.getMeasure(fieldIndex, row)) {
+        if (null != NonDictionaryUtil.getMeasure(fieldIndex, row)) {
           stream.write((byte) 1);
           if (aggType[counter] == CarbonCommonConstants.BYTE_VALUE_MEASURE) {
-            Double val = (Double) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            Double val = (Double) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeDouble(val);
           } else if (aggType[counter] == CarbonCommonConstants.SUM_COUNT_VALUE_MEASURE) {
-            Double val = (Double) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            Double val = (Double) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeDouble(val);
           } else if (aggType[counter] == CarbonCommonConstants.BIG_INT_MEASURE) {
-            Long val = (Long) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            Long val = (Long) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeLong(val);
           } else if (aggType[counter] == CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
-            byte[] bigDecimalInBytes = (byte[]) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            byte[] bigDecimalInBytes = (byte[]) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeInt(bigDecimalInBytes.length);
             stream.write(bigDecimalInBytes);
           }
@@ -413,19 +413,19 @@ public class IntermediateFileMerger implements Callable<Void> {
 
       int fieldIndex = 0;
       for (int counter = 0; counter < mergerParameters.getMeasureColCount(); counter++) {
-        if (null != RemoveDictionaryUtil.getMeasure(fieldIndex, row)) {
+        if (null != NonDictionaryUtil.getMeasure(fieldIndex, row)) {
           stream.write((byte) 1);
           if (aggType[counter] == CarbonCommonConstants.BYTE_VALUE_MEASURE) {
-            Double val = (Double) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            Double val = (Double) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeDouble(val);
           } else if (aggType[counter] == CarbonCommonConstants.SUM_COUNT_VALUE_MEASURE) {
-            Double val = (Double) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            Double val = (Double) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeDouble(val);
           } else if (aggType[counter] == CarbonCommonConstants.BIG_INT_MEASURE) {
-            Long val = (Long) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            Long val = (Long) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeLong(val);
           } else if (aggType[counter] == CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
-            byte[] bigDecimalInBytes = (byte[]) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+            byte[] bigDecimalInBytes = (byte[]) NonDictionaryUtil.getMeasure(fieldIndex, row);
             stream.writeInt(bigDecimalInBytes.length);
             stream.write(bigDecimalInBytes);
           }

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/RowComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/RowComparator.java
@@ -22,7 +22,7 @@ import java.util.Comparator;
 
 import org.apache.carbondata.core.constants.IgnoreDictionary;
 import org.apache.carbondata.core.util.ByteUtil.UnsafeComparer;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 public class RowComparator implements Comparator<Object[]> {
   /**
@@ -61,7 +61,7 @@ public class RowComparator implements Comparator<Object[]> {
         ByteBuffer buff1 = ByteBuffer.wrap(byteArr1);
 
         // extract a high card dims from complete byte[].
-        RemoveDictionaryUtil
+        NonDictionaryUtil
             .extractSingleHighCardDims(byteArr1, noDictionaryindex, noDictionaryCount, buff1);
 
         byte[] byteArr2 = (byte[]) rowB[IgnoreDictionary.BYTE_ARRAY_INDEX_IN_ROW.getIndex()];
@@ -69,7 +69,7 @@ public class RowComparator implements Comparator<Object[]> {
         ByteBuffer buff2 = ByteBuffer.wrap(byteArr2);
 
         // extract a high card dims from complete byte[].
-        RemoveDictionaryUtil
+        NonDictionaryUtil
             .extractSingleHighCardDims(byteArr2, noDictionaryindex, noDictionaryCount, buff2);
 
         int difference = UnsafeComparer.INSTANCE.compareTo(buff1, buff2);
@@ -78,8 +78,8 @@ public class RowComparator implements Comparator<Object[]> {
         }
         noDictionaryindex++;
       } else {
-        int dimFieldA = RemoveDictionaryUtil.getDimension(normalIndex, rowA);
-        int dimFieldB = RemoveDictionaryUtil.getDimension(normalIndex, rowB);
+        int dimFieldA = NonDictionaryUtil.getDimension(normalIndex, rowA);
+        int dimFieldB = NonDictionaryUtil.getDimension(normalIndex, rowB);
         diff = dimFieldA - dimFieldB;
         if (diff != 0) {
           return diff;

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/RowComparatorForNormalDims.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/RowComparatorForNormalDims.java
@@ -18,7 +18,7 @@ package org.apache.carbondata.processing.sortandgroupby.sortdata;
 
 import java.util.Comparator;
 
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 /**
  * This class is used as comparator for comparing dims which are non high cardinality dims.
@@ -49,8 +49,8 @@ public class RowComparatorForNormalDims implements Comparator<Object[]> {
 
     for (int i = 0; i < dimensionCount; i++) {
 
-      int dimFieldA = RemoveDictionaryUtil.getDimension(i, rowA);
-      int dimFieldB = RemoveDictionaryUtil.getDimension(i, rowB);
+      int dimFieldA = NonDictionaryUtil.getDimension(i, rowA);
+      int dimFieldB = NonDictionaryUtil.getDimension(i, rowB);
 
       diff = dimFieldA - dimFieldB;
       if (diff != 0) {

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
@@ -38,7 +38,7 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 public class SortDataRows {
   /**
@@ -279,28 +279,28 @@ public class SortDataRows {
         int fieldIndex = 0;
 
         for (int dimCount = 0; dimCount < dimColCount; dimCount++) {
-          stream.writeInt(RemoveDictionaryUtil.getDimension(fieldIndex++, row));
+          stream.writeInt(NonDictionaryUtil.getDimension(fieldIndex++, row));
         }
 
         // if any high cardinality dims are present then write it to the file.
 
         if (combinedDimCount > 0) {
-          stream.write(RemoveDictionaryUtil.getByteArrayForNoDictionaryCols(row));
+          stream.write(NonDictionaryUtil.getByteArrayForNoDictionaryCols(row));
         }
 
         // as measures are stored in separate array.
         fieldIndex = 0;
         for (int mesCount = 0; mesCount < parameters.getMeasureColCount(); mesCount++) {
-          if (null != RemoveDictionaryUtil.getMeasure(fieldIndex, row)) {
+          if (null != NonDictionaryUtil.getMeasure(fieldIndex, row)) {
             stream.write((byte) 1);
             if (aggType[mesCount] == CarbonCommonConstants.SUM_COUNT_VALUE_MEASURE) {
-              Double val = (Double) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+              Double val = (Double) NonDictionaryUtil.getMeasure(fieldIndex, row);
               stream.writeDouble(val);
             } else if (aggType[mesCount] == CarbonCommonConstants.BIG_INT_MEASURE) {
-              Long val = (Long) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+              Long val = (Long) NonDictionaryUtil.getMeasure(fieldIndex, row);
               stream.writeLong(val);
             } else if (aggType[mesCount] == CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
-              BigDecimal val = (BigDecimal) RemoveDictionaryUtil.getMeasure(fieldIndex, row);
+              BigDecimal val = (BigDecimal) NonDictionaryUtil.getMeasure(fieldIndex, row);
               byte[] bigDecimalInBytes = DataTypeUtil.bigDecimalToByte(val);
               stream.writeInt(bigDecimalInBytes.length);
               stream.write(bigDecimalInBytes);

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortTempFileChunkHolder.java
@@ -37,7 +37,7 @@ import org.apache.carbondata.core.util.ByteUtil.UnsafeComparer;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHolder> {
 
@@ -359,7 +359,7 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
         }
       }
 
-      RemoveDictionaryUtil.prepareOutObj(holder, dim, finalByteArr, measures);
+      NonDictionaryUtil.prepareOutObj(holder, dim, finalByteArr, measures);
 
       // increment number if record read
       this.numberOfObjectRead++;
@@ -425,7 +425,7 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
         }
       }
 
-      RemoveDictionaryUtil.prepareOutObj(holder, dim, nonDicArray, measures);
+      NonDictionaryUtil.prepareOutObj(holder, dim, nonDicArray, measures);
 
       // increment number if record read
       this.numberOfObjectRead++;
@@ -503,7 +503,7 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
         ByteBuffer buff1 = ByteBuffer.wrap(byteArr1);
 
         // extract a high card dims from complete byte[].
-        RemoveDictionaryUtil
+        NonDictionaryUtil
             .extractSingleHighCardDims(byteArr1, noDictionaryindex, noDictionaryCount, buff1);
 
         byte[] byteArr2 =
@@ -512,7 +512,7 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
         ByteBuffer buff2 = ByteBuffer.wrap(byteArr2);
 
         // extract a high card dims from complete byte[].
-        RemoveDictionaryUtil
+        NonDictionaryUtil
             .extractSingleHighCardDims(byteArr2, noDictionaryindex, noDictionaryCount, buff2);
 
         int difference = UnsafeComparer.INSTANCE.compareTo(buff1, buff2);
@@ -521,8 +521,8 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
         }
         noDictionaryindex++;
       } else {
-        int dimFieldA = RemoveDictionaryUtil.getDimension(normalIndex, returnRow);
-        int dimFieldB = RemoveDictionaryUtil.getDimension(normalIndex, other.returnRow);
+        int dimFieldA = NonDictionaryUtil.getDimension(normalIndex, returnRow);
+        int dimFieldB = NonDictionaryUtil.getDimension(normalIndex, other.returnRow);
         diff = dimFieldA - dimFieldB;
         if (diff != 0) {
           return diff;

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/UnCompressedTempSortFileWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/UnCompressedTempSortFileWriter.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 public class UnCompressedTempSortFileWriter extends AbstractTempSortFileWriter {
 
@@ -49,12 +49,12 @@ public class UnCompressedTempSortFileWriter extends AbstractTempSortFileWriter {
       int fieldIndex = 0;
 
       for (int counter = 0; counter < dimensionCount; counter++) {
-        dataOutputStream.writeInt((Integer) RemoveDictionaryUtil.getDimension(fieldIndex++, row));
+        dataOutputStream.writeInt((Integer) NonDictionaryUtil.getDimension(fieldIndex++, row));
       }
 
       //write byte[] of high card dims
       if (noDictionaryCount > 0) {
-        dataOutputStream.write(RemoveDictionaryUtil.getByteArrayForNoDictionaryCols(row));
+        dataOutputStream.write(NonDictionaryUtil.getByteArrayForNoDictionaryCols(row));
       }
       fieldIndex = 0;
       for (int counter = 0; counter < complexDimensionCount; counter++) {
@@ -66,7 +66,7 @@ public class UnCompressedTempSortFileWriter extends AbstractTempSortFileWriter {
       for (int counter = 0; counter < measureCount; counter++) {
         if (null != row[fieldIndex]) {
           dataOutputStream.write((byte) 1);
-          dataOutputStream.writeDouble((Double) RemoveDictionaryUtil.getMeasure(fieldIndex, row));
+          dataOutputStream.writeDouble((Double) NonDictionaryUtil.getMeasure(fieldIndex, row));
         } else {
           dataOutputStream.write((byte) 0);
         }

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdatastep/SortKeyStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdatastep/SortKeyStep.java
@@ -28,7 +28,7 @@ import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAn
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortDataRows;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortIntermediateFileMerger;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortParameters;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -136,7 +136,7 @@ public class SortKeyStep extends BaseStep {
     }
 
     // check if all records are null than send empty row to next step
-    else if (RemoveDictionaryUtil.checkAllValuesForNull(row)) {
+    else if (NonDictionaryUtil.checkAllValuesForNull(row)) {
       // create empty row out size
       int outSize = Integer.parseInt(meta.getOutputRowSize());
 
@@ -171,10 +171,10 @@ public class SortKeyStep extends BaseStep {
       this.meta.getFields(data.getOutputRowMeta(), getStepname(), null, null, this);
 
       this.meta.setNoDictionaryCount(
-          RemoveDictionaryUtil.extractNoDictionaryCount(meta.getNoDictionaryDims()));
+          NonDictionaryUtil.extractNoDictionaryCount(meta.getNoDictionaryDims()));
 
       this.noDictionaryColMaping =
-          RemoveDictionaryUtil.convertStringToBooleanArr(meta.getNoDictionaryDimsMapping());
+          NonDictionaryUtil.convertStringToBooleanArr(meta.getNoDictionaryDimsMapping());
       SortParameters parameters =
           SortParameters.createSortParameters(meta.getDatabaseName(), meta.getTabelName(),
               meta.getDimensionCount(), meta.getComplexDimensionCount(), meta.getMeasureCount(),

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -76,7 +76,7 @@ import org.apache.carbondata.processing.store.writer.CarbonDataWriterVo;
 import org.apache.carbondata.processing.store.writer.CarbonFactDataWriter;
 import org.apache.carbondata.processing.store.writer.exception.CarbonDataWriterException;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 import org.apache.spark.sql.types.Decimal;
 
@@ -263,6 +263,9 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
   private long schemaUpdatedTimeStamp;
 
   private String segmentId;
+
+  private int taskExtension;
+
   /**
    * current data format version
    */
@@ -288,6 +291,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
     this.aggKeyBlock = new boolean[columnStoreCount];
     this.isNoDictionary = new boolean[columnStoreCount];
     this.bucketNumber = carbonFactDataHandlerModel.getBucketId();
+    this.taskExtension = carbonFactDataHandlerModel.getTaskExtension();
     this.isUseInvertedIndex = new boolean[columnStoreCount];
     if (null != carbonFactDataHandlerModel.getIsUseInvertedIndex()) {
       for (int i = 0; i < isUseInvertedIndex.length; i++) {
@@ -784,7 +788,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
       noDictionaryColumnsData = new byte[noDictionaryCount][noDictionaryData.length][];
       for (int i = 0; i < noDictionaryData.length; i++) {
         int complexColumnIndex = primitiveDimLens.length + noDictionaryCount;
-        byte[][] splitKey = RemoveDictionaryUtil
+        byte[][] splitKey = NonDictionaryUtil
             .splitNoDictionaryKey(noDictionaryData[i], noDictionaryCount + complexIndexMap.size());
 
         int complexTypeIndex = 0;
@@ -1013,9 +1017,9 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
     byte[] composedNonDictEndKey = null;
     if (noDictionaryStartKey != null) {
       composedNonDictStartKey =
-          RemoveDictionaryUtil.packByteBufferIntoSingleByteArray(noDictionaryStartKey);
+          NonDictionaryUtil.packByteBufferIntoSingleByteArray(noDictionaryStartKey);
       composedNonDictEndKey =
-          RemoveDictionaryUtil.packByteBufferIntoSingleByteArray(noDictionaryEndKey);
+          NonDictionaryUtil.packByteBufferIntoSingleByteArray(noDictionaryEndKey);
     }
     return this.dataWriter
         .buildDataNodeHolder(blockStorage, dataHolderLocal, entryCountLocal, startkeyLocal,
@@ -1430,6 +1434,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
     carbonDataWriterVo.setSegmentProperties(segmentProperties);
     carbonDataWriterVo.setTableBlocksize(tableBlockSize);
     carbonDataWriterVo.setBucketNumber(bucketNumber);
+    carbonDataWriterVo.setTaskExtension(taskExtension);
     carbonDataWriterVo.setSchemaUpdatedTimeStamp(schemaUpdatedTimeStamp);
     return carbonDataWriterVo;
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -185,13 +185,16 @@ public class CarbonFactDataHandlerModel {
    */
   private long schemaUpdatedTimeStamp;
 
+  private int taskExtension;
+
   /**
    * Create the model using @{@link CarbonDataLoadConfiguration}
    * @param configuration
    * @return CarbonFactDataHandlerModel
    */
   public static CarbonFactDataHandlerModel createCarbonFactDataHandlerModel(
-      CarbonDataLoadConfiguration configuration, String storeLocation, int bucketId) {
+      CarbonDataLoadConfiguration configuration, String storeLocation, int bucketId,
+      int taskExtension) {
 
     CarbonTableIdentifier identifier =
         configuration.getTableIdentifier().getCarbonTableIdentifier();
@@ -200,8 +203,7 @@ public class CarbonFactDataHandlerModel {
     boolean[] isUseInvertedIndex =
         CarbonDataProcessorUtil.getIsUseInvertedIndex(configuration.getDataFields());
 
-    int[] dimLensWithComplex =
-        (int[]) configuration.getDataLoadProperty(DataLoadProcessorConstants.DIMENSION_LENGTHS);
+    int[] dimLensWithComplex = configuration.getCardinalityFinder().getCardinality();
     List<Integer> dimsLenList = new ArrayList<Integer>();
     for (int eachDimLen : dimLensWithComplex) {
       if (eachDimLen != 0) dimsLenList.add(eachDimLen);
@@ -293,6 +295,7 @@ public class CarbonFactDataHandlerModel {
     }
     carbonFactDataHandlerModel.bucketId = bucketId;
     carbonFactDataHandlerModel.segmentId = configuration.getSegmentId();
+    carbonFactDataHandlerModel.taskExtension = taskExtension;
     return carbonFactDataHandlerModel;
   }
 
@@ -523,6 +526,10 @@ public class CarbonFactDataHandlerModel {
 
   public void setSegmentId(String segmentId) {
     this.segmentId = segmentId;
+  }
+
+  public int getTaskExtension() {
+    return taskExtension;
   }
 }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -288,7 +288,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     initFileCount();
     String carbonDataFileName = carbonTablePath
         .getCarbonDataFileName(fileCount, dataWriterVo.getCarbonDataFileAttributes().getTaskId(),
-            dataWriterVo.getBucketNumber(),
+            dataWriterVo.getBucketNumber(), dataWriterVo.getTaskExtension(),
             dataWriterVo.getCarbonDataFileAttributes().getFactTimeStamp());
     String actualFileNameVal = carbonDataFileName + CarbonCommonConstants.FILE_INPROGRESS_STATUS;
     FileData fileData = new FileData(actualFileNameVal, dataWriterVo.getStoreLocation());
@@ -340,7 +340,6 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
   /**
    * Below method will be used to fill the vlock info details
    *
-   * @param infoList        info list
    * @param numberOfRows    number of rows in file
    * @param filePath        file path
    * @param currentPosition current offset
@@ -440,7 +439,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     List<BlockIndex> blockIndexThrift = CarbonMetadataUtil.getBlockIndexInfo(blockIndexInfoList);
     String fileName = dataWriterVo.getStoreLocation() + File.separator + carbonTablePath
         .getCarbonIndexFileName(dataWriterVo.getCarbonDataFileAttributes().getTaskId(),
-            dataWriterVo.getBucketNumber(),
+            dataWriterVo.getBucketNumber(), dataWriterVo.getTaskExtension(),
             dataWriterVo.getCarbonDataFileAttributes().getFactTimeStamp());
     CarbonIndexFileWriter writer = new CarbonIndexFileWriter();
     // open file

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/CarbonDataWriterVo.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/CarbonDataWriterVo.java
@@ -68,6 +68,8 @@ public class CarbonDataWriterVo {
 
   private long schemaUpdatedTimeStamp;
 
+  private int taskExtension;
+
   /**
    * @return the storeLocation
    */
@@ -319,5 +321,13 @@ public class CarbonDataWriterVo {
    */
   public void setSchemaUpdatedTimeStamp(long schemaUpdatedTimeStamp) {
     this.schemaUpdatedTimeStamp = schemaUpdatedTimeStamp;
+  }
+
+  public int getTaskExtension() {
+    return taskExtension;
+  }
+
+  public void setTaskExtension(int taskExtension) {
+    this.taskExtension = taskExtension;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
@@ -36,7 +36,7 @@ import org.apache.carbondata.processing.schema.metadata.ColumnSchemaDetailsWrapp
 import org.apache.carbondata.processing.schema.metadata.HierarchiesInfo;
 import org.apache.carbondata.processing.schema.metadata.TableOptionWrapper;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Counter;
@@ -670,7 +670,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     tableOptionWrapper.populateTableOptions(tableOption);
 
     updateDimensions(carbondim, carbonmsr, noDictionaryDims);
-    dimColDataTypes = RemoveDictionaryUtil.extractDimColsDataTypeValues(columnsDataTypeString);
+    dimColDataTypes = NonDictionaryUtil.extractDimColsDataTypeValues(columnsDataTypeString);
     if (null != complexTypeString) {
       complexTypes = getComplexTypesMap(complexTypeString);
     } else {
@@ -1073,7 +1073,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     dimColNames = list.toArray(new String[list.size()]);
 
     // get high cardinality dimension Array
-    noDictionaryCols = RemoveDictionaryUtil.extractNoDictionaryDimsArr(noDictionaryDims);
+    noDictionaryCols = NonDictionaryUtil.extractNoDictionaryDimsArr(noDictionaryDims);
 
     String[] sm = null;
     if (null != msr) {

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -72,7 +72,7 @@ import org.apache.carbondata.processing.schema.metadata.ColumnSchemaDetailsWrapp
 import org.apache.carbondata.processing.schema.metadata.ColumnsInfo;
 import org.apache.carbondata.processing.schema.metadata.HierarchiesInfo;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
-import org.apache.carbondata.processing.util.RemoveDictionaryUtil;
+import org.apache.carbondata.processing.util.NonDictionaryUtil;
 import static org.apache.carbondata.processing.constants.TableOptionConstant.BAD_RECORDS_ACTION;
 import static org.apache.carbondata.processing.constants.TableOptionConstant.BAD_RECORDS_LOGGER_ENABLE;
 import static org.apache.carbondata.processing.constants.TableOptionConstant.SERIALIZATION_NULL_FORMAT;
@@ -934,8 +934,8 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
       Object[] out = populateOutputRow(r);
       if (out != null) {
         for (int i = 0; i < meta.normLength - meta.complexTypes.size(); i++) {
-          if (null == RemoveDictionaryUtil.getDimension(i, out)) {
-            RemoveDictionaryUtil.setDimension(i, 1, out);
+          if (null == NonDictionaryUtil.getDimension(i, out)) {
+            NonDictionaryUtil.setDimension(i, 1, out);
           }
         }
       }
@@ -1279,7 +1279,7 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
     }
 
     insertHierIfRequired(out);
-    RemoveDictionaryUtil
+    NonDictionaryUtil
         .prepareOut(newArray, byteBufferArr, out, dimLen - meta.complexTypes.size());
 
     return newArray;

--- a/processing/src/main/java/org/apache/carbondata/processing/util/NonDictionaryUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/NonDictionaryUtil.java
@@ -32,7 +32,7 @@ import org.apache.carbondata.core.constants.IgnoreDictionary;
 /**
  * This is the utility class for No Dictionary changes.
  */
-public class RemoveDictionaryUtil {
+public class NonDictionaryUtil {
   /**
    * Here we are dividing one single object [] into 3 arrays. one for
    * dimensions , one for high card, one for measures.
@@ -44,7 +44,7 @@ public class RemoveDictionaryUtil {
       int dimCount) {
 
     byte[] nonDictionaryCols =
-        RemoveDictionaryUtil.packByteBufferIntoSingleByteArray(byteBufferArr);
+        NonDictionaryUtil.packByteBufferIntoSingleByteArray(byteBufferArr);
     Integer[] dimArray = new Integer[dimCount];
     for (int i = 0; i < dimCount; i++) {
       dimArray[i] = (Integer) out[i];
@@ -388,7 +388,7 @@ public class RemoveDictionaryUtil {
       buffArr[index++].rewind();
     }
 
-    return RemoveDictionaryUtil.packByteBufferIntoSingleByteArray(buffArr);
+    return NonDictionaryUtil.packByteBufferIntoSingleByteArray(buffArr);
 
   }
 


### PR DESCRIPTION
To make sort step as non blocking step, implemented batch sorting so user can configure how much data can be sorted at once in memory and written to disk.

New classes are implemented 
`UnsafeBatchParallelReadMergeSorterImpl` This class receives the data from converter step and sorts the data in batches and sends to writer step.
`DataWriterBatchProcessorStepImpl` It receives the data in batches and write directly to the file in carbondata format.

Please notice that here `UnsafeBatchParallelReadMergeSorterImpl` is non blocking step , as soon as it sorts the batch data and sends to writer, it starts sorting for next batch with out waiting for `DataWriterBatchProcessorStepImpl` to consume it.

Configurations :

`carbon.load.use.batch.sort` it enables batch sort while loading the data. By default it is true.

`carbon.load.batch.sort.size.inmb` Size of data in mb to be processed in batch. By default it is the 45 percent size of  `sort.inmemory.size.inmb`. User can configure the size on his wish but it is recommendable to keep it less then 45 percent of `sort.inmemory.size.inmb` otherwise it may start spilling the intermediate temp data to disk, so it may slow down the loading process.