### PR TITLE
[CARBONDATA-642] Delete Subquery is not working while creating and loading 2 tables

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -419,17 +419,11 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
     }
 
   protected lazy val deleteRecords: Parser[LogicalPlan] =
-    (DELETE ~> FROM ~> table) ~ (WHERE ~> restInput).? <~ opt(";") ^^ {
-      case table ~ condition =>
+    (DELETE ~> FROM ~> table) ~ restInput.? <~ opt(";") ^^ {
+      case table ~ rest =>
         val tableName = getTableName(table.tableIdentifier)
         val alias = table.alias.getOrElse("")
-        val stmt = condition match {
-          case Some(cond) =>
-            "select tupleId from " + tableName + " " + alias + " where " + cond
-          case _ =>
-            "select tupleId from " + tableName + " " + alias
-        }
-        DeleteRecords(stmt, table)
+        DeleteRecords("select tupleId from " + tableName + " " + alias + rest.getOrElse(""), table)
     }
 
   protected lazy val updateTable: Parser[LogicalPlan] =

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -81,6 +81,18 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
       Seq()
     )
   }
+
+  test("delete data from  carbon table[ JOIN with another table ]") {
+    sql("""drop table if exists iud_db.dest""")
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
+    sql(""" DELETE FROM dest t1 INNER JOIN source2 t2 ON t1.c1 = t2.c11""").show(truncate = false)
+    checkAnswer(
+      sql("""select c1 from iud_db.dest"""),
+      Seq(Row("c"), Row("d"), Row("e"))
+    )
+  }
+
 //  test("delete data from  carbon table[where IN (sub query) ]") {
 //    sql("""drop table if exists iud_db.dest""")
 //    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()


### PR DESCRIPTION


This PR handles following problem
**Problem**: In carbon delete statement, JOIN is not  supported to delete using 2 or more tables.
**Analysis**: Carbon delete query parsing is failing, when JOIN existing in delete query. For example ‘DELETE FROM Table1 t1 INNER JOIN Table2 t2 ON t1.ID = t2.ID;’
**Solution**: Change the parser logic of delete statement to support all valid delete statements [including joins]


        - new unit test case added 
        - Manual testing done

