### PR TITLE
[CARBONDATA-944] Fixed unwanted exception in case of Drop table through spark-sql-CLI

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -213,11 +213,12 @@ class CarbonSource extends CreatableRelationProvider with RelationProvider
       throw new MalformedCarbonCommandException("Table Name Should not have spaces ")
     }
     try {
-      CarbonEnv.get.carbonMetastore.lookupRelation(Option(dbName), tableName)(sparkSession)
-      CarbonEnv.get.carbonMetastore.storePath + s"/$dbName/$tableName"
+      CarbonEnv.getInstance(sparkSession).carbonMetastore
+        .lookupRelation(Option(dbName), tableName)(sparkSession)
+      CarbonEnv.getInstance(sparkSession).carbonMetastore.storePath + s"/$dbName/$tableName"
     } catch {
       case ex: Exception =>
-        throw new Exception(s"do not have $dbName and $tableName for carbon table", ex)
+        throw new Exception(s"Do not have $dbName and $tableName", ex)
     }
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -112,7 +112,17 @@ class CarbonSource extends CreatableRelationProvider with RelationProvider
       dataSchema: StructType): BaseRelation = {
     CarbonEnv.getInstance(sqlContext.sparkSession)
     addLateDecodeOptimization(sqlContext.sparkSession)
-    val path = createTableIfNotExists(sqlContext.sparkSession, parameters, dataSchema)
+    val dbName: String = parameters.getOrElse("dbName",
+      CarbonCommonConstants.DATABASE_DEFAULT_NAME).toLowerCase
+    val tableName: String = parameters.getOrElse("tableName", "default_table").toLowerCase
+
+    val path = if (sqlContext.sparkSession.sessionState.catalog.listTables(dbName)
+      .exists(_.table.equalsIgnoreCase(tableName))) {
+        getPathForTable(sqlContext.sparkSession, dbName, tableName)
+    } else {
+        createTableIfNotExists(sqlContext.sparkSession, parameters, dataSchema)
+    }
+
     CarbonDatasourceHadoopRelation(sqlContext.sparkSession, Array(path), parameters,
       Option(dataSchema))
   }
@@ -183,6 +193,31 @@ class CarbonSource extends CreatableRelationProvider with RelationProvider
         CarbonEnv.getInstance(sparkSession).carbonMetastore.storePath + s"/$dbName/$tableName"
       case ex: Exception =>
         throw new Exception("do not have dbname and tablename for carbon table", ex)
+    }
+  }
+
+  /**
+   * Returns the path of the table
+   * @param sparkSession
+   * @param dbName
+   * @param tableName
+   * @return
+   */
+  private def getPathForTable(sparkSession: SparkSession, dbName: String,
+      tableName : String): String = {
+
+    if (StringUtils.isBlank(tableName)) {
+      throw new MalformedCarbonCommandException("The Specified Table Name is Blank")
+    }
+    if (tableName.contains(" ")) {
+      throw new MalformedCarbonCommandException("Table Name Should not have spaces ")
+    }
+    try {
+      CarbonEnv.get.carbonMetastore.lookupRelation(Option(dbName), tableName)(sparkSession)
+      CarbonEnv.get.carbonMetastore.storePath + s"/$dbName/$tableName"
+    } catch {
+      case ex: Exception =>
+        throw new Exception(s"do not have $dbName and $tableName for carbon table", ex)
     }
   }
 


### PR DESCRIPTION
This PR includes a fix for Table Already Exists exception in case of Drop Table command.

Build verification with spark-1.6 successful
Build with spark-2.1 successful
Verified The defect Manually

                 
---
