### PR TITLE
[CARBONDATA-738] resolved bug for Able to load dataframe with boolean type in a carbon…

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -166,7 +166,6 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) {
       case LongType => CarbonType.LONG.getName
       case FloatType => CarbonType.DOUBLE.getName
       case DoubleType => CarbonType.DOUBLE.getName
-      case BooleanType => CarbonType.DOUBLE.getName
       case TimestampType => CarbonType.TIMESTAMP.getName
       case DateType => CarbonType.DATE.getName
       case other => sys.error(s"unsupported type: $other")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -150,7 +150,6 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
       case LongType => CarbonType.LONG.getName
       case FloatType => CarbonType.DOUBLE.getName
       case DoubleType => CarbonType.DOUBLE.getName
-      case BooleanType => CarbonType.DOUBLE.getName
       case TimestampType => CarbonType.TIMESTAMP.getName
       case DateType => CarbonType.DATE.getName
       case other => sys.error(s"unsupported type: $other")


### PR DESCRIPTION
i created a dataframe with boolean type as follows
case class People(name: String, occupation: String, consultant: Boolean)
val people = List(People("sangeeta", "engineer", true), People("pallavi", "consultant", true))
val peopleRDD: RDD[People] = cc.sc.parallelize(people)
val peopleDF: DataFrame = peopleRDD.toDF("name", "occupation", "id")
peopleDF.write
.format("carbondata")
.option("tableName", "carbon2")
.option("compress", "true")
.mode(SaveMode.Overwrite)
.save()
cc.sql("SELECT * FROM carbon2").show()
currently boolean type is not supported in carbon data but table gets created
but it shows me null values
------------------
name	occupation	id
------------------
pallavi	consultant	null
sangeeta	engineer	null
------------------
for boolean type it should throw unsupported type exception it is not supported in carbon data

there is problem with carbondataframe writer

