### PR TITLE
[CARBONDATA-839] Fixed issue with meta lock not getting deleted for rename table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/locks/AbstractCarbonLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/AbstractCarbonLock.java
@@ -18,6 +18,7 @@
 package org.apache.carbondata.core.locks;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.util.CarbonProperties;
 
 /**
@@ -70,6 +71,14 @@ public abstract class AbstractCarbonLock implements ICarbonLock {
       retryTimeout = CarbonCommonConstants.MAX_TIMEOUT_FOR_LOAD_METADATA_LOCK_DEFAULT;
     }
 
+  }
+
+  public boolean releaseLockManually(String lockFile) {
+    try {
+      return FileFactory.deleteFile(lockFile, FileFactory.getFileType(lockFile));
+    } catch (Exception e) {
+      return false;
+    }
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/locks/ICarbonLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/ICarbonLock.java
@@ -36,4 +36,12 @@ public interface ICarbonLock {
    */
   boolean lockWithRetries();
 
+  /**
+   * This method will delete the lock file at the specified location.
+   *
+   * @param lockFile The path of the lock file.
+   * @return True if the lock file is deleted, false otherwise.
+   */
+  boolean releaseLockManually(String lockFile);
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 /**
  * This class handles the file locking in the local file system.
@@ -70,7 +71,8 @@ public class LocalFileLock extends AbstractCarbonLock {
       LogServiceFactory.getLogService(LocalFileLock.class.getName());
 
   static {
-    tmpPath = System.getProperty("java.io.tmpdir");
+    tmpPath = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION,
+        System.getProperty("java.io.tmpdir"));
   }
 
   /**
@@ -151,6 +153,7 @@ public class LocalFileLock extends AbstractCarbonLock {
             LOGGER.info("Successfully deleted the lock file " + lockFilePath);
           } else {
             LOGGER.error("Not able to delete the lock file " + lockFilePath);
+            status = false;
           }
         } catch (IOException e) {
           LOGGER.error(e.getMessage());

--- a/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.format.{SchemaEvolutionEntry, TableInfo}
 
 object AlterTableUtil {
+
   def validateTableAndAcquireLock(dbName: String, tableName: String, LOGGER: LogService)
     (sparkSession: SparkSession): ICarbonLock = {
     val relation =

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -381,11 +381,19 @@ class AlterTableValidationTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop database testdb")
   }
 
+  test("test to check if the lock file is successfully deleted") {
+    sql("create table lock_check(id int, name string) stored by 'carbondata'")
+    sql("alter table lock_check rename to lock_rename")
+    assert(!new File(s"${ CarbonCommonConstants.STORE_LOCATION } + /default/lock_rename/meta.lock")
+      .exists())
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS restructure")
     sql("DROP TABLE IF EXISTS restructure_new")
     sql("DROP TABLE IF EXISTS restructure_test")
     sql("DROP TABLE IF EXISTS restructure_bad")
     sql("DROP TABLE IF EXISTS restructure_badnew")
+    sql("DROP TABLE IF EXISTS lock_rename")
   }
 }


### PR DESCRIPTION
The following things are fixed in this patch:

1. Meta lock location has been changed from "tmp" to table store location.
2. The meta lock file was not being delete when the lock was released in case of table rename because the  path stored in the lock would not be updated along with the table rename. To fix this, a new method to manually delete the lock file has been added in AbstractCarbonLock.