### PR TITLE
CARBONDATA-748

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -152,6 +152,159 @@ public final class ByteUtil {
       return (x1 + Long.MIN_VALUE) < (x2 + Long.MIN_VALUE);
     }
 
+
+/*		public static int binarySearch(byte[] a, int fromIndex, int toIndex, byte[] key) {
+			int keyLength = key.length;
+			rangeCheck(a.length, fromIndex, toIndex, keyLength);
+			return binarySearch0(a, fromIndex, toIndex / keyLength, key);
+		}
+
+		// Like public version, but without range checks.
+		private static int binarySearch0(byte[] a, int fromIndex, int toIndex, byte[] key) {
+			int low = fromIndex;
+			int high = toIndex - 1;
+			int keyLength = key.length;
+			// int high = toIndex/keyLength;
+
+			while (low <= high) {
+				int mid = (low + high) >>> 1;
+				// byte midVal = a[mid];
+
+				int result = ByteUtil.UnsafeComparer.INSTANCE.compareTo(a, mid * keyLength, keyLength, key, 0,
+						keyLength);
+
+				if (result < 0)
+					low = mid + keyLength;
+				else if (result > 0)
+					high = mid - keyLength;
+				else
+					return mid; // key found
+			}
+			return -(low + 1); // key not found.
+		}*/
+	/**
+	 * Checks that {@code fromIndex} and {@code toIndex} are in the range and toIndex % keyLength = 0
+	 * and throws an exception if they aren't.
+	 */
+	private static void rangeCheck(int arrayLength, int fromIndex, int toIndex, int keyWordLength) {
+		if (fromIndex > toIndex || toIndex % keyWordLength != 0) {
+			throw new IllegalArgumentException("fromIndex(" + fromIndex + ") > toIndex(" + toIndex + ")");
+		}
+		if (fromIndex < 0) {
+			throw new ArrayIndexOutOfBoundsException(fromIndex);
+		}
+		if (toIndex > arrayLength) {
+			throw new ArrayIndexOutOfBoundsException(toIndex);
+		}
+	}
+	
+	/**
+	 * search a specific key's range boundary in sorted byte array
+	 * 
+	 * @param dataChunk
+	 * @param fromIndex
+	 * @param toIndex
+	 *            it's max value should be word Number in dataChunk, equal to indataChunk.length/keyWord.length
+	 * @param keyWord
+	 * @return int[] contains a range's lower boundary and upper boundary
+	 */
+	public static int[] binaryRangeSearch(byte[] dataChunk, int fromIndex, int toIndex, byte[] keyWord) {
+
+
+		int keyLength = keyWord.length;
+		rangeCheck(dataChunk.length, fromIndex, toIndex, keyLength);
+		
+		// reset to index =  word total number in the dataChunk
+		toIndex = toIndex/keyWord.length;	
+		
+		int[] rangeIndex = new int[2];
+		int low = fromIndex;
+		int high = toIndex - 1;
+
+		while (low <= high) {
+			int mid = (low + high) >>> 1;
+
+			int result = ByteUtil.UnsafeComparer.INSTANCE.compareTo(dataChunk, mid * keyLength, keyLength, keyWord, 0,
+					keyLength);
+
+			if (result < 0)
+				low = mid + 1;
+			else if (result > 0)
+				high = mid - 1;
+			else {
+				// key found  then find the range bound
+				rangeIndex[0] = binaryRangeBoundarySearch(dataChunk, low, mid, keyWord, false);
+				rangeIndex[1] = binaryRangeBoundarySearch(dataChunk, mid, high, keyWord, true);
+				return rangeIndex;
+			}
+
+		}
+		// key not found. return a not exist range
+		rangeIndex[0] = 0;
+		rangeIndex[1] = -1;
+		return rangeIndex;
+	}
+
+  /**
+   * use to search a specific keyword's lower boundary and upper boundary according to upFindFlg
+   * @param dataChunk
+   * @param fromIndex
+   * @param toIndex
+   * @param keyWord
+   * @param upFindFlg true:find upper boundary  false: find lower boundary
+   * @return boundary index 
+   */
+	public static int binaryRangeBoundarySearch(byte[] dataChunk, int fromIndex, int toIndex, byte[] keyWord, boolean upFindFlg) {
+		int low = fromIndex;
+		int high = toIndex;
+		int keyLength = keyWord.length;
+
+		while (low <= high) {
+			int mid = (low + high) >>> 1;
+
+			int result1 = ByteUtil.UnsafeComparer.INSTANCE.compareTo(dataChunk, mid * keyLength, keyLength, keyWord, 0,
+					keyLength);
+
+			if (upFindFlg) {
+				if (result1 == 0) {
+
+					low = mid + 1;
+				} else if (result1 > 0) {
+
+					high = mid - 1;
+					int result2 = ByteUtil.UnsafeComparer.INSTANCE.compareTo(dataChunk, high * keyLength, keyLength, keyWord, 0,
+							keyLength);
+					if (result2 == 0) {
+						return high;
+					}
+				} else {
+					throw new UnsupportedOperationException();
+				}
+			} else {
+
+				if (result1 == 0) {
+
+					high = mid - 1;
+				} else if (result1 < 0) {
+					low = mid + 1;
+					int result2 = ByteUtil.UnsafeComparer.INSTANCE.compareTo(dataChunk, low * keyLength, keyLength, keyWord, 0,
+							keyLength);
+					if (result2 == 0) {
+						return low;
+					}
+				} else {
+					throw new UnsupportedOperationException();
+				}
+
+			}
+		}
+		if (upFindFlg) {
+			return high;
+		} else {
+			return low;
+		}
+	}
+
     /**
      * Lexicographically compare two arrays.
      *

--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -152,42 +152,12 @@ public final class ByteUtil {
       return (x1 + Long.MIN_VALUE) < (x2 + Long.MIN_VALUE);
     }
 
-
-/*		public static int binarySearch(byte[] a, int fromIndex, int toIndex, byte[] key) {
-			int keyLength = key.length;
-			rangeCheck(a.length, fromIndex, toIndex, keyLength);
-			return binarySearch0(a, fromIndex, toIndex / keyLength, key);
-		}
-
-		// Like public version, but without range checks.
-		private static int binarySearch0(byte[] a, int fromIndex, int toIndex, byte[] key) {
-			int low = fromIndex;
-			int high = toIndex - 1;
-			int keyLength = key.length;
-			// int high = toIndex/keyLength;
-
-			while (low <= high) {
-				int mid = (low + high) >>> 1;
-				// byte midVal = a[mid];
-
-				int result = ByteUtil.UnsafeComparer.INSTANCE.compareTo(a, mid * keyLength, keyLength, key, 0,
-						keyLength);
-
-				if (result < 0)
-					low = mid + keyLength;
-				else if (result > 0)
-					high = mid - keyLength;
-				else
-					return mid; // key found
-			}
-			return -(low + 1); // key not found.
-		}*/
 	/**
 	 * Checks that {@code fromIndex} and {@code toIndex} are in the range and toIndex % keyLength = 0
 	 * and throws an exception if they aren't.
 	 */
 	private static void rangeCheck(int arrayLength, int fromIndex, int toIndex, int keyWordLength) {
-		if (fromIndex > toIndex || toIndex % keyWordLength != 0) {
+		if (fromIndex > toIndex) {
 			throw new IllegalArgumentException("fromIndex(" + fromIndex + ") > toIndex(" + toIndex + ")");
 		}
 		if (fromIndex < 0) {
@@ -195,6 +165,9 @@ public final class ByteUtil {
 		}
 		if (toIndex > arrayLength) {
 			throw new ArrayIndexOutOfBoundsException(toIndex);
+		}		
+		if (toIndex % keyWordLength != 0) {
+			throw new IllegalArgumentException("toIndex(" + toIndex + ") % keyWordLength(" + keyWordLength + ") != 0");
 		}
 	}
 	

--- a/core/src/main/java/org/apache/carbondata/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -154,24 +154,45 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
   }
 
   private BitSet setFilterdIndexToBitSet(DimensionColumnDataChunk dimensionColumnDataChunk,
-      int numerOfRows) {
-    BitSet bitSet = new BitSet(numerOfRows);
-    if (dimensionColumnDataChunk instanceof FixedLengthDimensionDataChunk) {
-      FixedLengthDimensionDataChunk fixedDimensionChunk =
-          (FixedLengthDimensionDataChunk) dimensionColumnDataChunk;
-      byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
-      for (int k = 0; k < filterValues.length; k++) {
-        for (int j = 0; j < numerOfRows; j++) {
-          if (ByteUtil.UnsafeComparer.INSTANCE
-              .compareTo(fixedDimensionChunk.getCompleteDataChunk(), j * filterValues[k].length,
-                  filterValues[k].length, filterValues[k], 0, filterValues[k].length) == 0) {
-            bitSet.set(j);
-          }
-        }
-      }
-    }
-    return bitSet;
-  }
+	      int numerOfRows) {
+
+	    BitSet bitSet = new BitSet(numerOfRows);
+	    //BitSet bitSet1 = new BitSet(numerOfRows);
+	    
+	    if (dimensionColumnDataChunk instanceof FixedLengthDimensionDataChunk) {
+	      FixedLengthDimensionDataChunk fixedDimensionChunk =
+	          (FixedLengthDimensionDataChunk) dimensionColumnDataChunk;
+	      byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
+	      byte[] dataChunk= fixedDimensionChunk.getCompleteDataChunk();
+
+		  //long start = System.currentTimeMillis();
+	      for (int k = 0; k < filterValues.length; k++) {
+	    	  
+	    	  int[] index = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, filterValues[k]);
+	    	  for(int i = index[0]; i<=index[1];i++){
+	    		  
+	    		  bitSet.set(i);
+	    	  }
+	      }
+	  
+	      //below comments code is used to confirm the binary range search is correct  
+	/*      System.out.println("optimizied time: "+(System.currentTimeMillis() - start));
+
+		  start = System.currentTimeMillis();
+	      for (int k = 0; k < filterValues.length; k++) {
+	        for (int j = 0; j < numerOfRows; j++) {
+	          if (ByteUtil.UnsafeComparer.INSTANCE
+	              .compareTo(fixedDimensionChunk.getCompleteDataChunk(), j * filterValues[k].length,
+	                  filterValues[k].length, filterValues[k], 0, filterValues[k].length) == 0) {
+	            bitSet1.set(j);
+	          }
+	        }
+	      }  
+	      System.out.println("non-optimized time: "+(System.currentTimeMillis() - start));
+	      System.out.println("set equal: " + bitSet.equals(bitSet1));*/  
+	    }
+	    return bitSet;
+	  }
 
   public BitSet isScanRequired(byte[][] blkMaxVal, byte[][] blkMinVal) {
     BitSet bitSet = new BitSet(1);

--- a/core/src/main/java/org/apache/carbondata/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -175,21 +175,6 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
 	    	  }
 	      }
 	  
