### PR TITLE
[CARBONDATA-796]Drop database command clears all carbonfiles from carbon.store/dbfolder

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/CarbonHiveCommands.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution.command
+
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.execution.command.{CarbonDropTableCommand, DropDatabaseCommand, RunnableCommand}
+
+case class CarbonDropDatabaseCommand(command: DropDatabaseCommand)
+  extends RunnableCommand {
+
+  override val output = command.output
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val dbName = command.databaseName
+    // DropHiveDB command will fail if cascade is false and one or more table exists in database
+    val rows = command.run(sparkSession)
+    if (command.cascade) {
+      val tablesInDB = CarbonEnv.get.carbonMetastore.getAllTables()
+        .filterNot(_.database.exists(_.equalsIgnoreCase(dbName)))
+      tablesInDB.foreach { tableName =>
+        CarbonDropTableCommand(true, Some(dbName), tableName.table).run(sparkSession)
+      }
+    }
+    CarbonEnv.get.carbonMetastore.dropDatabaseDirectory(dbName)
+    rows
+  }
+}
+

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/DDLStrategy.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
+import org.apache.spark.sql.hive.execution.command.CarbonDropDatabaseCommand
 
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
@@ -57,15 +58,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
         CarbonEnv.get.carbonMetastore.createDatabaseDirectory(dbName)
         ExecutedCommandExec(createDb) :: Nil
       case drop@DropDatabaseCommand(dbName, ifExists, isCascade) =>
-        if (isCascade) {
-          val tablesInDB = CarbonEnv.get.carbonMetastore.getAllTables()
-            .filterNot(_.database.exists(_.equalsIgnoreCase(dbName)))
-          tablesInDB.foreach{tableName =>
-            CarbonDropTableCommand(true, Some(dbName), tableName.table).run(sparkSession)
-          }
-        }
-        CarbonEnv.get.carbonMetastore.dropDatabaseDirectory(dbName)
-        ExecutedCommandExec(drop) :: Nil
+        ExecutedCommandExec(CarbonDropDatabaseCommand(drop)) :: Nil
       case alterTable@AlterTableCompaction(altertablemodel) =>
         val isCarbonTable = CarbonEnv.get.carbonMetastore
           .tableExists(TableIdentifier(altertablemodel.tableName,

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
@@ -158,4 +158,22 @@ class CarbonDataSourceSuite extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbonunion")
   })
 
+  test("test drop database with and without cascade") {
+    sql("drop database if exists testdb cascade")
+    sql("create database testdb")
+    sql("create table testdb.test1(name string, id int)stored by 'carbondata'")
+    sql("insert into testdb.test1 select 'xx',1")
+    sql("insert into testdb.test1 select 'xx',11")
+    try {
+      sql("drop database testdb")
+      sys.error("drop db should fail as one table exist in db")
+    } catch {
+      case e =>
+        println(e.getMessage)
+    }
+    checkAnswer(sql("select * from testdb.test1"), Seq(Row("xx", 1), Row("xx", 11)))
+    sql("drop table testdb.test1")
+    sql("drop database testdb")
+  }
+
 }


### PR DESCRIPTION
When user trigger drop database command, Carbon is deleted all the files from <carbon.store>/database/ folder without check whether any file exist
eg., create database db1;
create table db1.test1(id int, name string) stored as 'carbondata';
drop database db1; --> This command clears all the files in <carbon.store>/database/ folder.