### PR TITLE
[CARBONDATA-960] Fix Unsafe merge sort issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1081,7 +1081,7 @@ public final class CarbonCommonConstants {
 
   public static final String ENABLE_INMEMORY_MERGE_SORT = "enable.inmemory.merge.sort";
 
-  public static final String ENABLE_INMEMORY_MERGE_SORT_DEFAULT = "true";
+  public static final String ENABLE_INMEMORY_MERGE_SORT_DEFAULT = "false";
 
   public static final String OFFHEAP_SORT_CHUNK_SIZE_IN_MB = "offheap.sort.chunk.size.inmb";
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/comparator/UnsafeRowComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/comparator/UnsafeRowComparator.java
@@ -50,20 +50,23 @@ public class UnsafeRowComparator implements Comparator<UnsafeCarbonRow> {
     for (boolean isNoDictionary : noDictionaryColMaping) {
       if (isNoDictionary) {
         short aShort1 = CarbonUnsafe.unsafe.getShort(baseObject, rowA + sizeA);
+        byte[] byteArr1 = new byte[aShort1];
         sizeA += 2;
+        CarbonUnsafe.unsafe.copyMemory(baseObject, rowA + sizeA, byteArr1,
+            CarbonUnsafe.BYTE_ARRAY_OFFSET, aShort1);
+        sizeA += aShort1;
 
         short aShort2 = CarbonUnsafe.unsafe.getShort(baseObject, rowB + sizeB);
+        byte[] byteArr2 = new byte[aShort2];
         sizeB += 2;
-        int minLength = (aShort1 <= aShort2) ? aShort1 : aShort2;
-        int difference = UnsafeComparer.INSTANCE
-            .compareUnsafeTo(baseObject, baseObject, rowA + sizeA, rowB + sizeB, aShort1, aShort2,
-                minLength);
+        CarbonUnsafe.unsafe.copyMemory(baseObject, rowB + sizeB, byteArr2,
+            CarbonUnsafe.BYTE_ARRAY_OFFSET, aShort2);
+        sizeB += aShort2;
 
+        int difference = UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
         if (difference != 0) {
           return difference;
         }
-        sizeA += aShort1;
-        sizeB += aShort2;
       } else {
         int dimFieldA = CarbonUnsafe.unsafe.getInt(baseObject, rowA + sizeA);
         sizeA += 4;
@@ -92,22 +95,25 @@ public class UnsafeRowComparator implements Comparator<UnsafeCarbonRow> {
     for (boolean isNoDictionary : noDictionaryColMaping) {
       if (isNoDictionary) {
         short aShort1 = CarbonUnsafe.unsafe.getShort(baseObjectL, rowA + sizeA);
+        byte[] byteArr1 = new byte[aShort1];
         sizeA += 2;
+        CarbonUnsafe.unsafe
+            .copyMemory(baseObjectL, rowA + sizeA, byteArr1, CarbonUnsafe.BYTE_ARRAY_OFFSET,
+                aShort1);
+        sizeA += aShort1;
 
         short aShort2 = CarbonUnsafe.unsafe.getShort(baseObjectR, rowB + sizeB);
+        byte[] byteArr2 = new byte[aShort2];
         sizeB += 2;
+        CarbonUnsafe.unsafe
+            .copyMemory(baseObjectR, rowB + sizeB, byteArr2, CarbonUnsafe.BYTE_ARRAY_OFFSET,
+                aShort2);
+        sizeB += aShort2;
 
-        int minLength = (aShort1 <= aShort2) ? aShort1 : aShort2;
-
-        int difference = UnsafeComparer.INSTANCE
-            .compareUnsafeTo(baseObjectL, baseObjectR, rowA + sizeA, rowB + sizeB, aShort1, aShort2,
-                minLength);
-
+        int difference = UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
         if (difference != 0) {
           return difference;
         }
-        sizeA += aShort1;
-        sizeB += aShort2;
       } else {
         int dimFieldA = CarbonUnsafe.unsafe.getInt(baseObjectL, rowA + sizeA);
         sizeA += 4;

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/holder/UnsafeInmemoryMergeHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/holder/UnsafeInmemoryMergeHolder.java
@@ -43,6 +43,8 @@ public class UnsafeInmemoryMergeHolder implements Comparable<UnsafeInmemoryMerge
 
   private Object baseObject;
 
+  private byte index;
+
   public UnsafeInmemoryMergeHolder(UnsafeCarbonRowPage rowPage, byte index) {
     this.actualSize = rowPage.getBuffer().getActualSize();
     this.rowPage = rowPage;
@@ -50,7 +52,7 @@ public class UnsafeInmemoryMergeHolder implements Comparable<UnsafeInmemoryMerge
     this.comparator = new UnsafeRowComparator(rowPage);
     this.baseObject = rowPage.getDataBlock().getBaseObject();
     currentRow = new UnsafeCarbonRowForMerge();
-    currentRow.index = index;
+    this.index = index;
   }
 
   public boolean hasNext() {
@@ -62,7 +64,9 @@ public class UnsafeInmemoryMergeHolder implements Comparable<UnsafeInmemoryMerge
 
   public void readRow() {
     address = rowPage.getBuffer().get(counter);
+    currentRow = new UnsafeCarbonRowForMerge();
     currentRow.address = address + rowPage.getDataBlock().getBaseOffset();
+    currentRow.index = index;
     counter++;
   }
 


### PR DESCRIPTION
There is an issue in unsafe merge sort as the comparisons gone wrong when the data is compared in unsafe without getting to heap. It is fixed now. 