### PR TITLE
[CARBONDATA-875] in create database DDL , DBNAME should be case insensitive.

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonMetastore.scala
@@ -657,7 +657,7 @@ class CarbonMetastore(conf: RuntimeConfig, val storePath: String) {
   }
 
   def createDatabaseDirectory(dbName: String) {
-    val databasePath = storePath + File.separator + dbName
+    val databasePath = storePath + File.separator + dbName.toLowerCase
     val fileType = FileFactory.getFileType(databasePath)
     FileFactory.mkdirs(databasePath, fileType)
   }


### PR DESCRIPTION
issue : when using Create database DDL , we are creating the folder with the user given name , i.e we are maintaining case sensitivity. but it should be case insensitive. 

Solution : convert the db name to lower case and create folder.