### PR TITLE
[CARBONDATA-957] Fixed table not found exception in rename table after lock acquire failure

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
@@ -94,6 +94,7 @@ public class HdfsFileLock extends AbstractCarbonLock {
       return true;
 
     } catch (IOException e) {
+      LOGGER.error(e, e.getMessage());
       return false;
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
@@ -124,6 +124,7 @@ public class LocalFileLock extends AbstractCarbonLock {
         return false;
       }
     } catch (IOException e) {
+      LOGGER.error(e, e.getMessage());
       return false;
     }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -830,9 +830,9 @@ object GlobalDictionaryUtil {
     val dictLock = CarbonLockFactory
       .getCarbonLockObj(carbonTablePath.getRelativeDictionaryDirectory,
         columnSchema.getColumnUniqueId + LockUsage.LOCK)
-
-    val isDictionaryLocked = dictLock.lockWithRetries()
+    var isDictionaryLocked = false
     try {
+      isDictionaryLocked = dictLock.lockWithRetries()
       if (isDictionaryLocked) {
         LOGGER.info(s"Successfully able to get the dictionary lock for ${
           columnSchema.getColumnName


### PR DESCRIPTION
During rename table if an exception is thrown during acquiring locks then table not exists exception was thrown while reverting the changes.
Solution: Added an additional check in the revert process and creating the carbon table manually instead of getting from relations.