### PR TITLE
[CARBONDATA-752]  solved bug for complex type give exception in spark2.1

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -56,9 +56,14 @@ object DataTypeConverterUtil {
       case "decimaltype" => DataType.DECIMAL
       case "timestamptype" => DataType.TIMESTAMP
       case "datetype" => DataType.DATE
-      case "arraytype" => DataType.ARRAY
-      case "structtype" => DataType.STRUCT
-      case _ => sys.error(s"Unsupported data type: $dataType")
+      case others =>
+        if (others != null && others.startsWith("arraytype")) {
+          DataType.ARRAY
+        } else if (others != null && others.startsWith("structtype")) {
+          DataType.STRUCT
+        } else {
+          sys.error(s"Unsupported data type: $dataType")
+        }
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexTypeQuery.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexTypeQuery.scala
@@ -28,139 +28,262 @@ import org.scalatest.BeforeAndAfterAll
 class TestComplexTypeQuery extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll: Unit = {
-     sql("drop table if exists complexcarbontable").show
-     sql("drop table if exists complexhivetable").show
-     sql("drop table if exists complex_filter").show
-     sql("drop table if exists structusingstructCarbon").show
-     sql("drop table if exists structusingstructHive").show
-     sql("drop table if exists structusingarraycarbon").show
-     sql("drop table if exists structusingarrayhive").show
-     sql("create table complexcarbontable(deviceInformationId int, channelsId string, ROMSize string, ROMName String, purchasedate string, mobile struct<imei:string, imsi:string>, MAC array<string>, locationinfo array<struct<ActiveAreaId:int, ActiveCountry:string, ActiveProvince:string, Activecity:string, ActiveDistrict:string, ActiveStreet:string>>, proddate struct<productionDate:string,activeDeactivedate:array<string>>, gamePointId double,contractNumber double)  STORED BY 'org.apache.carbondata.format'  TBLPROPERTIES ('DICTIONARY_INCLUDE'='deviceInformationId', 'DICTIONARY_EXCLUDE'='channelsId','COLUMN_GROUP'='(ROMSize,ROMName)')");
-     sql("LOAD DATA local inpath '" + resourcesPath + "/complextypesample.csv' INTO table complexcarbontable  OPTIONS('DELIMITER'=',', 'QUOTECHAR'='\"', 'FILEHEADER'='deviceInformationId,channelsId,ROMSize,ROMName,purchasedate,mobile,MAC,locationinfo,proddate,gamePointId,contractNumber', 'COMPLEX_DELIMITER_LEVEL_1'='$', 'COMPLEX_DELIMITER_LEVEL_2'=':')");
-     sql("create table complexhivetable(deviceInformationId int, channelsId string, ROMSize string, ROMName String, purchasedate string, mobile struct<imei:string, imsi:string>, MAC array<string>, locationinfo array<struct<ActiveAreaId:int, ActiveCountry:string, ActiveProvince:string, Activecity:string, ActiveDistrict:string, ActiveStreet:string>>, proddate struct<productionDate:string,activeDeactivedate:array<string>>, gamePointId double,contractNumber double)row format delimited fields terminated by ',' collection items terminated by '$' map keys terminated by ':'")
-     sql(s"LOAD DATA local inpath '$resourcesPath/complextypesample.csv' INTO table complexhivetable");
-     sql("create table complex_filter(test1 int, test2 array<String>,test3 array<bigint>,test4 array<int>,test5 array<decimal>,test6 array<timestamp>,test7 array<double>) STORED BY 'org.apache.carbondata.format'")
-     sql("LOAD DATA INPATH '" + resourcesPath + "/array1.csv'  INTO TABLE complex_filter options ('DELIMITER'=',', 'QUOTECHAR'='\"', 'COMPLEX_DELIMITER_LEVEL_1'='$', 'FILEHEADER'= 'test1,test2,test3,test4,test5,test6,test7')").show()
-     
-     sql("create table structusingarraycarbon (MAC struct<MAC1:array<string>,ActiveCountry:array<string>>) STORED BY 'org.apache.carbondata.format'");
-     sql("LOAD DATA local INPATH '" + resourcesPath + "/struct_all.csv' INTO table structusingarraycarbon options ('DELIMITER'=',', 'QUOTECHAR'='\"', 'FILEHEADER'='MAC','COMPLEX_DELIMITER_LEVEL_1'='$','COMPLEX_DELIMITER_LEVEL_2'='&')")
-     sql("create table structusingarrayhive (MAC struct<MAC1:array<string>,ActiveCountry:array<string>>)row format delimited fields terminated by ',' collection items terminated by '$' map keys terminated by '&'");
-     sql("LOAD DATA local INPATH '" + resourcesPath + "/struct_all.csv' INTO table structusingarrayhive")
-     
-     sql("create table structusingstructCarbon(name struct<middlename:string, othernames:struct<firstname:string,lastname:string>,age:int> ) STORED BY 'org.apache.carbondata.format'")
-     sql("LOAD DATA local INPATH '" + resourcesPath + "/structusingstruct.csv' INTO table structusingstructCarbon options ('DELIMITER'=',', 'QUOTECHAR'='\"', 'FILEHEADER'='name','COMPLEX_DELIMITER_LEVEL_1'='$','COMPLEX_DELIMITER_LEVEL_2'='&')")
-      sql("create table structusingstructhive(name struct<middlename:string, othernames:struct<firstname:string,lastname:string>,age:int> )row format delimited fields terminated by ',' collection items terminated by '$' map keys terminated by '&'")
-     sql("LOAD DATA local INPATH '" + resourcesPath + "/structusingstruct.csv' INTO table structusingstructhive")
-     
+    sql("drop table if exists complexcarbontable").show
+    sql("drop table if exists complexhivetable").show
+    sql("drop table if exists complex_filter").show
+    sql("drop table if exists structusingstructCarbon").show
+    sql("drop table if exists structusingstructHive").show
+    sql("drop table if exists structusingarraycarbon").show
+    sql("drop table if exists structusingarrayhive").show
+    sql(
+      "create table complexcarbontable(deviceInformationId int, channelsId string, ROMSize " +
+      "string, ROMName String, purchasedate string, mobile struct<imei:string, imsi:string>, MAC " +
+      "array<string>, locationinfo array<struct<ActiveAreaId:int, ActiveCountry:string, " +
+      "ActiveProvince:string, Activecity:string, ActiveDistrict:string, ActiveStreet:string>>, " +
+      "proddate struct<productionDate:string,activeDeactivedate:array<string>>, gamePointId " +
+      "double,contractNumber double)  STORED BY 'org.apache.carbondata.format'  TBLPROPERTIES " +
+      "('DICTIONARY_INCLUDE'='deviceInformationId', 'DICTIONARY_EXCLUDE'='channelsId'," +
+      "'COLUMN_GROUP'='(ROMSize,ROMName)')")
+    sql("LOAD DATA local inpath '" + resourcesPath +
+        "/complextypesample.csv' INTO table complexcarbontable  OPTIONS('DELIMITER'=',', " +
+        "'QUOTECHAR'='\"', 'FILEHEADER'='deviceInformationId,channelsId,ROMSize,ROMName," +
+        "purchasedate,mobile,MAC,locationinfo,proddate,gamePointId,contractNumber', " +
+        "'COMPLEX_DELIMITER_LEVEL_1'='$', 'COMPLEX_DELIMITER_LEVEL_2'=':')");
+    sql(
+      "create table complexhivetable(deviceInformationId int, channelsId string, ROMSize string, " +
+      "ROMName String, purchasedate string, mobile struct<imei:string, imsi:string>, MAC " +
+      "array<string>, locationinfo array<struct<ActiveAreaId:int, ActiveCountry:string, " +
+      "ActiveProvince:string, Activecity:string, ActiveDistrict:string, ActiveStreet:string>>, " +
+      "proddate struct<productionDate:string,activeDeactivedate:array<string>>, gamePointId " +
+      "double,contractNumber double)row format delimited fields terminated by ',' collection " +
+      "items terminated by '$' map keys terminated by ':'")
+    sql(s"LOAD DATA local inpath '$resourcesPath/complextypesample.csv' INTO table " +
+        s"complexhivetable")
+    sql(
+      "create table complex_filter(test1 int, test2 array<String>,test3 array<bigint>,test4 " +
+      "array<int>,test5 array<decimal>,test6 array<timestamp>,test7 array<double>) STORED BY 'org" +
+      ".apache.carbondata.format'")
+    sql("LOAD DATA INPATH '" + resourcesPath +
+        "/array1.csv'  INTO TABLE complex_filter options ('DELIMITER'=',', 'QUOTECHAR'='\"', " +
+        "'COMPLEX_DELIMITER_LEVEL_1'='$', 'FILEHEADER'= 'test1,test2,test3,test4,test5,test6," +
+        "test7')")
+      .show()
+
+    sql(
+      "create table structusingarraycarbon (MAC struct<MAC1:array<string>," +
+      "ActiveCountry:array<string>>) STORED BY 'org.apache.carbondata.format'");
+    sql("LOAD DATA local INPATH '" + resourcesPath +
+        "/struct_all.csv' INTO table structusingarraycarbon options ('DELIMITER'=',', " +
+        "'QUOTECHAR'='\"', 'FILEHEADER'='MAC','COMPLEX_DELIMITER_LEVEL_1'='$'," +
+        "'COMPLEX_DELIMITER_LEVEL_2'='&')")
+    sql(
+      "create table structusingarrayhive (MAC struct<MAC1:array<string>," +
+      "ActiveCountry:array<string>>)row format delimited fields terminated by ',' collection " +
+      "items terminated by '$' map keys terminated by '&'");
+    sql("LOAD DATA local INPATH '" + resourcesPath +
+        "/struct_all.csv' INTO table structusingarrayhive")
+
+    sql(
+      "create table structusingstructCarbon(name struct<middlename:string, " +
+      "othernames:struct<firstname:string,lastname:string>,age:int> ) STORED BY 'org.apache" +
+      ".carbondata.format'")
+    sql("LOAD DATA local INPATH '" + resourcesPath +
+        "/structusingstruct.csv' INTO table structusingstructCarbon options ('DELIMITER'=',', " +
+        "'QUOTECHAR'='\"', 'FILEHEADER'='name','COMPLEX_DELIMITER_LEVEL_1'='$'," +
+        "'COMPLEX_DELIMITER_LEVEL_2'='&')")
+    sql(
+      "create table structusingstructhive(name struct<middlename:string, " +
+      "othernames:struct<firstname:string,lastname:string>,age:int> )row format delimited fields " +
+      "terminated by ',' collection items terminated by '$' map keys terminated by '&'")
+    sql("LOAD DATA local INPATH '" + resourcesPath +
+        "/structusingstruct.csv' INTO table structusingstructhive")
+
   }
-  
-  test("Test ^ * special character data loading for complex types") {
-    sql("create table complexcarbonwithspecialchardelimeter(deviceInformationId int, channelsId string, ROMSize string, ROMName String, purchasedate string, mobile struct<imei:string, imsi:string>, MAC array<string>, locationinfo array<struct<ActiveAreaId:int, ActiveCountry:string, ActiveProvince:string, Activecity:string, ActiveDistrict:string, ActiveStreet:string>>, proddate struct<productionDate:string,activeDeactivedate:array<string>>, gamePointId double,contractNumber double)  STORED BY 'org.apache.carbondata.format'  TBLPROPERTIES ('DICTIONARY_INCLUDE'='deviceInformationId', 'DICTIONARY_EXCLUDE'='channelsId','COLUMN_GROUP'='(ROMSize,ROMName)')");
-    sql("LOAD DATA local inpath '" + resourcesPath + "/complextypespecialchardelimiter.csv' INTO table complexcarbonwithspecialchardelimeter  OPTIONS('DELIMITER'=',', 'QUOTECHAR'='\"', 'FILEHEADER'='deviceInformationId,channelsId,ROMSize,ROMName,purchasedate,mobile,MAC,locationinfo,proddate,gamePointId,contractNumber', 'COMPLEX_DELIMITER_LEVEL_1'='^', 'COMPLEX_DELIMITER_LEVEL_2'='*')");
-    sql("create table complexhivewithspecialchardelimeter(deviceInformationId int, channelsId string, ROMSize string, ROMName String, purchasedate string, mobile struct<imei:string, imsi:string>, MAC array<string>, locationinfo array<struct<ActiveAreaId:int, ActiveCountry:string, ActiveProvince:string, Activecity:string, ActiveDistrict:string, ActiveStreet:string>>, proddate struct<productionDate:string,activeDeactivedate:array<string>>, gamePointId double,contractNumber double)row format delimited fields terminated by ',' collection items terminated by '^' map keys terminated by '*'")
-    sql("LOAD DATA local inpath '" + resourcesPath + "/complextypespecialchardelimiter.csv' INTO table complexhivewithspecialchardelimeter");
-    checkAnswer(sql("select * from complexcarbonwithspecialchardelimeter"), sql("select * from complexhivewithspecialchardelimeter"))
+
+  test("test for create table with complex type") {
+    try {
+      sql("drop table if exists carbon_table")
+      sql(
+        ("CREATE TABLE CARBON_TABLE(stringField string,complexData array<string>)stored by " +
+         "'CARBONDATA' ")
+          .stripMargin)
+      assert(true)
+    }
+    catch {
+      case exception: Exception => assert(false)
+    }
+  }
+
+  test(
+    "Test ^ * special character data loading for complex types") {
+    sql(
+      "create table complexcarbonwithspecialchardelimeter(deviceInformationId int, channelsId " +
+      "string, ROMSize string, ROMName String, purchasedate string, mobile struct<imei:string, " +
+      "imsi:string>, MAC array<string>, locationinfo array<struct<ActiveAreaId:int, " +
+      "ActiveCountry:string, ActiveProvince:string, Activecity:string, ActiveDistrict:string, " +
+      "ActiveStreet:string>>, proddate struct<productionDate:string," +
+      "activeDeactivedate:array<string>>, gamePointId double,contractNumber double)  STORED BY " +
+      "'org.apache.carbondata.format'  TBLPROPERTIES ('DICTIONARY_INCLUDE'='deviceInformationId'," +
+      " 'DICTIONARY_EXCLUDE'='channelsId','COLUMN_GROUP'='(ROMSize,ROMName)')");
+    sql("LOAD DATA local inpath '" + resourcesPath +
+        "/complextypespecialchardelimiter.csv' INTO table complexcarbonwithspecialchardelimeter  " +
+        "OPTIONS('DELIMITER'=',', 'QUOTECHAR'='\"', 'FILEHEADER'='deviceInformationId,channelsId," +
+        "ROMSize,ROMName,purchasedate,mobile,MAC,locationinfo,proddate,gamePointId," +
+        "contractNumber', 'COMPLEX_DELIMITER_LEVEL_1'='^', 'COMPLEX_DELIMITER_LEVEL_2'='*')");
+    sql(
+      "create table complexhivewithspecialchardelimeter(deviceInformationId int, channelsId " +
+      "string, ROMSize string, ROMName String, purchasedate string, mobile struct<imei:string, " +
+      "imsi:string>, MAC array<string>, locationinfo array<struct<ActiveAreaId:int, " +
+      "ActiveCountry:string, ActiveProvince:string, Activecity:string, ActiveDistrict:string, " +
+      "ActiveStreet:string>>, proddate struct<productionDate:string," +
+      "activeDeactivedate:array<string>>, gamePointId double,contractNumber double)row format " +
+      "delimited fields terminated by ',' collection items terminated by '^' map keys terminated " +
+      "by '*'")
+    sql("LOAD DATA local inpath '" + resourcesPath +
+        "/complextypespecialchardelimiter.csv' INTO table complexhivewithspecialchardelimeter");
+    checkAnswer(sql("select * from complexcarbonwithspecialchardelimeter"),
+      sql("select * from complexhivewithspecialchardelimeter"))
     sql("drop table if exists complexcarbonwithspecialchardelimeter")
     sql("drop table if exists complexhivewithspecialchardelimeter")
   }
- 
-   test("complex filter set1") {
+
+  test("complex filter set1") {
     checkAnswer(
       sql("select test3[1] from complex_filter where test4[1] not like'%1%' order by test1"),
       Seq(Row(5678), Row(1234))
     )
   }
-   test("complex filter set2") {
+  test("complex filter set2") {
     checkAnswer(
       sql("select test2[0] from complex_filter  where  test3[0] like '%1234%'"),
       Seq(Row("hello"))
     )
   }
   test("select * from structusingarraycarbon") {
-     checkAnswer(sql("select * from structusingarraycarbon"),
-     sql("select * from structusingarrayhive"))
+    checkAnswer(sql("select * from structusingarraycarbon"),
+      sql("select * from structusingarrayhive"))
   }
-  
-   test("select * from structusingstructCarbon") {
-     checkAnswer(sql("select * from structusingstructCarbon"),
-     sql("select * from structusingstructhive"))
+
+  test("select * from structusingstructCarbon") {
+    checkAnswer(sql("select * from structusingstructCarbon"),
+      sql("select * from structusingstructhive"))
   }
-  
+
   test("select * from complexcarbontable") {
-     checkAnswer(sql("select * from complexcarbontable"),
-     sql("select * from complexhivetable"))
+    checkAnswer(sql("select * from complexcarbontable"),
+      sql("select * from complexhivetable"))
   }
-  
+
   test("select mobile, proddate, deviceInformationId  from complexcarbontable") {
-     checkAnswer(sql("select mobile, proddate, deviceInformationId  from complexcarbontable"),
-     sql("select mobile, proddate, deviceInformationId  from complexhivetable"))
+    checkAnswer(sql("select mobile, proddate, deviceInformationId  from complexcarbontable"),
+      sql("select mobile, proddate, deviceInformationId  from complexhivetable"))
   }
 
   test("select mobile, MAC, deviceInformationId, purchasedate from complexcarbontable") {
-     checkAnswer(sql("select mobile, MAC, deviceInformationId, purchasedate from complexcarbontable"),
-     sql("select mobile, MAC, deviceInformationId, purchasedate from complexhivetable"))
+    checkAnswer(sql("select mobile, MAC, deviceInformationId, purchasedate from " +
+                    "complexcarbontable"),
+      sql("select mobile, MAC, deviceInformationId, purchasedate from complexhivetable"))
   }
 
-   test("select mobile, ROMSize, deviceInformationId from complexcarbontable") {
-     checkAnswer(sql("select mobile, ROMSize, deviceInformationId from complexcarbontable"),
-     sql("select mobile, ROMSize, deviceInformationId from complexhivetable"))
+  test("select mobile, ROMSize, deviceInformationId from complexcarbontable") {
+    checkAnswer(sql("select mobile, ROMSize, deviceInformationId from complexcarbontable"),
+      sql("select mobile, ROMSize, deviceInformationId from complexhivetable"))
   }
 
-   test("select locationinfo, purchasedate, deviceInformationId from complexcarbontable") {
-     checkAnswer(sql("select locationinfo, purchasedate, deviceInformationId from complexcarbontable"),
-     sql("select locationinfo, purchasedate, deviceInformationId from complexhivetable"))
+  test("select locationinfo, purchasedate, deviceInformationId from complexcarbontable") {
+    checkAnswer(sql("select locationinfo, purchasedate, deviceInformationId from " +
+                    "complexcarbontable"),
+      sql("select locationinfo, purchasedate, deviceInformationId from complexhivetable"))
   }
-    test("select locationinfo, ROMName, purchasedate, deviceinformationId from complexcarbontable") {
-     checkAnswer(sql("select locationinfo, ROMName, purchasedate, deviceinformationId from complexcarbontable"),
-     sql("select locationinfo, ROMName, purchasedate, deviceinformationId from complexhivetable"))
+  test("select locationinfo, ROMName, purchasedate, deviceinformationId from complexcarbontable") {
+    checkAnswer(sql(
+      "select locationinfo, ROMName, purchasedate, deviceinformationId from complexcarbontable"),
+      sql("select locationinfo, ROMName, purchasedate, deviceinformationId from complexhivetable"))
   }
-     test("select MAC from complexcarbontable where MAC[0] = 'MAC1'") {
-     checkAnswer(sql("select MAC from complexcarbontable where MAC[0] = 'MAC1'"),
-     sql("select MAC from complexhivetable where MAC[0] = 'MAC1'"))
+  test("select MAC from complexcarbontable where MAC[0] = 'MAC1'") {
+    checkAnswer(sql("select MAC from complexcarbontable where MAC[0] = 'MAC1'"),
+      sql("select MAC from complexhivetable where MAC[0] = 'MAC1'"))
   }
-      test("select mobile from complexcarbontable where mobile.imei like '1AA%'") {
-     checkAnswer(sql("select mobile from complexcarbontable where mobile.imei like '1AA%'"),
-     sql("select mobile from complexhivetable where mobile.imei like '1AA%'"))
-  }
-
-
-     test("select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId > 2 AND locationinfo[0].ActiveAreaId < 7") {
-     checkAnswer(sql("select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId > 2 AND locationinfo[0].ActiveAreaId < 7"),
-     sql("select locationinfo from complexhivetable where locationinfo[0].ActiveAreaId > 2 AND locationinfo[0].ActiveAreaId < 7"))
-  }
-        test("select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId >= 2 AND locationinfo[0].ActiveAreaId <= 7") {
-     checkAnswer(sql("select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId >= 2 AND locationinfo[0].ActiveAreaId <= 7"),
-     sql("select locationinfo from complexhivetable where locationinfo[0].ActiveAreaId >= 2 AND locationinfo[0].ActiveAreaId <= 7"))
-  }
-           test("select locationinfo from complexcarbontable where (locationinfo[0].ActiveAreaId +5 )> 6 AND (locationinfo[0].ActiveAreaId+10) < 20") {
-     checkAnswer(sql("select locationinfo from complexcarbontable where (locationinfo[0].ActiveAreaId +5 )> 6 AND (locationinfo[0].ActiveAreaId+10) < 20"),
-     sql("select locationinfo from complexhivetable where (locationinfo[0].ActiveAreaId +5 )> 6 AND (locationinfo[0].ActiveAreaId+10) < 20"))
-  }
-              test("select count(mobile),channelsId from complexcarbontable group by mobile,channelsId") {
-     checkAnswer(sql("select count(mobile),channelsId from complexcarbontable group by mobile,channelsId"),
-     sql("select count(mobile),channelsId from complexhivetable group by mobile,channelsId"))
+  test("select mobile from complexcarbontable where mobile.imei like '1AA%'") {
+    checkAnswer(sql("select mobile from complexcarbontable where mobile.imei like '1AA%'"),
+      sql("select mobile from complexhivetable where mobile.imei like '1AA%'"))
   }
 
-                test("select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order by channelsId") {
-     checkAnswer(sql("select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order by channelsId"),
-     sql("select count(mobile),channelsId from complexhivetable group by mobile,channelsId order by channelsId"))
+
+  test(
+    "select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId > 2 AND " +
+    "locationinfo[0].ActiveAreaId < 7") {
+    checkAnswer(sql(
+      "select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId > 2 AND " +
+      "locationinfo[0].ActiveAreaId < 7"),
+      sql(
+        "select locationinfo from complexhivetable where locationinfo[0].ActiveAreaId > 2 AND " +
+        "locationinfo[0].ActiveAreaId < 7"))
   }
-        test("select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order by channelsId limit 10") {
-     checkAnswer(sql("select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order by channelsId limit 10"),
-     sql("select count(mobile),channelsId from complexhivetable group by mobile,channelsId order by channelsId limit 10"))
+  test(
+    "select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId >= 2 AND " +
+    "locationinfo[0].ActiveAreaId <= 7") {
+    checkAnswer(sql(
+      "select locationinfo from complexcarbontable where locationinfo[0].ActiveAreaId >= 2 AND " +
+      "locationinfo[0].ActiveAreaId <= 7"),
+      sql(
+        "select locationinfo from complexhivetable where locationinfo[0].ActiveAreaId >= 2 AND " +
+        "locationinfo[0].ActiveAreaId <= 7"))
   }
-           test("select count(mobile),channelsId from complexcarbontable where MAC[0] = 'MAC1'  group by mobile,channelsId order by channelsId limit 10") {
-     checkAnswer(sql("select count(mobile),channelsId from complexcarbontable where MAC[0] = 'MAC1'  group by mobile,channelsId order by channelsId limit 10"),
-     sql("select count(mobile),channelsId from complexhivetable where MAC[0] = 'MAC1'  group by mobile,channelsId order by channelsId limit 10"))
+  test(
+    "select locationinfo from complexcarbontable where (locationinfo[0].ActiveAreaId +5 )> 6 AND " +
+    "(locationinfo[0].ActiveAreaId+10) < 20") {
+    checkAnswer(sql(
+      "select locationinfo from complexcarbontable where (locationinfo[0].ActiveAreaId +5 )> 6 " +
+      "AND (locationinfo[0].ActiveAreaId+10) < 20"),
+      sql(
+        "select locationinfo from complexhivetable where (locationinfo[0].ActiveAreaId +5 )> 6 " +
+        "AND (locationinfo[0].ActiveAreaId+10) < 20"))
+  }
+  test("select count(mobile),channelsId from complexcarbontable group by mobile,channelsId") {
+    checkAnswer(sql(
+      "select count(mobile),channelsId from complexcarbontable group by mobile,channelsId"),
+      sql("select count(mobile),channelsId from complexhivetable group by mobile,channelsId"))
+  }
+
+  test(
+    "select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order by " +
+    "channelsId") {
+    checkAnswer(sql(
+      "select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order " +
+      "by channelsId"),
+      sql(
+        "select count(mobile),channelsId from complexhivetable group by mobile,channelsId order " +
+        "by channelsId"))
+  }
+  test(
+    "select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order by " +
+    "channelsId limit 10") {
+    checkAnswer(sql(
+      "select count(mobile),channelsId from complexcarbontable group by mobile,channelsId order " +
+      "by channelsId limit 10"),
+      sql(
+        "select count(mobile),channelsId from complexhivetable group by mobile,channelsId order " +
+        "by channelsId limit 10"))
+  }
+  test(
+    "select count(mobile),channelsId from complexcarbontable where MAC[0] = 'MAC1'  group by " +
+    "mobile,channelsId order by channelsId limit 10") {
+    checkAnswer(sql(
+      "select count(mobile),channelsId from complexcarbontable where MAC[0] = 'MAC1'  group by " +
+      "mobile,channelsId order by channelsId limit 10"),
+      sql(
+        "select count(mobile),channelsId from complexhivetable where MAC[0] = 'MAC1'  group by " +
+        "mobile,channelsId order by channelsId limit 10"))
   }
 
   override def afterAll {
-	 sql("drop table if exists complexcarbontable").show
-     sql("drop table if exists complexhivetable").show
-     sql("drop table if exists structusingstructCarbon").show
-     sql("drop table if exists structusingstructHive").show
-     sql("drop table if exists structusingarraycarbon").show
-     sql("drop table if exists structusingarrayhive").show
+    sql("drop table if exists complexcarbontable").show
+    sql("drop table if exists complexhivetable").show
+    sql("drop table if exists structusingstructCarbon").show
+    sql("drop table if exists structusingstructHive").show
+    sql("drop table if exists structusingarraycarbon").show
+    sql("drop table if exists structusingarrayhive").show
 
   }
 }


### PR DESCRIPTION
using complex type in create table gives me exception

spark.sql(
s"""
CREATE TABLE carbon_table(
shortField short,
intField int,
bigintField long,
doubleField double,
stringField string,
timestampField timestamp,
decimalField decimal(18,2),
dateField date,
charField char(5),
floatField float,
complexData array<string>
)
STORED BY 'CARBONDATA'
TBLPROPERTIES('DICTIONARY_INCLUDE'='dateField, charField')
""".stripMargin)

it gives me exception

Caused by: java.lang.RuntimeException: Unsupported data type: ArrayType(StringType,true)
at scala.sys.package$.error(package.scala:27)
at org.apache.carbondata.spark.util.DataTypeConverterUtil$.convertToCarbonTypeForSpark2(DataTypeConverterUtil.scal