-	      //below comments code is used to confirm the binary range search is correct  
-	/*      System.out.println("optimizied time: "+(System.currentTimeMillis() - start));
-
-		  start = System.currentTimeMillis();
-	      for (int k = 0; k < filterValues.length; k++) {
-	        for (int j = 0; j < numerOfRows; j++) {
-	          if (ByteUtil.UnsafeComparer.INSTANCE
-	              .compareTo(fixedDimensionChunk.getCompleteDataChunk(), j * filterValues[k].length,
-	                  filterValues[k].length, filterValues[k], 0, filterValues[k].length) == 0) {
-	            bitSet1.set(j);
-	          }
-	        }
-	      }  
-	      System.out.println("non-optimized time: "+(System.currentTimeMillis() - start));
-	      System.out.println("set equal: " + bitSet.equals(bitSet1));*/  
 	    }
 	    return bitSet;
 	  }

--- a/core/src/test/java/org/apache/carbondata/core/util/ByteUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/ByteUtilTest.java
@@ -133,6 +133,238 @@ public class ByteUtilTest extends TestCase {
         prepareBuffers();
         assertTrue(UnsafeComparer.INSTANCE.compareTo(buff1, buff2) < 0);
     }
+    
+
+	@Test
+	public void testBinaryRangeSearch() {
+
+		byte[] dataChunk = new byte[10];
+
+		dataChunk = "abbcccddddeffgggh".getBytes();
+		byte[] key = new byte[1];
+		int[] range;
+
+		key[0] = Byte.valueOf("97");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(0, range[0]);
+		this.assertEquals(0, range[1]);
+
+		key[0] = Byte.valueOf("104");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(16, range[0]);
+		this.assertEquals(16, range[1]);
+
+		key[0] = Byte.valueOf("101");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(10, range[0]);
+		this.assertEquals(10, range[1]);
+
+		key[0] = Byte.valueOf("99");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(3, range[0]);
+		this.assertEquals(5, range[1]);
+
+		dataChunk = "ab".getBytes();
+
+		key[0] = Byte.valueOf("97");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(0, range[0]);
+		this.assertEquals(0, range[1]);
+
+		key[0] = Byte.valueOf("98");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(1, range[0]);
+		this.assertEquals(1, range[1]);
+
+		dataChunk = "aabb".getBytes();
+
+		key[0] = Byte.valueOf("97");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(0, range[0]);
+		this.assertEquals(1, range[1]);
+
+		key[0] = Byte.valueOf("98");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(2, range[0]);
+		this.assertEquals(3, range[1]);
+
+		dataChunk = "a".getBytes();
+
+		key[0] = Byte.valueOf("97");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(0, range[0]);
+		this.assertEquals(0, range[1]);
+
+		dataChunk = "aa".getBytes();
+
+		key[0] = Byte.valueOf("97");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(0, range[0]);
+		this.assertEquals(1, range[1]);
+
+		dataChunk = "aabbbbbbbbbbcc".getBytes();
+		key[0] = Byte.valueOf("98");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length, key);
+		this.assertEquals(2, range[0]);
+		this.assertEquals(11, range[1]);
+
+	}
+
+	@Test
+	public void testBinaryRangeSearchLengthTwo() {
+
+		byte[] dataChunk = new byte[10];
+
+		dataChunk = "aabbbbbbbbbbcc".getBytes();
+		byte[] keyWord = new byte[2];
+		int[] range;
+
+		keyWord[0] = Byte.valueOf("98");
+		keyWord[1] = Byte.valueOf("98");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length ,
+				keyWord);
+		this.assertEquals(1, range[0]);
+		this.assertEquals(5, range[1]);
+
+		keyWord[0] = Byte.valueOf("97");
+		keyWord[1] = Byte.valueOf("97");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length ,
+				keyWord);
+		this.assertEquals(0, range[0]);
+		this.assertEquals(0, range[1]);
+
+		keyWord[0] = Byte.valueOf("99");
+		keyWord[1] = Byte.valueOf("99");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length ,
+				keyWord);
+		this.assertEquals(6, range[0]);
+		this.assertEquals(6, range[1]);
+
+	}
+
+	@Test
+	public void testBinaryRangeSearchLengthThree() {
+
+		byte[] dataChunk = new byte[10];
+
+		dataChunk = "aaabbbbbbbbbccc".getBytes();
+		byte[] keyWord = new byte[3];
+		int[] range;
+
+		keyWord[0] = Byte.valueOf("98");
+		keyWord[1] = Byte.valueOf("98");
+		keyWord[2] = Byte.valueOf("98");
+		range = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeSearch(dataChunk, 0, dataChunk.length ,
+				keyWord);
+		this.assertEquals(1, range[0]);
+		this.assertEquals(3, range[1]);
+
+	}
+
+	@Test
+	public void testbinaryRangeBoundarySearchLengthTwo() {
+
+		byte[] dataChunk = new byte[10];
+		byte[] keyWord = new byte[2];
+		int[] expectRangeIndex = new int[2];
+		int[] lowRangeIndex = new int[2];
+		int[] midRangeIndex = new int[2];
+		int[] highRangeIndex = new int[2];
+
+		// 0-4 5-10 11-17
+		dataChunk = "abababababacacacacacacadadadadadadad".getBytes();
+
+		keyWord[0] = Byte.valueOf("97");
+		keyWord[1] = Byte.valueOf("100");
+		expectRangeIndex[0] = 11;
+		expectRangeIndex[1] = 17;
+		lowRangeIndex[0] = 0;
+		lowRangeIndex[1] = 11;
+		midRangeIndex[0] = 11;
+		midRangeIndex[1] = 17;
+		highRangeIndex[0] = 17;
+		highRangeIndex[1] = 17;
+
+		testRangeboundary(dataChunk, keyWord, expectRangeIndex, lowRangeIndex, midRangeIndex, highRangeIndex);
+
+		keyWord[0] = Byte.valueOf("97");
+		keyWord[1] = Byte.valueOf("98");
+		expectRangeIndex[0] = 0;
+		expectRangeIndex[1] = 4;
+		lowRangeIndex[0] = 0;
+		lowRangeIndex[1] = 0;
+		midRangeIndex[0] = 0;
+		midRangeIndex[1] = 4;
+		highRangeIndex[0] = 4;
+		highRangeIndex[1] = 17;
+
+		testRangeboundary(dataChunk, keyWord, expectRangeIndex, lowRangeIndex, midRangeIndex, highRangeIndex);
+
+		keyWord[0] = Byte.valueOf("97");
+		keyWord[1] = Byte.valueOf("99");
+		expectRangeIndex[0] = 5;
+		expectRangeIndex[1] = 10;
+		lowRangeIndex[0] = 0;
+		lowRangeIndex[1] = 5;
+		midRangeIndex[0] = 5;
+		midRangeIndex[1] = 10;
+		highRangeIndex[0] = 10;
+		highRangeIndex[1] = 17;
+
+		testRangeboundary(dataChunk, keyWord, expectRangeIndex, lowRangeIndex, midRangeIndex, highRangeIndex);
+		
+		
+		// 0-4
+		dataChunk = "aaaaaaaaaa".getBytes();
+		keyWord[0] = Byte.valueOf("97");
+		keyWord[1] = Byte.valueOf("97");
+		expectRangeIndex[0] = 0;
+		expectRangeIndex[1] = 4;
+		lowRangeIndex[0] = 0;
+		lowRangeIndex[1] = 0;
+		midRangeIndex[0] = 0;
+		midRangeIndex[1] = 4;
+		highRangeIndex[0] = 4;
+		highRangeIndex[1] = 4;
+
+		testRangeboundary(dataChunk, keyWord, expectRangeIndex, lowRangeIndex, midRangeIndex, highRangeIndex);
+
+	}
+
+	/**
+	 * use to test a specific key's range bound in sorted byte array
+	 *
+	 * @param dataChunk
+	 *            is a sorted byte array according to filter value's
+	 * @param keyWord
+	 *            is a specific value
+	 * @param expectRangeIndex
+	 * @param lowRangeIndex
+	 * @param midRangeIndex
+	 * @param highRangeIndex
+	 * @return
+	 */
+	private void testRangeboundary(byte[] dataChunk, byte[] keyWord, int[] expectRangeIndex, int[] lowRangeIndex,
+			int[] midRangeIndex, int[] highRangeIndex) {
+		for (int low = lowRangeIndex[0]; low <= lowRangeIndex[1]; low++) {
+			for (int mid = midRangeIndex[0]; mid <= midRangeIndex[1]; mid++) {
+				for (int high = highRangeIndex[0]; high <= highRangeIndex[1]; high++) {
+//					System.out.print("");
+//					System.out.print("low: " + low);
+//					System.out.print(" mid: " + mid);
+//					System.out.println(" high: " + high);
+					int boundIndex;
+					// lower limit
+					boundIndex = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeBoundarySearch(dataChunk, low, mid, keyWord, false);
+					this.assertEquals(expectRangeIndex[0], boundIndex);
+					// upper limit
+					boundIndex = ByteUtil.UnsafeComparer.INSTANCE.binaryRangeBoundarySearch(dataChunk, mid, high, keyWord, true);
+					this.assertEquals(expectRangeIndex[1], boundIndex);
+				}
+			}
+		}
+	}
+    
 
     /**
      * This will prepare the byte buffers in the required format for comparision.


### PR DESCRIPTION
fix jira CARBONDATA-748, use binary search to replace linear search
the performance is much better no ,from more than 10 seconds to a few millisecond