### PR TITLE
[CARBONDATA-990] fix instruction error

### DIFF
--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -113,7 +113,7 @@ To get started with CarbonData : [Quick Start](quick-start-guide.md), [DDL Opera
    | spark.yarn.dist.archives | Comma-separated list of archives to be extracted into the working directory of each executor. |`$SPARK_HOME/carbonlib/carbondata.tar.gz` |
    | spark.executor.extraJavaOptions | A string of extra JVM options to pass to executors. For instance  **NOTE**: You can enter multiple values separated by space. |`-Dcarbon.properties.filepath=carbon.properties` |
    | spark.executor.extraClassPath | Extra classpath entries to prepend to the classpath of executors. **NOTE**: If SPARK_CLASSPATH is defined in spark-env.sh, then comment it and append the values in below parameter spark.driver.extraClassPath |`carbondata.tar.gz/carbonlib/*` |
-   | spark.driver.extraClassPath | Extra classpath entries to prepend to the classpath of the driver. **NOTE**: If SPARK_CLASSPATH is defined in spark-env.sh, then comment it and append the value in below parameter spark.driver.extraClassPath. |`$SPARK_HOME/carbonlib/carbonlib/*` |
+   | spark.driver.extraClassPath | Extra classpath entries to prepend to the classpath of the driver. **NOTE**: If SPARK_CLASSPATH is defined in spark-env.sh, then comment it and append the value in below parameter spark.driver.extraClassPath. |`$SPARK_HOME/carbonlib/*` |
    | spark.driver.extraJavaOptions | A string of extra JVM options to pass to the driver. For instance, GC settings or other logging. |`-Dcarbon.properties.filepath=$SPARK_HOME/conf/carbon.properties` |
 
 


### PR DESCRIPTION
Hello,

I followed the instruction on the page http://carbondata.incubator.apache.org/installation-guide.html and find an error in Installing and Configuring CarbonData on "Spark on YARN" Cluster part.

 The value of “spark.driver.extraClassPath” should be “$SPARK_HOME/carbonlib/*” rather than “$SPARK_HOME/carbonlib/carbonlib/*”.

 Thank you.