### PR TITLE
[CARBONDATA-900] Is null query on a newly added measure column is not returning proper results

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -1447,10 +1447,12 @@ public final class FilterUtil {
       bitSet.set(0, numberOfRows, defaultValue);
       bitSetGroup.setBitSet(bitSet, i);
     }
-    // create and fill bitset for the last page
-    BitSet bitSet = new BitSet(rowCountForLastPage);
-    bitSet.set(0, rowCountForLastPage, defaultValue);
-    bitSetGroup.setBitSet(bitSet, pagesTobeFullFilled);
+    // create and fill bitset for the last page if any records are left
+    if (rowCountForLastPage > 0) {
+      BitSet bitSet = new BitSet(rowCountForLastPage);
+      bitSet.set(0, rowCountForLastPage, defaultValue);
+      bitSetGroup.setBitSet(bitSet, pagesTobeFullFilled);
+    }
     return bitSetGroup;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -167,6 +167,10 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
             blockChunkHolder.getDimensionRawDataChunk()[dimensionBlocksIndex[0]].getPagesCount();
         numberOfRows =
             blockChunkHolder.getDimensionRawDataChunk()[dimensionBlocksIndex[0]].getRowCount();
+      } else {
+        // specific for restructure case where default values need to be filled
+        pageNumbers = blockChunkHolder.getDataBlock().numberOfPages();
+        numberOfRows = new int[] { blockChunkHolder.getDataBlock().nodeSize() };
       }
     }
     if (msrColEvalutorInfoList.size() > 0) {
@@ -175,6 +179,10 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
             blockChunkHolder.getMeasureRawDataChunk()[measureBlocksIndex[0]].getPagesCount();
         numberOfRows =
             blockChunkHolder.getMeasureRawDataChunk()[measureBlocksIndex[0]].getRowCount();
+      } else {
+        // specific for restructure case where default values need to be filled
+        pageNumbers = blockChunkHolder.getDataBlock().numberOfPages();
+        numberOfRows = new int[] { blockChunkHolder.getDataBlock().nodeSize() };
       }
     }
     BitSetGroup bitSetGroup = new BitSetGroup(pageNumbers);

--- a/core/src/test/java/org/apache/carbondata/core/scan/filter/FilterUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/filter/FilterUtilTest.java
@@ -38,6 +38,7 @@ import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.expression.LiteralExpression;
 import org.apache.carbondata.core.scan.expression.conditional.ListExpression;
 import org.apache.carbondata.core.scan.filter.intf.RowImpl;
+import org.apache.carbondata.core.util.BitSetGroup;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -386,5 +387,16 @@ public class FilterUtilTest extends AbstractDictionaryCacheTest {
     };
     SegmentProperties segmentProperties = new SegmentProperties(columnsInTable, columnCardinality);
     assertTrue(FilterUtil.prepareDefaultStartIndexKey(segmentProperties) instanceof IndexKey);
+  }
+
+  @Test public void testCreateBitSetGroupWithDefaultValue() {
+    // test for exactly divisible values
+    BitSetGroup bitSetGroupWithDefaultValue =
+        FilterUtil.createBitSetGroupWithDefaultValue(14, 448000, true);
+    assertTrue(bitSetGroupWithDefaultValue.getNumberOfPages() == 14);
+    // test for remainder values
+    bitSetGroupWithDefaultValue =
+        FilterUtil.createBitSetGroupWithDefaultValue(15, 448200, true);
+    assertTrue(bitSetGroupWithDefaultValue.getNumberOfPages() == 15);
   }
 }

--- a/integration/spark-common-test/src/test/resources/restructure/data6.csv
+++ b/integration/spark-common-test/src/test/resources/restructure/data6.csv
@@ -1,0 +1,3 @@
+7,hello1
+8,welcome1
+bye,11

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
@@ -187,6 +187,25 @@ class AddColumnTestCases extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select distinct(CUST_NAME) from carbon_new"),Row("testuser"))
   }
 
