### PR TITLE
[CARBONDATA-880] Path should not get printed in the explain extended DDL

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -74,4 +74,9 @@ case class CarbonDatasourceHadoopRelation(
   }
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = new Array[Filter](0)
 
+  override def toString: String = {
+    "CarbonDatasourceHadoopRelation [ " + "Database name :" + carbonTable.getDatabaseName +
+    ", " + "Table name :" + carbonTable.getFactTableName + ", Schema :" + tableSchema + " ]"
+  }
+
 }


### PR DESCRIPTION
Path is getting printed in the explain extended DDL. this should not get printed. AS this can be security issue. and no need to expose the store path to the end user.

so overriding the toString method and printing only database name and table name.

after fix :
CarbonDatasourceHadoopRelation [ Database name :default, Table name :t1, Schema :Some(StructType(StructField(name,StringType,true), StructField(id,DecimalType(3,2),true), StructField(country,StringType,true))) ]

