### PR TITLE
[CARBONDATA-971] Select query with where condition is failing

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/AbstractScannedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/AbstractScannedResultCollector.java
@@ -107,7 +107,7 @@ public abstract class AbstractScannedResultCollector implements ScannedResultCol
                 bigDecimalMsrValue.setScale(carbonMeasure.getScale(), RoundingMode.HALF_UP);
           }
           return org.apache.spark.sql.types.Decimal
-              .apply(bigDecimalMsrValue, carbonMeasure.getPrecision(), carbonMeasure.getScale());
+              .apply(bigDecimalMsrValue);
         default:
           return dataChunk.getMeasureDataHolder().getReadableDoubleValueByIndex(index);
       }


### PR DESCRIPTION
Problem: Bigdata Select query with where condition is failing
Solution : Remove precision and scale while applying big decimal measure value