### PR TITLE
[CARBONDATA-781] Reuse SegmentProperties object when schema is the same in table level to reduce the memory

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/SegmentTaskIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/SegmentTaskIndexStore.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.datastore;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -31,12 +32,14 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.cache.Cache;
 import org.apache.carbondata.core.cache.CarbonLRUCache;
 import org.apache.carbondata.core.datastore.block.AbstractIndex;
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.block.SegmentTaskIndex;
 import org.apache.carbondata.core.datastore.block.SegmentTaskIndexWrapper;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.datastore.exception.IndexBuilderException;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.mutate.UpdateVO;
 import org.apache.carbondata.core.statusmanager.SegmentUpdateStatusManager;
 import org.apache.carbondata.core.util.CarbonUtil;
@@ -67,6 +70,9 @@ public class SegmentTaskIndexStore
    * block can be loaded concurrently
    */
   private Map<String, Object> segmentLockMap;
+
+  private Map<SegmentPropertiesWrapper, SegmentProperties> segmentProperties =
+      new HashMap<SegmentPropertiesWrapper, SegmentProperties>();
 
   /**
    * constructor to initialize the SegmentTaskIndexStore
@@ -345,7 +351,24 @@ public class SegmentTaskIndexStore
     List<DataFileFooter> footerList = CarbonUtil
         .readCarbonIndexFile(taskBucketHolder.taskNo, taskBucketHolder.bucketNumber,
             tableBlockInfoList, tableIdentifier);
-    AbstractIndex segment = new SegmentTaskIndex();
+
+    List<ColumnSchema> columnsInTable = footerList.get(0).getColumnInTable();
+    int[] columnCardinality = footerList.get(0).getSegmentInfo().getColumnCardinality();
+    SegmentPropertiesWrapper segmentPropertiesWrapper =
+        new SegmentPropertiesWrapper(tableIdentifier, columnsInTable, columnCardinality);
+    SegmentProperties segmentProperties;
+    if (this.segmentProperties.containsKey(segmentPropertiesWrapper)) {
+      segmentProperties = this.segmentProperties.get(segmentPropertiesWrapper);
+    } else {
+      // create a metadata details
+      // this will be useful in query handling
+      // all the data file metadata will have common segment properties we
+      // can use first one to get create the segment properties
+      segmentProperties = new SegmentProperties(columnsInTable, columnCardinality);
+      this.segmentProperties.put(segmentPropertiesWrapper, segmentProperties);
+    }
+
+    AbstractIndex segment = new SegmentTaskIndex(segmentProperties);
     // file path of only first block is passed as it all table block info path of
     // same task id will be same
     segment.buildIndex(footerList);
@@ -394,6 +417,36 @@ public class SegmentTaskIndexStore
       int result = taskNo != null ? taskNo.hashCode() : 0;
       result = 31 * result + (bucketNumber != null ? bucketNumber.hashCode() : 0);
       return result;
+    }
+  }
+
+  public static class SegmentPropertiesWrapper {
+    private AbsoluteTableIdentifier tableIdentifier = null;
+    private List<ColumnSchema> columnsInTable = null;
+    private int[] columnCardinality = null;
+
+    public SegmentPropertiesWrapper(AbsoluteTableIdentifier tableIdentifier,
+        List<ColumnSchema> columnsInTable, int[] columnCardinality) {
+      this.tableIdentifier = tableIdentifier;
+      this.columnsInTable = columnsInTable;
+      this.columnCardinality = columnCardinality;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof SegmentPropertiesWrapper)) {
+        return false;
+      }
+      SegmentPropertiesWrapper other = (SegmentPropertiesWrapper) obj;
+      return tableIdentifier.equals(other.tableIdentifier)
+        && columnsInTable.equals(other.columnsInTable)
+        && Arrays.equals(columnCardinality, other.columnCardinality);
+    }
+
+    @Override
+    public int hashCode() {
+      return tableIdentifier.hashCode()
+        + columnsInTable.hashCode() + Arrays.hashCode(columnCardinality);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/SegmentTaskIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/SegmentTaskIndexStore.java
@@ -352,6 +352,8 @@ public class SegmentTaskIndexStore
         .readCarbonIndexFile(taskBucketHolder.taskNo, taskBucketHolder.bucketNumber,
             tableBlockInfoList, tableIdentifier);
 
+    // Reuse SegmentProperties object if tableIdentifier, columnsInTable and columnCardinality are
+    // the same.
     List<ColumnSchema> columnsInTable = footerList.get(0).getColumnInTable();
     int[] columnCardinality = footerList.get(0).getSegmentInfo().getColumnCardinality();
     SegmentPropertiesWrapper segmentPropertiesWrapper =
@@ -420,10 +422,14 @@ public class SegmentTaskIndexStore
     }
   }
 
+  /**
+   * This class wraps tableIdentifier, columnsInTable and columnCardinality as a key to determine
+   * whether the SegmentProperties object can be reused.
+   */
   public static class SegmentPropertiesWrapper {
-    private AbsoluteTableIdentifier tableIdentifier = null;
-    private List<ColumnSchema> columnsInTable = null;
-    private int[] columnCardinality = null;
+    private AbsoluteTableIdentifier tableIdentifier;
+    private List<ColumnSchema> columnsInTable;
+    private int[] columnCardinality;
 
     public SegmentPropertiesWrapper(AbsoluteTableIdentifier tableIdentifier,
         List<ColumnSchema> columnsInTable, int[] columnCardinality) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentTaskIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentTaskIndex.java
@@ -29,17 +29,15 @@ import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
  */
 public class SegmentTaskIndex extends AbstractIndex {
 
+  public SegmentTaskIndex(SegmentProperties segmentProperties) {
+    this.segmentProperties = segmentProperties;
+  }
+
   /**
    * Below method is store the blocks in some data structure
    *
    */
   public void buildIndex(List<DataFileFooter> footerList) {
-    // create a metadata details
-    // this will be useful in query handling
-    // all the data file metadata will have common segment properties we
-    // can use first one to get create the segment properties
-    segmentProperties = new SegmentProperties(footerList.get(0).getColumnInTable(),
-        footerList.get(0).getSegmentInfo().getColumnCardinality());
     // create a segment builder info
     // in case of segment create we do not need any file path and each column value size
     // as Btree will be build as per min max and start key

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
@@ -263,7 +263,8 @@ public class ColumnSchema implements Serializable {
   @Override public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((columnName == null) ? 0 : columnName.hashCode());
+    result = prime * result + ((columnName == null) ? 0 : columnName.hashCode()) +
+      ((dataType == null) ? 0 : dataType.hashCode());
     return result;
   }
 
@@ -286,6 +287,13 @@ public class ColumnSchema implements Serializable {
         return false;
       }
     } else if (!columnName.equals(other.columnName)) {
+      return false;
+    }
+    if (dataType == null) {
+      if (other.dataType != null) {
+        return false;
+      }
+    } else if (!dataType.equals(other.dataType)) {
       return false;
     }
     return true;

--- a/core/src/test/java/org/apache/carbondata/core/datastore/block/SegmentTaskIndexTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/block/SegmentTaskIndexTest.java
@@ -58,7 +58,6 @@ public class SegmentTaskIndexTest {
       @Mock public void build(BTreeBuilderInfo segmentBuilderInfos) {}
     };
     long numberOfRows = 100;
-    SegmentTaskIndex segmentTaskIndex = new SegmentTaskIndex();
     columnSchema.setColumnName("employeeName");
     columnSchemaList.add(new ColumnSchema());
 
@@ -68,6 +67,9 @@ public class SegmentTaskIndexTest {
     footer.setNumberOfRows(numberOfRows);
     footerList.add(footer);
 
+    SegmentProperties properties = new SegmentProperties(footerList.get(0).getColumnInTable(),
+        footerList.get(0).getSegmentInfo().getColumnCardinality());
+    SegmentTaskIndex segmentTaskIndex = new SegmentTaskIndex(properties);
     segmentTaskIndex.buildIndex(footerList);
     assertEquals(footerList.get(0).getNumberOfRows(), numberOfRows);
 


### PR DESCRIPTION
When I load carbondata 1000+ times with 35 nodes, I found SegmentProperties objects occupy 2.5+G(76K * 35 * 1000) memory in driver. 
![carbonproperties](https://cloud.githubusercontent.com/assets/1400819/23979443/82d44320-0a34-11e7-9a5b-c4dcab4f9232.jpg)
I don't have small files so I don't want to compact the segments. I analyzed the dump file and found the values of SegmentProperties are the same in same segment, so I think we can reuse the SegmentProperties object in same segment.

cc @jackylk @QiangCai 