### PR TITLE
[CARBONDATA-863] Separated column schema generation and dictionary file generation

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/AlterTableAddColumnRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/AlterTableAddColumnRDD.scala
@@ -19,7 +19,6 @@ package org.apache.carbondata.spark.rdd
 
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.execution.command.AlterTableAddColumnsModel
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -49,13 +48,12 @@ class AddColumnPartition(rddId: Int, idx: Int, schema: ColumnSchema) extends Par
  */
 class AlterTableAddColumnRDD[K, V](sc: SparkContext,
     @transient newColumns: Seq[ColumnSchema],
-    alterTableModel: AlterTableAddColumnsModel,
     carbonTableIdentifier: CarbonTableIdentifier,
     carbonStorePath: String) extends RDD[(Int, String)](sc, Nil) {
 
   override def getPartitions: Array[Partition] = {
     newColumns.zipWithIndex.map { column =>
-      new DropColumnPartition(id, column._2, column._1)
+      new AddColumnPartition(id, column._2, column._1)
     }.toArray
   }
 
@@ -65,7 +63,7 @@ class AlterTableAddColumnRDD[K, V](sc: SparkContext,
     val status = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS
     val iter = new Iterator[(Int, String)] {
       try {
-        val columnSchema = split.asInstanceOf[DropColumnPartition].columnSchema
+        val columnSchema = split.asInstanceOf[AddColumnPartition].columnSchema
         // create dictionary file if it is a dictionary column
         if (columnSchema.hasEncoding(Encoding.DICTIONARY) &&
             !columnSchema.hasEncoding(Encoding.DIRECT_DICTIONARY)) {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -152,7 +152,7 @@ case class AlterTableDropColumnModel(databaseName: Option[String],
     tableName: String,
     columns: List[String])
 
-class AlterTableProcessor(
+class AlterTableColumnSchemaGenerator(
     alterTableModel: AlterTableAddColumnsModel,
     dbName: String,
     tableInfo: TableInfo,
@@ -253,12 +253,6 @@ class AlterTableProcessor(
         }
       }
     }
-    // generate dictionary files for the newly added columns
-    new AlterTableAddColumnRDD(sc,
-      newCols,
-      alterTableModel,
-      tableIdentifier,
-      storePath).collect()
     tableSchema.setListOfColumns(allColumns.asJava)
     tableInfo.setLastUpdatedTime(System.currentTimeMillis())
     tableInfo.setFactTable(tableSchema)


### PR DESCRIPTION
1. Earlier column schema and dictionary were being generated in the same method and thus if the dictionary generation failed then the column schemas could not be reverted back to the inital state.
Now the schema generation and dictionary generation are done seperately and if dictionary generation fails then the schema is reverted
2. Refactored code
3. moved lock acquire code in try block with release mechanism in case of failure.
4. Added test case