### PR TITLE
[CARBONDATA-730] added decimal type in carbon data frame writer

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -201,4 +201,5 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) {
     }
   }
 
+
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/CarbonDataFrameWriter.scala
@@ -168,6 +168,8 @@ class CarbonDataFrameWriter(val dataFrame: DataFrame) {
       case DoubleType => CarbonType.DOUBLE.getName
       case TimestampType => CarbonType.TIMESTAMP.getName
       case DateType => CarbonType.DATE.getName
+      case decimal: DecimalType => s"${CarbonType.DECIMAL.getName} (${decimal.precision}" +
+                                   s", ${decimal.scale})"
       case other => sys.error(s"unsupported type: $other")
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -152,6 +152,8 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
       case DoubleType => CarbonType.DOUBLE.getName
       case TimestampType => CarbonType.TIMESTAMP.getName
       case DateType => CarbonType.DATE.getName
+      case decimal: DecimalType => s"${CarbonType.DECIMAL.getName} (${decimal.precision}" +
+                                   s", ${decimal.scale})"
       case other => sys.error(s"unsupported type: $other")
     }
   }


### PR DESCRIPTION
Below exception is thrown while trying to save dataframe with a decimal column type.

scala> df.printSchema
– account: integer (nullable = true)
– currency: integer (nullable = true)
– branch: integer (nullable = true)
– country: integer (nullable = true)
– date: date (nullable = true)
– fcbalance: decimal(16,3) (nullable = true)
– lcbalance: decimal(16,3) (nullable = true)

scala> df.write.format("carbondata").option("tableName", "accBal").option("compress", "true").mode(SaveMode.Overwrite).save()

java.lang.RuntimeException: unsupported type: DecimalType(16,3)
at scala.sys.package$.error(package.scala:27)
           
