### PR TITLE
[CARBONDATA-791] Exists queries of TPC-DS are failing in carbon.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -189,13 +189,13 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
   }
 
   @Override public void close() {
+    if (null != dataBlockIterator) {
+      dataBlockIterator.close();
+    }
     try {
       fileReader.finish();
     } catch (IOException e) {
       LOGGER.error(e);
-    }
-    if (null != dataBlockIterator) {
-      dataBlockIterator.close();
     }
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/optimizer/CarbonDecoderOptimizerHelper.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/optimizer/CarbonDecoderOptimizerHelper.scala
@@ -148,7 +148,11 @@ class CarbonPlanMarker {
         }
       }
     }
-    markerStack.peek().set
+    if (!markerStack.empty()) {
+      markerStack.peek().set
+    } else {
+      new util.HashSet[AttributeReferenceWrapper]()
+    }
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.command.LoadTableByInsert
@@ -40,7 +42,7 @@ case class CarbonDatasourceHadoopRelation(
     paths: Array[String],
     parameters: Map[String, String],
     tableSchema: Option[StructType],
-    var isSubquery: Boolean = false)
+    isSubquery: ArrayBuffer[Boolean] = new ArrayBuffer[Boolean]())
   extends BaseRelation with InsertableRelation {
 
   lazy val absIdentifier = AbsoluteTableIdentifier.fromTablePath(paths.head)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -168,7 +168,8 @@ case class CarbonDictionaryDecoder(
             s"""
              |boolean $isNull = false;
              |byte[] $valueIntern = $dictsRef.getDictionaryValueForKeyInBytes(${ ev.value });
-             |if (java.util.Arrays.equals(org.apache.carbondata.core.constants
+             |if ($valueIntern == null ||
+             |  java.util.Arrays.equals(org.apache.carbondata.core.constants
              |.CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY, $valueIntern)) {
              |  $isNull = true;
              |  $valueIntern = org.apache.carbondata.core.constants

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -59,9 +59,9 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
     relations = collectCarbonRelation(plan)
     if (relations.nonEmpty && !isOptimized(plan)) {
       // In case scalar subquery skip the transformation and update the flag.
-      if (relations.exists(_.carbonRelation.isSubquery)) {
-        relations.foreach(p => p.carbonRelation.isSubquery = false)
-        LOGGER.info("Skip CarbonOptimizer for scalar sub query")
+      if (relations.exists(_.carbonRelation.isSubquery.nonEmpty)) {
+        relations.foreach(p => p.carbonRelation.isSubquery.remove(0))
+        LOGGER.info("Skip CarbonOptimizer for scalar/predicate sub query")
         return plan
       }
       LOGGER.info("Starting to optimize plan")
@@ -523,10 +523,20 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
         }
         Aggregate(grpExps, aggExps, agg.child)
       case expand: Expand =>
-        expand.transformExpressions {
+        val ex = expand.transformExpressions {
           case attr: AttributeReference =>
             updateDataType(attr, attrMap, allAttrsNotDecode, aliasMap)
         }
+        // Update the datatype of literal type as per the output type, otherwise codegen fails.
+        val updatedProj = ex.projections.map { projs =>
+          projs.zipWithIndex.map { case(p, index) =>
+            p.transform {
+              case l: Literal if l.dataType != ex.output(index).dataType =>
+                Literal(l.value, ex.output(index).dataType)
+            }
+          }
+        }
+        Expand(updatedProj, ex.output, ex.child)
       case filter: Filter =>
         filter
       case j: Join =>


### PR DESCRIPTION
Carbon plan fails to handle exists queries. For exists queries plan comes as predicatesubquery and try to resolve the plan individually. We should not resolve the plan individually , we should handle it all at once. So for that purpose added flags in relation.
