### PR TITLE
[CARBONDATA-943] Added check to display error message in catch block

### DIFF
--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/exception/MalformedCarbonCommandException.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/exception/MalformedCarbonCommandException.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.spark.exception;
 
+// After parsing carbon query successfully , if any validation fails then
+// use MalformedCarbonCommandException
 public class MalformedCarbonCommandException extends Exception {
 
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -48,7 +48,16 @@ class CarbonSparkSqlParser(conf: SQLConf) extends AbstractSqlParser {
       case ce: MalformedCarbonCommandException =>
         throw ce
       case ex =>
-        astBuilder.parser.parse(sqlText)
+        try {
+          astBuilder.parser.parse(sqlText)
+        } catch {
+          case mce: MalformedCarbonCommandException =>
+            throw mce
+          case e =>
+            sys
+              .error("\n" + "BaseSqlParser>>>> " + ex.getMessage + "\n" + "CarbonSqlParser>>>> " +
+                     e.getMessage)
+        }
     }
   }
 


### PR DESCRIPTION
problem : Failing Mathematical functional in spark 2.1 is not displaying proper error message
Solution : Added check to display error message in catch block