### PR TITLE
[CARBONDATA-873] Drop table command throwing table already exists exception

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetadataUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetadataUtil.scala
@@ -41,7 +41,8 @@ object CarbonHiveMetadataUtil {
       tableName: String,
       sparkSession: SparkSession): Unit = {
     try {
-      sparkSession.sql(s"DROP TABLE IF EXISTS $databaseName.$tableName")
+      sparkSession.sharedState.externalCatalog.asInstanceOf[HiveExternalCatalog].client.
+        runSqlHive(s"DROP TABLE IF EXISTS $databaseName.$tableName")
     } catch {
       case e: Exception =>
         LOGGER.audit(


### PR DESCRIPTION
problem : Drop table command throwing table already exists exception
Solution: While invalidating the table from hive metastore, execute drop table command externally.