### PR TITLE
[CARBONDATA-907] The grammar for DELETE SEGMENT FOR DATE in website is not correct

### DIFF
--- a/docs/dml-operation-on-carbondata.md
+++ b/docs/dml-operation-on-carbondata.md
@@ -290,8 +290,8 @@ This command will allow to delete the CarbonData segment(s) from the store based
 The segment created before the particular date will be removed from the specific stores.
 
 ```
-DELETE FROM TABLE [schema_name.]table_name 
-WHERE[DATE_FIELD]BEFORE [DATE_VALUE]
+DELETE SEGMENTS FROM TABLE [db_name.]table_name 
+WHERE DATE_FIELD BEFORE DATE_VALUE
 ```
 
 ### Parameter Description

--- a/docs/dml-operation-on-carbondata.md
+++ b/docs/dml-operation-on-carbondata.md
@@ -291,7 +291,7 @@ The segment created before the particular date will be removed from the specific
 
 ```
 DELETE SEGMENTS FROM TABLE [db_name.]table_name 
-WHERE DATE_FIELD BEFORE DATE_VALUE
+WHERE STARTTIME BEFORE DATE_VALUE
 ```
 
 ### Parameter Description


### PR DESCRIPTION
Problem
As I check open source CarbonData code, the grammar for DELETE SEGMENT FOR DATE in website is not correct, while the corresponding example is correct.
Solution
Update the doc for for DELETE SEGMENT FOR DATE in website.