### PR TITLE
[CARBONDATA-828] CarbonGlobalDictionaryRDD model.isComplexes model.dimensions inconsistent

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -377,7 +377,7 @@ class CarbonGlobalDictionaryGenerateRDD(
             // check high cardinality
             if (model.isFirstLoad && model.highCardIdentifyEnable
                 && !model.isComplexes(split.index)
-                && model.dimensions(split.index).isColumnar) {
+                && model.primDimensions(split.index).isColumnar) {
               isHighCardinalityColumn = GlobalDictionaryUtil.isHighCardinalityColumn(
                 valuesBuffer.size, rowCount, model)
               if (isHighCardinalityColumn) {


### PR DESCRIPTION

 org.apache.carbondata.spark.rdd.CarbonGlobalDictionaryGenerateRDD find a bug:
code line 378-380
if (model.isFirstLoad && model.highCardIdentifyEnable
&& !model.isComplexes(split.index)
&& model.dimensions(split.index).isColumnar) {
model.dimensions(split.index).isColumnar must change to model.primDimensions(split.index).isColumnar because model.isComplexes.length may be != model.dimensions.length when create table use DICTIONARY_EXCLUDE or column datatype is complex