### PR TITLE
[CARBONDATA-849] Correcting the error message for alter table as per HIVE message for non existing table.

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -104,7 +104,7 @@ case class AlterTableModel(dbName: Option[String],
                            segmentUpdateStatusManager: Option[SegmentUpdateStatusManager],
                            compactionType: String,
                            factTimeStamp: Option[Long],
-                           alterSql: String)
+                           var alterSql: String)
 
 case class UpdateTableModel(isUpdate: Boolean,
                             updatedTimeStamp: Long,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/DDLStrategy.scala
@@ -72,7 +72,8 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
               "Unsupported alter operation on carbon table")
           }
         } else {
-          throw new MalformedCarbonCommandException("Unsupported alter operation on hive table")
+          throw new MalformedCarbonCommandException(
+            "Operation not allowed : " + altertablemodel.alterSql)
         }
       case dataTypeChange@AlterTableDataTypeChange(alterTableChangeDataTypeModel) =>
         val isCarbonTable = CarbonEnv.get.carbonMetastore

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -43,6 +43,9 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
           case x: LoadTable =>
             x.inputSqlString = input
             x
+          case x: AlterTableCompaction =>
+            x.alterTableModel.alterSql = input
+            x
           case logicalPlan => logicalPlan
         }
         case failureOrError =>


### PR DESCRIPTION
The error message getting while running alter on the non existing table is :
Exception in thread "main" org.apache.carbondata.spark.exception.MalformedCarbonCommandException: Unsupported alter operation on hive table
but this is not correct.
The hive table has blocked the alter DDL on its tables. So Carbon should be consistent with HIVE.
Correct msg : 
Operation not allowed: alter table name compact 'minor'