### PR TITLE
[CARBONDATA-975] remove unreasonable code

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -266,7 +266,7 @@ class AlterTableColumnSchemaGenerator(
     columnSchema.setDataType(dataType)
     columnSchema.setColumnName(colName)
     if (alterTableModel.highCardinalityDims.contains(colName)) {
-      encoders.remove(encoders.remove(Encoding.DICTIONARY))
+      encoders.remove(Encoding.DICTIONARY)
     }
     if (dataType == DataType.TIMESTAMP || dataType == DataType.DATE) {
       encoders.add(Encoding.DIRECT_DICTIONARY)
@@ -331,7 +331,7 @@ class TableNewProcessor(cm: TableModel) {
     columnSchema.setColumnName(colName)
     val highCardinalityDims = cm.highcardinalitydims.getOrElse(Seq())
     if (highCardinalityDims.contains(colName)) {
-      encoders.remove(encoders.remove(Encoding.DICTIONARY))
+      encoders.remove(Encoding.DICTIONARY)
     }
     if (dataType == DataType.TIMESTAMP || dataType == DataType.DATE) {
       encoders.add(Encoding.DIRECT_DICTIONARY)


### PR DESCRIPTION
remove the first "encoders.remove(" from the below code in carbonTableSchema.scala
encoders.remove(encoders.remove(Encoding.DICTIONARY))