### PR TITLE
[CARBONDATA-783] 	Fixed message fails with outofbound exception in dictionary server

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/dictionary/client/DictionaryClient.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/client/DictionaryClient.java
@@ -28,7 +28,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
 /**
  * Dictionary client to connect to Dictionary server and generate dictionary values
@@ -56,6 +56,9 @@ public class DictionaryClient {
         .handler(new ChannelInitializer<SocketChannel>() {
           @Override public void initChannel(SocketChannel ch) throws Exception {
             ChannelPipeline pipeline = ch.pipeline();
+            // Based on length provided at header, it collects all packets
+            pipeline
+                .addLast("LengthDecoder", new LengthFieldBasedFrameDecoder(1048576, 0, 2, 0, 2));
             pipeline.addLast("DictionaryClientHandler", dictionaryClientHandler);
           }
         });

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServer.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServer.java
@@ -29,7 +29,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
 /**
  * Dictionary Server to generate dictionary keys.
@@ -64,6 +64,8 @@ public class DictionaryServer {
       bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
         @Override public void initChannel(SocketChannel ch) throws Exception {
           ChannelPipeline pipeline = ch.pipeline();
+          // Based on length provided at header, it collects all packets
+          pipeline.addLast("LengthDecoder", new LengthFieldBasedFrameDecoder(1048576, 0, 2, 0, 2));
           pipeline.addLast("DictionaryServerHandler", dictionaryServerHandler);
         }
       });

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
@@ -38,8 +38,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
 /**
  * Test class to test dictionary client functionality.
  */
@@ -111,18 +109,51 @@ public class DictionaryClientTest {
     // Test dictionary initialization call
     empKey.setType(DictionaryMessageType.TABLE_INTIALIZATION);
     client.getDictionary(empKey);
-
+    int count = 2;
     // Test dictionary generation
-    for (int count = 2; count <= 10000; count++) {
+    for (; count <= 10000; count++) {
       empKey.setType(DictionaryMessageType.DICT_GENERATION);
       empKey.setData("FirstKey" + count);
+      DictionaryMessage val = client.getDictionary(empKey);
+      Assert.assertEquals(count, val.getDictionaryValue());
+    }
+
+    // Test dictionary generation with big messages
+    for (; count <= 10010; count++) {
+      empKey.setType(DictionaryMessageType.DICT_GENERATION);
+      empKey.setData(
+          "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + "FirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKeyFirstKey"
+              + count);
       DictionaryMessage val = client.getDictionary(empKey);
       Assert.assertEquals(count, val.getDictionaryValue());
     }
     // Test size function
     empKey.setType(DictionaryMessageType.SIZE);
     DictionaryMessage val = client.getDictionary(empKey);
-    Assert.assertEquals(10000, val.getDictionaryValue());
+    Assert.assertEquals(10010, val.getDictionaryValue());
 
 
     client.shutDown();


### PR DESCRIPTION
This error happens because we are using TCP protocol and it may not sends the whole data in single packet, so if the data is big it is sending in multiple packets but we are taking only first packet to process the data, that is why it is failing.

Now added the length decoder and added length of whole message at header, so length decoder receives all packets depending on the length provided at header of message.