### PR TITLE
[CARBONDATA-969] Don't persist rdd because it is only use once

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -630,7 +630,7 @@ object GlobalDictionaryUtil {
     try {
       // read local dictionary file, and spilt (columnIndex, columnValue)
       val basicRdd = sqlContext.sparkContext.textFile(allDictionaryPath)
-        .map(x => parseRecord(x, accumulator, csvFileColumns)).persist()
+        .map(x => parseRecord(x, accumulator, csvFileColumns))
 
       // group by column index, and filter required columns
       val requireColumnsList = requireColumns.toList


### PR DESCRIPTION
In GlobalDictionaryUtil.readAllDictionaryFiles, don't persist rdd because it is only use once.

@foryou2030 Can you check it because persist is added by you?
cc @QiangCai 