### PR TITLE
[CARBONDATA-953] Added validations in Unsafe dataload.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -604,6 +604,31 @@ public final class CarbonProperties {
   }
 
   /**
+   * Get the sort chunk memory size
+   * @return
+   */
+  public int getSortMemoryChunkSizeInMB() {
+    int inMemoryChunkSizeInMB;
+    try {
+      inMemoryChunkSizeInMB = Integer.parseInt(CarbonProperties.getInstance()
+          .getProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB,
+              CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB_DEFAULT));
+    } catch (Exception e) {
+      inMemoryChunkSizeInMB =
+          Integer.parseInt(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB_DEFAULT);
+      LOGGER.error("Problem in parsing the sort memory chunk size, setting with default value"
+          + inMemoryChunkSizeInMB);
+    }
+    if (inMemoryChunkSizeInMB > 1024) {
+      inMemoryChunkSizeInMB = 1024;
+      LOGGER.error(
+          "It is not recommended to increase the sort memory chunk size more than 1024MB, so setting the value to "
+              + inMemoryChunkSizeInMB);
+    }
+    return inMemoryChunkSizeInMB;
+  }
+
+  /**
    * Batch size of rows while sending data from one step to another in data loading.
    *
    * @return

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -622,7 +622,14 @@ public final class CarbonProperties {
     if (inMemoryChunkSizeInMB > 1024) {
       inMemoryChunkSizeInMB = 1024;
       LOGGER.error(
-          "It is not recommended to increase the sort memory chunk size more than 1024MB, so setting the value to "
+          "It is not recommended to increase the sort memory chunk size more than 1024MB, "
+              + "so setting the value to "
+              + inMemoryChunkSizeInMB);
+    } else if (inMemoryChunkSizeInMB < 32) {
+      inMemoryChunkSizeInMB = 32;
+      LOGGER.error(
+          "It is not recommended to decrease the sort memory chunk size less than 32MB, "
+              + "so setting the value to "
               + inMemoryChunkSizeInMB);
     }
     return inMemoryChunkSizeInMB;

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -625,10 +625,10 @@ public final class CarbonProperties {
           "It is not recommended to increase the sort memory chunk size more than 1024MB, "
               + "so setting the value to "
               + inMemoryChunkSizeInMB);
-    } else if (inMemoryChunkSizeInMB < 32) {
-      inMemoryChunkSizeInMB = 32;
+    } else if (inMemoryChunkSizeInMB < 1) {
+      inMemoryChunkSizeInMB = 1;
       LOGGER.error(
-          "It is not recommended to decrease the sort memory chunk size less than 32MB, "
+          "It is not recommended to decrease the sort memory chunk size less than 1MB, "
               + "so setting the value to "
               + inMemoryChunkSizeInMB);
     }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/DictionaryDecodeReadSupport.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/DictionaryDecodeReadSupport.java
@@ -57,7 +57,7 @@ public class DictionaryDecodeReadSupport<T> implements CarbonReadSupport<T> {
     dataTypes = new DataType[carbonColumns.length];
     for (int i = 0; i < carbonColumns.length; i++) {
       if (carbonColumns[i].hasEncoding(Encoding.DICTIONARY) && !carbonColumns[i]
-          .hasEncoding(Encoding.DIRECT_DICTIONARY)) {
+          .hasEncoding(Encoding.DIRECT_DICTIONARY) && !carbonColumns[i].isComplex()) {
         CacheProvider cacheProvider = CacheProvider.getInstance();
         Cache<DictionaryColumnUniqueIdentifier, Dictionary> forwardDictionaryCache = cacheProvider
             .createCache(CacheType.FORWARD_DICTIONARY, absoluteTableIdentifier.getStorePath());

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
@@ -158,6 +158,7 @@ public class SortDataRows {
           System.arraycopy(rowBatch, 0, recordHolderListLocal, entryCount, sizeLeft);
         }
         try {
+          semaphore.acquire();
           dataSorterAndWriterExecutorService.submit(new DataSorterAndWriter(recordHolderListLocal));
         } catch (Exception e) {
           LOGGER.error(


### PR DESCRIPTION
Added validations to Unsafe dataload, now there are no validations of how much chunksize can be configured and how much working thread memory uses. Now it is configured max siz to 1GB. And also there is no control of adding data to sort threads so it may lead to out of memory.So this PR fixes it.