### PR TITLE
[CARBONDATA-818] Make the file_name in carbonindex exactly

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -579,6 +579,13 @@ public class CarbonTablePath extends Path {
   }
 
   /**
+   * @return prefix of carbon data
+   */
+  public static String getCarbonDataPrefix() {
+    return DATA_PART_PREFIX;
+  }
+
+  /**
    *
    * @return carbon data extension
    */

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
@@ -1,0 +1,108 @@
+package org.apache.carbondata.spark.testsuite.dataload
+
+import java.io.{File, FilenameFilter}
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.reader.CarbonIndexFileReader
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestDataLoadWithFileName extends QueryTest with BeforeAndAfterAll {
+  var originVersion = ""
+
+  override def beforeAll() {
+    originVersion =
+      CarbonProperties.getInstance.getProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION)
+  }
+
+  test("Test the file_name in carbonindex with v1 format") {
+    CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "1")
+    sql("DROP TABLE IF EXISTS test_table_v1")
+    sql(
+      """
+        | CREATE TABLE test_table_v1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    val testData = s"$resourcesPath/sample.csv"
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table test_table_v1")
+    val indexReader = new CarbonIndexFileReader()
+    val carbonIndexPaths = new File(s"$storeLocation/default/test_table_v1/Fact/Part0/Segment_0/")
+      .listFiles(new FilenameFilter {
+        override def accept(dir: File, name: String): Boolean = {
+          name.endsWith(CarbonTablePath.getCarbonIndexExtension)
+        }
+      })
+    for (carbonIndexPath <- carbonIndexPaths) {
+      indexReader.openThriftReader(carbonIndexPath.getCanonicalPath)
+      assert(indexReader.readIndexHeader().getVersion === 1)
+      while (indexReader.hasNext) {
+        val readBlockIndexInfo = indexReader.readBlockIndexInfo()
+        assert(readBlockIndexInfo.getFile_name.startsWith(storeLocation))
+      }
+    }
+  }
+
+  test("Test the file_name in carbonindex with v2 format") {
+    CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "2")
+    sql("DROP TABLE IF EXISTS test_table_v2")
+    sql(
+      """
+        | CREATE TABLE test_table_v2(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    val testData = s"$resourcesPath/sample.csv"
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table test_table_v2")
+    val indexReader = new CarbonIndexFileReader()
+    val carbonIndexPaths = new File(s"$storeLocation/default/test_table_v2/Fact/Part0/Segment_0/")
+      .listFiles(new FilenameFilter {
+        override def accept(dir: File, name: String): Boolean = {
+          name.endsWith(CarbonTablePath.getCarbonIndexExtension)
+        }
+      })
+    for (carbonIndexPath <- carbonIndexPaths) {
+      indexReader.openThriftReader(carbonIndexPath.getCanonicalPath)
+      assert(indexReader.readIndexHeader().getVersion === 2)
+      while (indexReader.hasNext) {
+        val readBlockIndexInfo = indexReader.readBlockIndexInfo()
+        assert(readBlockIndexInfo.getFile_name.startsWith(storeLocation))
+      }
+    }
+  }
+
+  test("Test the file_name in carbonindex with v3 format") {
+    CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "3")
+    sql("DROP TABLE IF EXISTS test_table_v3")
+    sql(
+      """
+        | CREATE TABLE test_table_v3(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    val testData = s"$resourcesPath/sample.csv"
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table test_table_v3")
+    val indexReader = new CarbonIndexFileReader()
+    val carbonIndexPaths = new File(s"$storeLocation/default/test_table_v3/Fact/Part0/Segment_0/")
+      .listFiles(new FilenameFilter {
+        override def accept(dir: File, name: String): Boolean = {
+          name.endsWith(CarbonTablePath.getCarbonIndexExtension)
+        }
+      })
+    for (carbonIndexPath <- carbonIndexPaths) {
+      indexReader.openThriftReader(carbonIndexPath.getCanonicalPath)
+      assert(indexReader.readIndexHeader().getVersion === 3)
+      while (indexReader.hasNext) {
+        val readBlockIndexInfo = indexReader.readBlockIndexInfo()
+        assert(readBlockIndexInfo.getFile_name.startsWith(storeLocation))
+      }
+    }
+  }
+
+  override protected def afterAll() {
+    sql("DROP TABLE IF EXISTS test_table_v1")
+    sql("DROP TABLE IF EXISTS test_table_v2")
+    sql("DROP TABLE IF EXISTS test_table_v3")
+    CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION,
+      originVersion)
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
@@ -17,7 +17,7 @@ class TestDataLoadWithFileName extends QueryTest with BeforeAndAfterAll {
       CarbonProperties.getInstance.getProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION)
   }
 
-  test("Test the file_name in carbonindex with v1 format") {
+  test("Check the file_name in carbonindex with v1 format") {
     CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "1")
     sql("DROP TABLE IF EXISTS test_table_v1")
     sql(
@@ -39,12 +39,13 @@ class TestDataLoadWithFileName extends QueryTest with BeforeAndAfterAll {
       assert(indexReader.readIndexHeader().getVersion === 1)
       while (indexReader.hasNext) {
         val readBlockIndexInfo = indexReader.readBlockIndexInfo()
-        assert(readBlockIndexInfo.getFile_name.startsWith(storeLocation))
+        assert(readBlockIndexInfo.getFile_name.startsWith(CarbonTablePath.getCarbonDataPrefix))
+        assert(readBlockIndexInfo.getFile_name.endsWith(CarbonTablePath.getCarbonDataExtension))
       }
     }
   }
 
-  test("Test the file_name in carbonindex with v2 format") {
+  test("Check the file_name in carbonindex with v2 format") {
     CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "2")
     sql("DROP TABLE IF EXISTS test_table_v2")
     sql(
@@ -66,12 +67,13 @@ class TestDataLoadWithFileName extends QueryTest with BeforeAndAfterAll {
       assert(indexReader.readIndexHeader().getVersion === 2)
       while (indexReader.hasNext) {
         val readBlockIndexInfo = indexReader.readBlockIndexInfo()
-        assert(readBlockIndexInfo.getFile_name.startsWith(storeLocation))
+        assert(readBlockIndexInfo.getFile_name.startsWith(CarbonTablePath.getCarbonDataPrefix))
+        assert(readBlockIndexInfo.getFile_name.endsWith(CarbonTablePath.getCarbonDataExtension))
       }
     }
   }
 
-  test("Test the file_name in carbonindex with v3 format") {
+  test("Check the file_name in carbonindex with v3 format") {
     CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "3")
     sql("DROP TABLE IF EXISTS test_table_v3")
     sql(
@@ -93,7 +95,8 @@ class TestDataLoadWithFileName extends QueryTest with BeforeAndAfterAll {
       assert(indexReader.readIndexHeader().getVersion === 3)
       while (indexReader.hasNext) {
         val readBlockIndexInfo = indexReader.readBlockIndexInfo()
-        assert(readBlockIndexInfo.getFile_name.startsWith(storeLocation))
+        assert(readBlockIndexInfo.getFile_name.startsWith(CarbonTablePath.getCarbonDataPrefix))
+        assert(readBlockIndexInfo.getFile_name.endsWith(CarbonTablePath.getCarbonDataExtension))
       }
     }
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.carbondata.spark.testsuite.dataload
 
 import java.io.{File, FilenameFilter}

--- a/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/file/FileData.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/file/FileData.java
@@ -37,7 +37,7 @@ public class FileData extends FileManager {
   }
 
   /**
-   * @return Returns the fileName.
+   * @return Returns the carbonDataFileTempPath.
    */
   public String getFileName() {
     return fileName;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -347,11 +347,11 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
    * Below method will be used to fill the vlock info details
    *
    * @param numberOfRows    number of rows in file
-   * @param filePath        file path
+   * @param carbonDataFileName The name of carbonData file
    * @param currentPosition current offset
    */
-  protected void fillBlockIndexInfoDetails(long numberOfRows,
-      String filePath, long currentPosition) {
+  protected void fillBlockIndexInfoDetails(long numberOfRows, String carbonDataFileName,
+      long currentPosition) {
 
     // as min-max will change for each blocklet and second blocklet min-max can be lesser than
     // the first blocklet so we need to calculate the complete block level min-max by taking
@@ -382,7 +382,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     minmax.setMaxValues(currentMaxValue);
     BlockletIndex blockletIndex = new BlockletIndex(btree, minmax);
     BlockIndexInfo blockIndexInfo =
-        new BlockIndexInfo(numberOfRows, filePath, currentPosition, blockletIndex);
+        new BlockIndexInfo(numberOfRows, carbonDataFileName, currentPosition, blockletIndex);
     blockIndexInfoList.add(blockIndexInfo);
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -98,6 +98,12 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
    * file name
    */
   protected String fileName;
+
+  /**
+   * The path of carbonData file
+   */
+  protected String carbonDataFilePath;
+
   /**
    * Local cardinality for the segment
    */
@@ -295,6 +301,8 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     dataWriterVo.getFileManager().add(fileData);
     this.fileName = dataWriterVo.getStoreLocation() + File.separator + carbonDataFileName
         + CarbonCommonConstants.FILE_INPROGRESS_STATUS;
+    this.carbonDataFilePath =
+        dataWriterVo.getCarbonDataDirectoryPath() + File.separator + carbonDataFileName;
     this.fileCount++;
     try {
       // open channel for new data file
@@ -376,8 +384,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     minmax.setMaxValues(currentMaxValue);
     BlockletIndex blockletIndex = new BlockletIndex(btree, minmax);
     BlockIndexInfo blockIndexInfo =
-        new BlockIndexInfo(numberOfRows, filePath.substring(0, filePath.lastIndexOf('.')),
-            currentPosition, blockletIndex);
+        new BlockIndexInfo(numberOfRows, filePath, currentPosition, blockletIndex);
     blockIndexInfoList.add(blockIndexInfo);
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -100,9 +100,9 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
   protected String fileName;
 
   /**
-   * The path of carbonData file
+   * The name of carbonData file
    */
-  protected String carbonDataFilePath;
+  protected String carbonDataFileName;
 
   /**
    * Local cardinality for the segment
@@ -292,7 +292,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     // update the filename with new new sequence
     // increment the file sequence counter
     initFileCount();
-    String carbonDataFileName = carbonTablePath
+    this.carbonDataFileName = carbonTablePath
         .getCarbonDataFileName(fileCount, dataWriterVo.getCarbonDataFileAttributes().getTaskId(),
             dataWriterVo.getBucketNumber(), dataWriterVo.getTaskExtension(),
             dataWriterVo.getCarbonDataFileAttributes().getFactTimeStamp());
@@ -301,8 +301,6 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     dataWriterVo.getFileManager().add(fileData);
     this.fileName = dataWriterVo.getStoreLocation() + File.separator + carbonDataFileName
         + CarbonCommonConstants.FILE_INPROGRESS_STATUS;
-    this.carbonDataFilePath =
-        dataWriterVo.getCarbonDataDirectoryPath() + File.separator + carbonDataFileName;
     this.fileCount++;
     try {
       // open channel for new data file

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -261,8 +261,8 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
   protected void updateBlockletFileChannel(long blockletDataSize) throws CarbonDataWriterException {
     if ((currentFileSize + blockletDataSize) >= dataBlockSize && currentFileSize != 0) {
       // set the current file size to zero
-      LOGGER.info("Writing data to file as max file size reached for file: " + carbonDataFileTempPath
-          + " .Data block size: " + currentFileSize);
+      LOGGER.info("Writing data to file as max file size reached for file: "
+          + carbonDataFileTempPath + " .Data block size: " + currentFileSize);
       // write meta data to end of the existing file
       writeBlockletInfoToFile(fileChannel, carbonDataFileTempPath);
       this.currentFileSize = 0;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v1/CarbonFactDataWriterImplV1.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v1/CarbonFactDataWriterImplV1.java
@@ -373,7 +373,7 @@ public class CarbonFactDataWriterImplV1 extends AbstractFactDataWriter<int[]> {
       FileFooter convertFileMeta = CarbonMetadataUtil
           .convertFileFooter(blockletInfoList, localCardinality.length, localCardinality,
               thriftColumnSchemaList, dataWriterVo.getSegmentProperties());
-      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFilePath, currentPosition);
+      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFileName, currentPosition);
       writer.writeFooter(convertFileMeta, currentPosition);
     } catch (IOException e) {
       throw new CarbonDataWriterException("Problem while writing the carbon file: ", e);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v1/CarbonFactDataWriterImplV1.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v1/CarbonFactDataWriterImplV1.java
@@ -373,7 +373,7 @@ public class CarbonFactDataWriterImplV1 extends AbstractFactDataWriter<int[]> {
       FileFooter convertFileMeta = CarbonMetadataUtil
           .convertFileFooter(blockletInfoList, localCardinality.length, localCardinality,
               thriftColumnSchemaList, dataWriterVo.getSegmentProperties());
-      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), filePath, currentPosition);
+      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFilePath, currentPosition);
       writer.writeFooter(convertFileMeta, currentPosition);
     } catch (IOException e) {
       throw new CarbonDataWriterException("Problem while writing the carbon file: ", e);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v2/CarbonFactDataWriterImplV2.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v2/CarbonFactDataWriterImplV2.java
@@ -276,7 +276,7 @@ public class CarbonFactDataWriterImplV2 extends CarbonFactDataWriterImplV1 {
           .convertFilterFooter2(blockletInfoList, localCardinality, thriftColumnSchemaList,
               dataChunksOffsets, dataChunksLength);
       // fill the carbon index details
-      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), filePath, currentPosition);
+      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFilePath, currentPosition);
       // write the footer
       writer.writeFooter(convertFileMeta, currentPosition);
     } catch (IOException e) {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v2/CarbonFactDataWriterImplV2.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v2/CarbonFactDataWriterImplV2.java
@@ -276,7 +276,7 @@ public class CarbonFactDataWriterImplV2 extends CarbonFactDataWriterImplV1 {
           .convertFilterFooter2(blockletInfoList, localCardinality, thriftColumnSchemaList,
               dataChunksOffsets, dataChunksLength);
       // fill the carbon index details
-      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFilePath, currentPosition);
+      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFileName, currentPosition);
       // write the footer
       writer.writeFooter(convertFileMeta, currentPosition);
     } catch (IOException e) {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -540,11 +540,11 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
   public void closeWriter() throws CarbonDataWriterException {
     if (dataWriterHolder.getNodeHolder().size() > 0) {
       writeDataToFile(fileChannel);
-      writeBlockletInfoToFile(fileChannel, fileName);
+      writeBlockletInfoToFile(fileChannel, carbonDataFileTempPath);
       CarbonUtil.closeStreams(this.fileOutputStream, this.fileChannel);
       renameCarbonDataFile();
       copyCarbonDataFileToCarbonStorePath(
-          this.fileName.substring(0, this.fileName.lastIndexOf('.')));
+          this.carbonDataFileTempPath.substring(0, this.carbonDataFileTempPath.lastIndexOf('.')));
       try {
         writeIndexFile();
       } catch (IOException e) {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -476,10 +476,10 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
    * Below method will be used to fill the block info details
    *
    * @param numberOfRows    number of rows in file
-   * @param filePath        file path
+   * @param carbonDataFileName The name of carbonData file
    * @param currentPosition current offset
    */
-  protected void fillBlockIndexInfoDetails(long numberOfRows, String filePath,
+  protected void fillBlockIndexInfoDetails(long numberOfRows, String carbonDataFileName,
       long currentPosition) {
     byte[][] currentMinValue = new byte[blockletIndex.get(0).min_max_index.max_values.size()][];
     byte[][] currentMaxValue = new byte[blockletIndex.get(0).min_max_index.max_values.size()][];
@@ -528,7 +528,7 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
     org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex blockletIndex =
         new org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex(btree, minmax);
     BlockIndexInfo blockIndexInfo =
-        new BlockIndexInfo(numberOfRows, filePath, currentPosition, blockletIndex);
+        new BlockIndexInfo(numberOfRows, carbonDataFileName, currentPosition, blockletIndex);
     blockIndexInfoList.add(blockIndexInfo);
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -294,7 +294,7 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
           .convertFileFooterVersion3(blockletMetadata, blockletIndex, localCardinality,
               thriftColumnSchemaList.size(), dataWriterVo.getSegmentProperties());
       // fill the carbon index details
-      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFilePath, currentPosition);
+      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFileName, currentPosition);
       // write the footer
       byte[] byteArray = CarbonUtil.getByteArray(convertFileMeta);
       ByteBuffer buffer =

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -294,7 +294,7 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
           .convertFileFooterVersion3(blockletMetadata, blockletIndex, localCardinality,
               thriftColumnSchemaList.size(), dataWriterVo.getSegmentProperties());
       // fill the carbon index details
-      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), filePath, currentPosition);
+      fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFilePath, currentPosition);
       // write the footer
       byte[] byteArray = CarbonUtil.getByteArray(convertFileMeta);
       ByteBuffer buffer =
@@ -528,8 +528,7 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
     org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex blockletIndex =
         new org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex(btree, minmax);
     BlockIndexInfo blockIndexInfo =
-        new BlockIndexInfo(numberOfRows, filePath.substring(0, filePath.lastIndexOf('.')),
-            currentPosition, blockletIndex);
+        new BlockIndexInfo(numberOfRows, filePath, currentPosition, blockletIndex);
     blockIndexInfoList.add(blockIndexInfo);
   }
 


### PR DESCRIPTION
The file_name stored in carbonindex is a local path which used on executor as temp dir 
```
/tmp/6937581525189542/0/default/carbon_v3/Fact/Part0/Segment_0/0/part-0-0_batchno0-0-1490345609845.carbondata
```
But I think we want to store the actual carbondata path like
```
part-0-0_batchno0-0-1490345609845.carbondata
```

I have already check this with @QiangCai.

cc @jackylk 