### PR TITLE
[CARBONDATA-931] BigDecimal and VariableLength Dimension fixes

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeBigDecimalMeasureChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeBigDecimalMeasureChunkStore.java
@@ -124,11 +124,10 @@ public class UnsafeBigDecimalMeasureChunkStore extends UnsafeAbstractMeasureData
       int OffsetOfNextdata = CarbonUnsafe.unsafe.getInt(dataPageMemoryBlock.getBaseObject(),
           dataPageMemoryBlock.getBaseOffset() + this.offsetStartPosition + ((index + 1)
               * CarbonCommonConstants.INT_SIZE_IN_BYTE));
-      length =
-          (short) (OffsetOfNextdata - (currentDataOffset + CarbonCommonConstants.INT_SIZE_IN_BYTE));
+      length = OffsetOfNextdata - (currentDataOffset + CarbonCommonConstants.INT_SIZE_IN_BYTE);
     } else {
       // for last record we need to subtract with data length
-      length = (short) (this.offsetStartPosition - currentDataOffset);
+      length = (int) this.offsetStartPosition - currentDataOffset;
     }
     byte[] row = new byte[length];
     CarbonUnsafe.unsafe.copyMemory(dataPageMemoryBlock.getBaseObject(),


### PR DESCRIPTION
Problem:
a. NumberFormatException with Big decimal unsafe store
b. NegativeArraySizeException with Big decimal unsafe store
c. Cast exception with Big decimal unsafe store

Solution: 
In big decimal length is stored as int but while we are converting length to short for last record and it is causing above issue.

