### PR TITLE
[CARBONDATA-892] Fixed NullPointerException for 2nd level subquery

### DIFF
--- a/integration/spark-common-test/src/test/resources/temp/data1.csv
+++ b/integration/spark-common-test/src/test/resources/temp/data1.csv
@@ -1,0 +1,4 @@
+id,name,rating
+1,xyz,5
+2,ghj,2
+3,ghj,3

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -60,7 +60,11 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
     if (relations.nonEmpty && !isOptimized(plan)) {
       // In case scalar subquery skip the transformation and update the flag.
       if (relations.exists(_.carbonRelation.isSubquery.nonEmpty)) {
-        relations.foreach(p => p.carbonRelation.isSubquery.remove(0))
+        relations.foreach{carbonDecoderRelation =>
+          if (carbonDecoderRelation.carbonRelation.isSubquery.nonEmpty) {
+            carbonDecoderRelation.carbonRelation.isSubquery.remove(0)
+          }
+        }
         LOGGER.info("Skip CarbonOptimizer for scalar/predicate sub query")
         return plan
       }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/query/SubQueryTestSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/query/SubQueryTestSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.carbondata.query
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class SubQueryTestSuite extends QueryTest with BeforeAndAfterAll {
+
+  val tempDirPath = s"$resourcesPath/temp"
+
+  override def beforeAll(){
+    sql("drop table if exists subquery")
+    sql("create table subquery(id int, name string, rating float) stored by 'carbondata'")
+    sql(s"load data local inpath '$tempDirPath/data1.csv' into table subquery")
+  }
+
+  test("test to check if 2nd level subquery gives correct result") {
+    checkAnswer(sql(
+      "select * from subquery where id in(select id from subquery where name in(select name from" +
+      " subquery where rating=2.0))"),
+      Seq(Row(2,"ghj",2.0), Row(3,"ghj",3.0)))
+  }
+
+  override def afterAll() {
+    sql("drop table if exists subquery")
+  }
+}


### PR DESCRIPTION
Analysis: For every scalar or predicate query we keep an entry into the isSubquery array.
and delete an element from the array for every relation
When a 2nd level subquery is executed the number of relations were 3 and the isSubquery array had 2 elements. So for the third relation ArrayIndexOutOfBoundsException was thrown.

Solution:- Check for array being nonEmpty before removing the element.