### PR TITLE
[CARBONDATA-530] Keep the CarbonDecoder on top of limit in case of limit+sort plan

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -174,6 +174,11 @@ public final class CarbonCommonConstants {
    * MEMBER_DEFAULT_VAL_ARRAY
    */
   public static final byte[] MEMBER_DEFAULT_VAL_ARRAY = MEMBER_DEFAULT_VAL.getBytes();
+
+  /**
+   * Bytes for string 0, it is used in codegen in case of null values.
+   */
+  public static final byte[] ZERO_BYTE_ARRAY = "0".getBytes();
   /**
    * FILE STATUS IN-PROGRESS
    */

--- a/core/src/main/java/org/apache/carbondata/core/scan/processor/AbstractDataBlockIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/processor/AbstractDataBlockIterator.java
@@ -222,7 +222,9 @@ public abstract class AbstractDataBlockIterator extends CarbonIterator<List<Obje
     if (null != future) {
       try {
         AbstractScannedResult abstractScannedResult = future.get();
-        abstractScannedResult.freeMemory();
+        if (abstractScannedResult != null) {
+          abstractScannedResult.freeMemory();
+        }
       } catch (InterruptedException | ExecutionException e) {
         throw new RuntimeException(e);
       }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -207,6 +207,16 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
 
     def addTempDecoder(currentPlan: LogicalPlan): LogicalPlan = {
       currentPlan match {
+        case limit@Limit(_, child: Sort) =>
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+              new util.HashSet[AttributeReferenceWrapper](),
+              limit,
+              isOuter = true)
+          } else {
+            limit
+          }
         case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
           val attrsOnSort = new util.HashSet[AttributeReferenceWrapper]()
           sort.order.map { s =>

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -32,7 +32,9 @@ case class CarbonDictionaryCatalystDecoder(
     aliasMap: CarbonAliasDecoderRelation,
     isOuter: Boolean,
     child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = child.output
+  // the output should be updated with converted datatype, it is need for limit+sort plan.
+  override val output: Seq[Attribute] =
+    CarbonDictionaryDecoder.convertOutput(child.output, relations, profile, aliasMap)
 }
 
 abstract class CarbonProfile(attributes: Seq[Attribute]) extends Serializable {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -171,6 +171,8 @@ case class CarbonDictionaryDecoder(
              |if (java.util.Arrays.equals(org.apache.carbondata.core.constants
              |.CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY, $valueIntern)) {
              |  $isNull = true;
+             |  $valueIntern = org.apache.carbondata.core.constants
+             |  .CarbonCommonConstants.ZERO_BYTE_ARRAY;
              |}
              """.stripMargin
 
@@ -309,6 +311,10 @@ case class CarbonDictionaryDecoder(
 
 object CarbonDictionaryDecoder {
 
+  /**
+   * Converts the datatypes of attributes as per the decoder plan. If a column needs to be decoded
+   * here then that datatype is updated to its original datatype from Int type.
+   */
   def convertOutput(output: Seq[Attribute],
       relations: Seq[CarbonDecoderRelation],
       profile: CarbonProfile,
@@ -339,6 +345,9 @@ object CarbonDictionaryDecoder {
     }
   }
 
+  /**
+   * Whether the attributed requires to decode or not based on the profile.
+   */
   def canBeDecoded(attr: Attribute, profile: CarbonProfile): Boolean = {
     profile match {
       case ip: IncludeProfile if ip.attributes.nonEmpty =>
@@ -351,6 +360,9 @@ object CarbonDictionaryDecoder {
     }
   }
 
+  /**
+   * Converts from carbon datatype to corresponding spark datatype.
+   */
   def convertCarbonToSparkDataType(carbonDimension: CarbonDimension,
       relation: CarbonRelation): types.DataType = {
     carbonDimension.getDataType match {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -145,6 +145,16 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
 
     def addTempDecoder(currentPlan: LogicalPlan): LogicalPlan = {
       currentPlan match {
+        case limit@GlobalLimit(_, LocalLimit(_, child: Sort)) =>
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+              new util.HashSet[AttributeReferenceWrapper](),
+              limit,
+              isOuter = true)
+          } else {
+            limit
+          }
         case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
           val attrsOnSort = new util.HashSet[AttributeReferenceWrapper]()
           sort.order.map { s =>


### PR DESCRIPTION
There is a new optimization in spark2.1, it can group limit and sort together and get the topN efficiently. so we should put outer decoder above limit to make use of this optimization.