### PR TITLE
[CARBONDATA-843]null pointer exception was thrown when floor operation is done on decimal column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/AbstractScannedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/AbstractScannedResultCollector.java
@@ -106,7 +106,8 @@ public abstract class AbstractScannedResultCollector implements ScannedResultCol
             bigDecimalMsrValue =
                 bigDecimalMsrValue.setScale(carbonMeasure.getScale(), RoundingMode.HALF_UP);
           }
-          return org.apache.spark.sql.types.Decimal.apply(bigDecimalMsrValue);
+          return org.apache.spark.sql.types.Decimal
+              .apply(bigDecimalMsrValue, carbonMeasure.getPrecision(), carbonMeasure.getScale());
         default:
           return dataChunk.getMeasureDataHolder().getReadableDoubleValueByIndex(index);
       }


### PR DESCRIPTION
problem: null pointer exception is thrown when floor operation is done on decimal column.
analysis: when floor operation was done on decimal column, scale was greater than precision.During floor operation , we try to change the precision of the data.
solution: When sending to the spark layer for performing floor operation, we need to explicitly send the precision and scale to the spark layer which are taken from the CarbonMeasure

