### PR TITLE
[CARBONDATA-898]NullPointerException is getting thrown when rename table and select query is run concurrently

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/SchemaReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/SchemaReader.java
@@ -67,7 +67,7 @@ public class SchemaReader {
       return CarbonMetadata.getInstance().getCarbonTable(
           identifier.getCarbonTableIdentifier().getTableUniqueName());
     } else {
-      return null;
+      throw new IOException("File does not exist: " + schemaFilePath);
     }
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
@@ -171,7 +171,7 @@ class CarbonDataSourceSuite extends QueryTest with BeforeAndAfterAll {
       case e =>
         println(e.getMessage)
     }
-    checkAnswer(sql("select * from testdb.test1"), Seq(Row("xx", 1), Row("xx", 11)))
+    checkAnswer(sql("select count(*) from testdb.test1"), Seq(Row(2)))
     sql("drop table testdb.test1")
     sql("drop database testdb")
   }


### PR DESCRIPTION
When select query is triggered from one beeline client and concurrently rename table command is triggered from another beeline client, when any file operation like reading dictionary file for decoding surrogates or reading schema file for perparing carbon table is failing with NullPointerException if storage is HDFS. Fixed the scenarios to throw "file not found IOException".