### PR TITLE
[CARBONDATA-793] Fixed count with null values giving wrong values

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/emptyrow/TestEmptyRows.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/emptyrow/TestEmptyRows.scala
@@ -67,6 +67,20 @@ class TestEmptyRows extends QueryTest with BeforeAndAfterAll {
     )
   }
 
+  test("select count(Desc) from emptyRowTable") {
+    checkAnswer(
+      sql("select count(Desc) from emptyRowCarbonTable"),
+      sql("select count(Desc) from emptyRowHiveTable")
+    )
+  }
+
+  test("select count(distinct Desc) from emptyRowTable") {
+    checkAnswer(
+      sql("select count(distinct Desc) from emptyRowCarbonTable"),
+      sql("select count(distinct Desc) from emptyRowHiveTable")
+    )
+  }
+
   override def afterAll {
     sql("drop table emptyRowCarbonTable")
     sql("drop table emptyRowHiveTable")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -211,7 +211,6 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
           agg.aggregateExpressions.map {
             case attr: AttributeReference =>
             case a@Alias(attr: AttributeReference, name) =>
-            case Alias(AggregateExpression(Count(Seq(attr: AttributeReference)), _, _, _), _) =>
             case aggExp: AggregateExpression =>
               aggExp.transform {
                 case aggExp: AggregateExpression =>


### PR DESCRIPTION
if the data has null values then it should not count the data. But it is counting now as we are not decoding the data in case of count agg function. Now added decoder in case of count agg function as well.