### PR TITLE
[CARBONDATA-874] Fixed order by limit with select * query

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/sortexpr/AllDataTypesTestCaseSort.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/sortexpr/AllDataTypesTestCaseSort.scala
@@ -27,6 +27,8 @@ import org.scalatest.BeforeAndAfterAll
 class AllDataTypesTestCaseSort extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
+    sql("drop table if exists alldatatypestablesort")
+    sql("drop table if exists alldatatypestablesort_hive")
     sql("CREATE TABLE alldatatypestablesort (empno int, empname String, designation String, doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
     sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE alldatatypestablesort OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '\"')""");
 
@@ -41,8 +43,20 @@ class AllDataTypesTestCaseSort extends QueryTest with BeforeAndAfterAll {
       sql("select empno,empname,utilization,count(salary),sum(empno) from alldatatypestablesort_hive where empname in ('arvind','ayushi') group by empno,empname,utilization order by empno"))
   }
 
+  test("select * from alldatatypestablesort order by empname limit 10") {
+    sql("select * from alldatatypestablesort order by empname limit 10").collect()
+  }
+
+  test("select * from alldatatypestablesort order by salary limit 2") {
+    sql("select * from alldatatypestablesort order by salary limit 2").collect()
+  }
+
+  test("select * from alldatatypestablesort where empname='arvind' order by salary limit 2") {
+    sql("select * from alldatatypestablesort where empname='arvind' order by salary limit 2").collect()
+  }
+
   override def afterAll {
-    sql("drop table alldatatypestablesort")
-    sql("drop table alldatatypestablesort_hive")
+    sql("drop table if exists alldatatypestablesort")
+    sql("drop table if exists alldatatypestablesort_hive")
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
@@ -61,11 +61,15 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
             a.map(_.name).toArray, f), needDecoder)) ::
             Nil
       case CarbonDictionaryCatalystDecoder(relations, profile, aliasMap, _, child) =>
-        CarbonDictionaryDecoder(relations,
-          profile,
-          aliasMap,
-          planLater(child)
-        ) :: Nil
+        if (profile.isInstanceOf[IncludeProfile] && profile.isEmpty) {
+          planLater(child) :: Nil
+        } else {
+          CarbonDictionaryDecoder(relations,
+            profile,
+            aliasMap,
+            planLater(child)
+          ) :: Nil
+        }
       case _ => Nil
     }
   }


### PR DESCRIPTION
Order by limit with select * from query is not working as the it uses `TakeOrderedAndProjectExec`  internally and it try to get the output from logical plan instead of physical plan. So incase of logical releation we need to update the dictionary attributes with integer type.