### PR TITLE
[CARBONDATA-932] Fixed variable length filter query with empty data

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableLengthDimesionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableLengthDimesionDataChunkStore.java
@@ -171,7 +171,7 @@ public class UnsafeVariableLengthDimesionDataChunkStore
   /**
    * to compare the two byte array
    *
-   * @param index        index of first byte array
+   * @param index index of first byte array
    * @param compareValue value of to be compared
    * @return compare result
    */
@@ -199,20 +199,20 @@ public class UnsafeVariableLengthDimesionDataChunkStore
     }
     // as this class handles this variable length data, so filter value can be
     // smaller or bigger than than actual data, so we need to take the smaller length
-    int compareResult = 0;
-    int compareLength = length < compareValue.length ? length : compareValue.length;
+    int compareResult;
+    int compareLength = Math.min(length , compareValue.length);
     for (int i = 0; i < compareLength; i++) {
       compareResult = (CarbonUnsafe.unsafe.getByte(dataPageMemoryBlock.getBaseObject(),
           dataPageMemoryBlock.getBaseOffset() + currentDataOffset) & 0xff) - (compareValue[i]
           & 0xff);
       // if compare result is not equal we can break
       if (compareResult != 0) {
-        break;
+        return compareResult;
       }
       // increment the offset by one as comparison is done byte by byte
       currentDataOffset++;
     }
-    return compareResult;
+    return length - compareValue.length;
   }
 
 }


### PR DESCRIPTION
Problem: Variable length filter query is failing with empty data

Solution: Unsafe variable compare method is failing when record size is zero .