+  test("test for checking newly added measure column for is null condition") {
+    sql("DROP TABLE IF EXISTS carbon_measure_is_null")
+    sql("CREATE TABLE carbon_measure_is_null (CUST_ID int,CUST_NAME String) STORED BY 'carbondata'")
+    sql(
+      s"LOAD DATA INPATH '$resourcesPath/restructure/data6.csv' into table carbon_measure_is_null" +
+      s" OPTIONS" +
+      s"('BAD_RECORDS_LOGGER_ENABLE'='TRUE', " +
+      s"'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID,CUST_NAME')")
+    sql("ALTER TABLE carbon_measure_is_null ADD COLUMNS (a6 int)")
+    sql(
+      s"LOAD DATA INPATH '$resourcesPath/restructure/data6.csv' into table carbon_measure_is_null" +
+      s" OPTIONS" +
+      s"('BAD_RECORDS_LOGGER_ENABLE'='TRUE', " +
+      s"'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID,CUST_NAME,a6')")
+    checkAnswer(sql("select * from carbon_measure_is_null"),
+      sql("select * from carbon_measure_is_null where a6 is null"))
+    checkAnswer(sql("select count(*) from carbon_measure_is_null where a6 is not null"), Row(0))
+    sql("DROP TABLE IF EXISTS carbon_measure_is_null")
+  }
   test("test to check if intField returns correct result") {
     sql("DROP TABLE IF EXISTS carbon_table")
     sql("CREATE TABLE carbon_table(intField int,stringField string,charField string,timestampField timestamp, decimalField decimal(6,2)) STORED BY 'carbondata'")
@@ -229,6 +248,33 @@ class AddColumnTestCases extends QueryTest with BeforeAndAfterAll {
       "('DEFAULT.VALUE.newField'='21.87')")
     checkAnswer(sql("select distinct(newField) from carbon_table"), Row(21.87))
     sql("DROP TABLE IF EXISTS carbon_table")
+  }
+
+
+  test("test for checking newly added dictionary column for is null condition") {
+    sql("DROP TABLE IF EXISTS carbon_dictionary_is_null")
+    sql(
+      "CREATE TABLE carbon_dictionary_is_null (CUST_ID int,CUST_NAME String) STORED BY " +
+      "'carbondata'")
+    sql(
+      s"LOAD DATA INPATH '$resourcesPath/restructure/data6.csv' into table " +
+      s"carbon_dictionary_is_null" +
+      s" OPTIONS" +
+      s"('BAD_RECORDS_LOGGER_ENABLE'='TRUE', " +
+      s"'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID,CUST_NAME')")
+    sql(
+      "ALTER TABLE carbon_dictionary_is_null ADD COLUMNS (a6 int) tblproperties" +
+      "('dictionary_include'='a6')")
+    sql(
+      s"LOAD DATA INPATH '$resourcesPath/restructure/data6.csv' into table " +
+      s"carbon_dictionary_is_null" +
+      s" OPTIONS" +
+      s"('BAD_RECORDS_LOGGER_ENABLE'='TRUE', " +
+      s"'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID,CUST_NAME,a6')")
+    checkAnswer(sql("select * from carbon_dictionary_is_null"),
+      sql("select * from carbon_dictionary_is_null where a6 is null"))
+    checkAnswer(sql("select count(*) from carbon_dictionary_is_null where a6 is not null"), Row(0))
+    sql("DROP TABLE IF EXISTS carbon_dictionary_is_null")
   }
 
 


### PR DESCRIPTION
Probelme 1: When is null query is executed on newly added measure column, control goes to RowLevelFilterExecuterImpl class, where measure existence is checked. In case the measure is not found, bitset group is not getting populated with default values due to which that block is not returning any result.

Solution: When query is on a restructured block where newly added column does not exist, create the default bitset group so that based on default value existence default bitset group is created and results are returned based on that.

Problem2: While creating a default Bitset group in case of restructure array index out of bound exception is thrown.

Solution: If total number of records are exactly divisible by number of rows in each page then check for remainder > 0 to validate whether any record is left for which extra bitset need to be created.