### PR TITLE
[CARBONDATA-989] decompress error while load 'gz' and 'bz2' data into table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -38,25 +38,26 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(AbstractDFSCarbonFile.class.getName());
   protected FileStatus fileStatus;
-  protected FileSystem fs;
 
   public AbstractDFSCarbonFile(String filePath) {
     filePath = filePath.replace("\\", "/");
     Path path = new Path(filePath);
+    FileSystem fs;
     try {
       fs = path.getFileSystem(FileFactory.getConfiguration());
       fileStatus = fs.getFileStatus(path);
     } catch (IOException e) {
-      LOGGER.error("Exception occured:" + e.getMessage());
+      LOGGER.error("Exception occurred:" + e.getMessage());
     }
   }
 
   public AbstractDFSCarbonFile(Path path) {
+    FileSystem fs;
     try {
       fs = path.getFileSystem(FileFactory.getConfiguration());
       fileStatus = fs.getFileStatus(path);
     } catch (IOException e) {
-      LOGGER.error("Exception occured:" + e.getMessage());
+      LOGGER.error("Exception occurred:" + e.getMessage());
     }
   }
 
@@ -66,7 +67,9 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
 
   @Override public boolean createNewFile() {
     Path path = fileStatus.getPath();
+    FileSystem fs;
     try {
+      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
       return fs.createNewFile(path);
     } catch (IOException e) {
       return false;
@@ -86,13 +89,14 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override public boolean exists() {
+    FileSystem fs;
     try {
       if (null != fileStatus) {
         fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
         return fs.exists(fileStatus.getPath());
       }
     } catch (IOException e) {
-      LOGGER.error("Exception occured:" + e.getMessage());
+      LOGGER.error("Exception occurred:" + e.getMessage());
     }
     return false;
   }
@@ -115,7 +119,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
       fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
       return fs.rename(fileStatus.getPath(), new Path(changetoName));
     } catch (IOException e) {
-      LOGGER.error("Exception occured:" + e.getMessage());
+      LOGGER.error("Exception occurred:" + e.getMessage());
       return false;
     }
   }
@@ -126,7 +130,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
       fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
       return fs.delete(fileStatus.getPath(), true);
     } catch (IOException e) {
-      LOGGER.error("Exception occured:" + e.getMessage());
+      LOGGER.error("Exception occurred:" + e.getMessage());
       return false;
     }
   }
@@ -136,7 +140,9 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override public boolean setLastModifiedTime(long timestamp) {
+    FileSystem fs;
     try {
+      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
       fs.setTimes(fileStatus.getPath(), timestamp, timestamp);
     } catch (IOException e) {
       return false;
@@ -159,7 +165,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
     String tempWriteFilePath = fileName + CarbonCommonConstants.TEMPWRITEFILEEXTENSION;
     FileFactory.FileType fileType = FileFactory.getFileType(fileName);
     try {
-      CarbonFile tempFile = null;
+      CarbonFile tempFile;
       // delete temporary file if it already exists at a given path
       if (FileFactory.isFileExist(tempWriteFilePath, fileType)) {
         tempFile = FileFactory.getCarbonFile(tempWriteFilePath, fileType);
@@ -191,7 +197,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
       tempFile.renameForce(fileName);
       fileTruncatedSuccessfully = true;
     } catch (IOException e) {
-      LOGGER.error("Exception occured while truncating the file " + e.getMessage());
+      LOGGER.error("Exception occurred while truncating the file " + e.getMessage());
     } finally {
       CarbonUtil.closeStreams(dataOutputStream, dataInputStream);
     }
@@ -203,7 +209,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
    *
    * @param fileTimeStamp time to be compared with latest timestamp of file
    * @param endOffset     file length to be compared with current length of file
-   * @return
+   * @return whether a file has been modified or not
    */
   @Override public boolean isFileModified(long fileTimeStamp, long endOffset) {
     boolean isFileModified = false;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -40,6 +40,8 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.BZip2Codec;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.io.compress.GzipCodec;
 
 public final class FileFactory {
@@ -131,11 +133,15 @@ public final class FileFactory {
         } else {
           stream = fs.open(pt, bufferSize);
         }
+        String codecName = null;
         if (gzip) {
-          GzipCodec codec = new GzipCodec();
-          stream = codec.createInputStream(stream);
+          codecName = GzipCodec.class.getName();
         } else if (bzip2) {
-          BZip2Codec codec = new BZip2Codec();
+          codecName = BZip2Codec.class.getName();
+        }
+        if (null != codecName){
+          CompressionCodecFactory ccf = new CompressionCodecFactory(configuration);
+          CompressionCodec codec = ccf.getCodecByClassName(codecName);
           stream = codec.createInputStream(stream);
         }
         break;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -139,7 +139,7 @@ public final class FileFactory {
         } else if (bzip2) {
           codecName = BZip2Codec.class.getName();
         }
-        if (null != codecName){
+        if (null != codecName) {
           CompressionCodecFactory ccf = new CompressionCodecFactory(configuration);
           CompressionCodec codec = ccf.getCodecByClassName(codecName);
           stream = codec.createInputStream(stream);

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGeneratorTest.java
@@ -150,8 +150,6 @@ public class IncrementalColumnDictionaryGeneratorTest {
     // Create the generator and add the keys to dictionary
     IncrementalColumnDictionaryGenerator generator =
         new IncrementalColumnDictionaryGenerator(carbonDimension, 10);
-    Integer generatedKey = generator.generateKey("First");
-    Integer obtainedKey = generator.getOrGenerateKey("First");
 
     // Create a table schema for saving the dictionary
     TableSchema tableSchema = new TableSchema();

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGeneratorTest.java
@@ -178,7 +178,6 @@ public class ServerDictionaryGeneratorTest {
     firstKey.setColumnName(empColumnSchema.getColumnName());
     firstKey.setData("FirstKey");
     serverDictionaryGenerator.initializeGeneratorForTable(firstKey);
-    Integer value = serverDictionaryGenerator.generateKey(firstKey);
 
     //Update generator with a new dimension
 

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -113,7 +113,7 @@ To get started with CarbonData : [Quick Start](quick-start-guide.md), [DDL Opera
    | spark.yarn.dist.archives | Comma-separated list of archives to be extracted into the working directory of each executor. |`$SPARK_HOME/carbonlib/carbondata.tar.gz` |
    | spark.executor.extraJavaOptions | A string of extra JVM options to pass to executors. For instance  **NOTE**: You can enter multiple values separated by space. |`-Dcarbon.properties.filepath=carbon.properties` |
    | spark.executor.extraClassPath | Extra classpath entries to prepend to the classpath of executors. **NOTE**: If SPARK_CLASSPATH is defined in spark-env.sh, then comment it and append the values in below parameter spark.driver.extraClassPath |`carbondata.tar.gz/carbonlib/*` |
-   | spark.driver.extraClassPath | Extra classpath entries to prepend to the classpath of the driver. **NOTE**: If SPARK_CLASSPATH is defined in spark-env.sh, then comment it and append the value in below parameter spark.driver.extraClassPath. |`$SPARK_HOME/carbonlib/carbonlib/*` |
+   | spark.driver.extraClassPath | Extra classpath entries to prepend to the classpath of the driver. **NOTE**: If SPARK_CLASSPATH is defined in spark-env.sh, then comment it and append the value in below parameter spark.driver.extraClassPath. |`$SPARK_HOME/carbonlib/*` |
    | spark.driver.extraJavaOptions | A string of extra JVM options to pass to the driver. For instance, GC settings or other logging. |`-Dcarbon.properties.filepath=$SPARK_HOME/conf/carbon.properties` |
 
 

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/AlterTableExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/AlterTableExample.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.examples
+
+import java.io.File
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.spark.sql.SparkSession
+
+
+object AlterTableExample {
+
+  def main(args: Array[String]): Unit = {
+
+    val rootPath = new File(this.getClass.getResource("/").getPath
+                            + "../../../..").getCanonicalPath
+
+    val storeLocation = s"$rootPath/examples/spark2/target/store"
+    val warehouse = s"$rootPath/examples/spark2/target/warehouse"
+    val metastoredb = s"$rootPath/examples/spark2/target/metastore_db"
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+
+    import org.apache.spark.sql.CarbonSession._
+
+    val spark = SparkSession
+      .builder()
+      .master("local")
+      .appName("AlterTableExample")
+      .config("spark.sql.warehouse.dir", warehouse)
+      .getOrCreateCarbonSession(storeLocation, metastoredb)
+
+    spark.sparkContext.setLogLevel("WARN")
+
+    spark.sql("DROP TABLE IF EXISTS carbon_table")
+    spark.sql("DROP TABLE IF EXISTS new_carbon_table")
+
+    spark.sql(
+      s"""
+         | CREATE TABLE carbon_table(
+         |    shortField short,
+         |    intField int,
+         |    bigintField long,
+         |    doubleField double,
+         |    stringField string,
+         |    timestampField timestamp,
+         |    decimalField decimal(18,2),
+         |    dateField date,
+         |    charField char(5),
+         |    floatField float,
+         |    complexData array<string>
+         | )
+         | STORED BY 'carbondata'
+         | TBLPROPERTIES('DICTIONARY_INCLUDE'='dateField, charField')
+       """.stripMargin)
+
+    // Alter table change data type
+    spark.sql("DESCRIBE FORMATTED carbon_table").show()
+    spark.sql("ALTER TABLE carbon_table CHANGE intField intField bigint").show()
+
+    // Alter table add columns
+    spark.sql("DESCRIBE FORMATTED carbon_table").show()
+    spark.sql("ALTER TABLE carbon_table ADD COLUMNS (newField String) " +
+              "TBLPROPERTIES ('DEFAULT.VALUE.newField'='def')").show()
+
+    // Alter table drop columns
+    spark.sql("DESCRIBE FORMATTED carbon_table").show()
+    spark.sql("ALTER TABLE carbon_table DROP COLUMNS (newField)").show()
+    spark.sql("DESCRIBE FORMATTED carbon_table").show()
+
+    // Alter table rename table name
+    spark.sql("SHOW TABLES").show()
+    spark.sql("ALTER TABLE carbon_table RENAME TO new_carbon_table").show()
+    spark.sql("SHOW TABLES").show()
+
+    spark.sql("DROP TABLE IF EXISTS carbon_table")
+    spark.sql("DROP TABLE IF EXISTS new_carbon_table")
+
+  }
+}

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/AlterTableExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/AlterTableExample.scala
@@ -19,10 +19,10 @@ package org.apache.carbondata.examples
 
 import java.io.File
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.spark.sql.SparkSession
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
 
 object AlterTableExample {
 

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -266,7 +266,6 @@ public class StoreCreator {
     tableInfo.setLastUpdatedTime(System.currentTimeMillis());
     tableInfo.setFactTable(tableSchema);
     tableInfo.setAggregateTableList(new ArrayList<TableSchema>());
-
     CarbonTablePath carbonTablePath = CarbonStorePath
         .getCarbonTablePath(absoluteTableIdentifier.getStorePath(),
             absoluteTableIdentifier.getCarbonTableIdentifier());

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
@@ -83,13 +83,12 @@ class NO_DICTIONARY_COL_TestCase extends QueryTest with BeforeAndAfterAll {
       s"LOAD DATA LOCAL INPATH '$resourcesPath/data2.csv' INTO TABLE filtertestTable OPTIONS"+
         s"('DELIMITER'= ',', " +
         s"'FILEHEADER'= '')"
-    );
+    )
 
   }
 
   test("Count (*) with filter") {
-    // sql("select * from NO_DICTIONARY_CARBON_6 where empno != '16'").show()
-    sql("select * from NO_DICTIONARY_CARBON_6 where empno > '11' and empno <= '30'").show()
+    sql("select * from NO_DICTIONARY_CARBON_6 where empno > '11' and empno <= '30'")
     checkAnswer(
       sql("select count(*) from NO_DICTIONARY_CARBON_6 where empno='11'"),
       Seq(Row(1))

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/RangeFilterTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/RangeFilterTestCase.scala
@@ -136,8 +136,6 @@ class RangeFilterTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Range filter No Dictionary 1") {
-    sql("select * from NO_DICTIONARY_CARBON_6").show()
-    sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno > '11' and empno < '15'").show()
     checkAnswer(
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno > '11' and empno < '15'"),
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_HIVE_6 where empno > '11' and empno < '15'")
@@ -198,7 +196,6 @@ class RangeFilterTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Range filter No Dictionary outside Boundary 5") {
-    sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno < '11' and empno > '20'").show()
     checkAnswer(
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno < '11' and empno > '20'"),
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_HIVE_6 where empno < '11' and empno > '20'")
@@ -249,7 +246,6 @@ class RangeFilterTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Range filter No Dictionary Inside Boundary 12") {
-    sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno >= '11' and empno > '12' and empno <= '20' and empno <= '15'").show()
     checkAnswer(
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno >= '11' and empno > '12' and empno <= '20' and empno <= '15'"),
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_HIVE_6 where empno >= '11' and empno > '12' and empno <= '20'  and empno <= '15'")
@@ -271,7 +267,6 @@ class RangeFilterTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Range filter No Dictionary Inside Boundary 15") {
-    sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno >= '11' or empno > '12' and empno <= '20'").show()
     checkAnswer(
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno >= '11' or empno > '12' and empno <= '20'"),
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_HIVE_6 where empno >= '11' or empno > '12' and empno <= '20'")
@@ -279,7 +274,6 @@ class RangeFilterTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Range filter No Dictionary Inside Boundary 16") {
-    sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno >= '11' and empno > '12' or empno <= '20'").show()
     checkAnswer(
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_CARBON_6 where empno >= '11' and empno > '12' or empno <= '20'"),
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_HIVE_6 where empno >= '11' and empno > '12' or empno <= '20'")
@@ -337,9 +331,6 @@ class RangeFilterTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Range filter Dictionary 1") {
-    sql("select * from DICTIONARY_CARBON_6").show()
-    // sql("select * from NO_DICTIONARY_CARBON_6 where empno != '16'").show()
-    sql("select * from DICTIONARY_CARBON_6 where empno > '11' and workgroupcategory = '1' or workgroupcategoryname = 'developer' and empno < '15'").show()
     checkAnswer(
       sql("select empno,empname,workgroupcategory from DICTIONARY_CARBON_6 where empno > '11' and empno < '15'"),
       sql("select empno,empname,workgroupcategory from NO_DICTIONARY_HIVE_6 where empno > '11' and empno < '15'")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/directdictionary/DateDataTypeDirectDictionaryWithNoDictTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/directdictionary/DateDataTypeDirectDictionaryWithNoDictTestCase.scala
@@ -62,7 +62,7 @@ class DateDataTypeDirectDictionaryWithNoDictTestCase extends QueryTest with Befo
   }
 
   test("select doj from directDictionaryTable") {
-    sql("select doj from directDictionaryTable").show()
+    sql("select doj from directDictionaryTable")
     checkAnswer(
       sql("select doj from directDictionaryTable"),
       Seq(Row(Date.valueOf("2016-03-14")),
@@ -74,7 +74,7 @@ class DateDataTypeDirectDictionaryWithNoDictTestCase extends QueryTest with Befo
 
 
   test("select doj from directDictionaryTable with equals filter") {
-    sql("select doj from directDictionaryTable where doj='2016-03-14 15:00:09'").show()
+    sql("select doj from directDictionaryTable where doj='2016-03-14 15:00:09'")
     checkAnswer(
       sql("select doj from directDictionaryTable where doj='2016-03-14'"),
       Seq(Row(Date.valueOf("2016-03-14")))
@@ -83,7 +83,7 @@ class DateDataTypeDirectDictionaryWithNoDictTestCase extends QueryTest with Befo
   }
 
   test("select doj from directDictionaryTable with greater than filter") {
-    sql("select doj from directDictionaryTable where doj>'2016-03-14 15:00:09'").show()
+    sql("select doj from directDictionaryTable where doj>'2016-03-14 15:00:09'")
     checkAnswer(
       sql("select doj from directDictionaryTable where doj>'2016-03-14 15:00:09'"),
       Seq(Row(Date.valueOf("2016-04-14")))

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -17,19 +17,15 @@
 
 package org.apache.carbondata.spark.util
 
-import java.io.File
 import java.text.SimpleDateFormat
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.command.DataTypeInfo
 import org.apache.spark.sql.types._
 
-import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.datatype.{DataType => CarbonDataType}
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn
-import org.apache.carbondata.core.util.CarbonProperties
 
 object CarbonScalaUtil {
   def convertSparkToCarbonDataType(

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -145,7 +145,7 @@ case class CreateTable(cm: TableModel) extends RunnableCommand {
 
     val tableInfo: TableInfo = TableNewProcessor(cm)
 
-    if (tableInfo.getFactTable.getListOfColumns.size <= 0) {
+    if (tableInfo.getFactTable.getListOfColumns.isEmpty) {
       sys.error("No Dimensions found. Table should have at least one dimesnion !")
     }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexTypeQuery.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexTypeQuery.scala
@@ -28,13 +28,13 @@ import org.scalatest.BeforeAndAfterAll
 class TestComplexTypeQuery extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll: Unit = {
-    sql("drop table if exists complexcarbontable").show
-    sql("drop table if exists complexhivetable").show
-    sql("drop table if exists complex_filter").show
-    sql("drop table if exists structusingstructCarbon").show
-    sql("drop table if exists structusingstructHive").show
-    sql("drop table if exists structusingarraycarbon").show
-    sql("drop table if exists structusingarrayhive").show
+    sql("drop table if exists complexcarbontable")
+    sql("drop table if exists complexhivetable")
+    sql("drop table if exists complex_filter")
+    sql("drop table if exists structusingstructCarbon")
+    sql("drop table if exists structusingstructHive")
+    sql("drop table if exists structusingarraycarbon")
+    sql("drop table if exists structusingarrayhive")
     sql(
       "create table complexcarbontable(deviceInformationId int, channelsId string, ROMSize " +
       "string, ROMName String, purchasedate string, mobile struct<imei:string, imsi:string>, MAC " +
@@ -67,7 +67,7 @@ class TestComplexTypeQuery extends QueryTest with BeforeAndAfterAll {
         "/array1.csv'  INTO TABLE complex_filter options ('DELIMITER'=',', 'QUOTECHAR'='\"', " +
         "'COMPLEX_DELIMITER_LEVEL_1'='$', 'FILEHEADER'= 'test1,test2,test3,test4,test5,test6," +
         "test7')")
-      .show()
+      ()
 
     sql(
       "create table structusingarraycarbon (MAC struct<MAC1:array<string>," +
@@ -278,12 +278,12 @@ class TestComplexTypeQuery extends QueryTest with BeforeAndAfterAll {
   }
 
   override def afterAll {
-    sql("drop table if exists complexcarbontable").show
-    sql("drop table if exists complexhivetable").show
-    sql("drop table if exists structusingstructCarbon").show
-    sql("drop table if exists structusingstructHive").show
-    sql("drop table if exists structusingarraycarbon").show
-    sql("drop table if exists structusingarrayhive").show
+    sql("drop table if exists complexcarbontable")
+    sql("drop table if exists complexhivetable")
+    sql("drop table if exists structusingstructCarbon")
+    sql("drop table if exists structusingstructHive")
+    sql("drop table if exists structusingarraycarbon")
+    sql("drop table if exists structusingarrayhive")
 
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithSingleQuotechar.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithSingleQuotechar.scala
@@ -36,7 +36,7 @@ class TestLoadDataWithSingleQuotechar extends QueryTest with BeforeAndAfterAll {
       sql(
         s"LOAD DATA LOCAL INPATH '$resourcesPath/dataWithSingleQuote.csv' INTO TABLE " +
           "carbontable OPTIONS('DELIMITER'= ',')")
-      sql("SELECT * from carbontable").show(100, false)
+      sql("SELECT * from carbontable")
       checkAnswer(
         sql("SELECT * from carbontable"),
         Seq(Row(1,"Tom"),

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
@@ -37,7 +37,7 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
     sql("create table carbontable(id int, username struct<sur_name:string," +
         "actual_name:struct<first_name:string,last_name:string>>, country string, salary double)" +
         "STORED BY 'org.apache.carbondata.format'")
-    sql("describe carbontable").show
+    sql("describe carbontable")
   }
   
   test("Test table rename operation on carbon table and on hive table") {
@@ -128,10 +128,10 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
     sql("create table carbontable(id int, username struct<sur_name:string," +
         "actual_name:struct<first_name:string,last_name:string>>, country string, salary double)" +
         "STORED BY 'org.apache.carbondata.format'")
-    sql("describe formatted carbontable").show(50)
+    sql("describe formatted carbontable")
     sql("create table hivetable(id int, username struct<sur_name:string," +
         "actual_name:struct<first_name:string,last_name:string>>, country string, salary double)")
-    sql("describe formatted hivetable").show(50)
+    sql("describe formatted hivetable")
   }
 
   test("describe command carbon table for decimal scale and precision test") {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -190,7 +190,7 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
     sql("update cardinalityUpdateTest set (FirstName) = ('FirstTwentyOne') where ID = 2").show()
 
     // alter table.
-    sql("alter table cardinalityUpdateTest compact 'major'").show()
+    sql("alter table cardinalityUpdateTest compact 'major'")
 
     // Verify the new updated value in compacted segment.
     // now check the answers it should be same.

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -32,7 +32,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql("use iud_db")
   }
   test("delete data from carbon table with alias [where clause ]") {
-    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
     sql("""delete from iud_db.dest d where d.c1 = 'a'""").show
     checkAnswer(
@@ -42,7 +42,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
   }
   test("delete data from  carbon table[where clause ]") {
     sql("""drop table if exists iud_db.dest""")
-    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
     sql("""delete from dest where c2 = 2""").show
     checkAnswer(
@@ -52,7 +52,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
   }
   test("delete data from  carbon table[where IN  ]") {
     sql("""drop table if exists iud_db.dest""")
-    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
     sql("""delete from dest where c1 IN ('d', 'e')""").show
     checkAnswer(
@@ -63,7 +63,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("delete data from  carbon table[with alias No where clause]") {
     sql("""drop table if exists iud_db.dest""")
-    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
     sql("""delete from iud_db.dest a""").show
     checkAnswer(
@@ -73,7 +73,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
   }
   test("delete data from  carbon table[No alias No where clause]") {
     sql("""drop table if exists iud_db.dest""")
-    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
     sql("""delete from dest""").show()
     checkAnswer(
@@ -84,7 +84,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("delete data from  carbon table[ JOIN with another table ]") {
     sql("""drop table if exists iud_db.dest""")
-    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
     sql(""" DELETE FROM dest t1 INNER JOIN source2 t2 ON t1.c1 = t2.c11""").show(truncate = false)
     checkAnswer(
@@ -115,7 +115,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
 //  }
   test("delete data from  carbon table[where numeric condition  ]") {
     sql("""drop table if exists iud_db.dest""")
-    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud_db.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
     sql("""delete from  iud_db.dest where c2 >= 4""").show()
     checkAnswer(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/IUDCompactionTestCases.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/IUDCompactionTestCases.scala
@@ -33,8 +33,6 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql("""use iud4""")
     sql(
       """create table iud4.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-
-      .show()
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/comp1.csv' INTO table iud4.dest""")
     sql(
       """create table iud4.source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
@@ -43,7 +41,6 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/other.csv' INTO table iud4.other""")
     sql(
       """create table iud4.hdest (c1 string,c2 int,c3 string,c5 string) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n' STORED AS TEXTFILE""")
-      .show()
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/comp1.csv' INTO table iud4.hdest""")
     sql(
       """CREATE TABLE iud4.update_01(imei string,age int,task bigint,num double,level decimal(10,3),name string)STORED BY 'org.apache.carbondata.format' """)
@@ -56,20 +53,19 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
 
 
   test("test IUD Horizontal Compaction Update Alter Clean") {
-    sql("""drop database if exists iud4 cascade""").show()
+    sql("""drop database if exists iud4 cascade""")
     sql("""create database iud4""")
-    sql("""use iud4""").show()
+    sql("""use iud4""")
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
+
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""")
     sql(
       """create table source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""")
     sql(
       """update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and s.c22 < 3 or (s.c22 > 10 and s.c22 < 13) or (s.c22 > 20 and s.c22 < 23) or (s.c22 > 30 and s.c22 < 33))""")
       .show()
@@ -79,9 +75,8 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and (s.c22 > 5 and c22 < 8) or (s.c22 > 15 and s.c22 < 18 ) or (s.c22 > 25 and c22 < 28) or (s.c22 > 35 and c22 < 38))""")
       .show()
-    sql("""alter table dest2 compact 'minor'""").show()
-    sql("""clean files for table dest2""").show()
-    sql("""select c1,c2,c3,c5 from dest2 order by c2""").show(100)
+    sql("""alter table dest2 compact 'minor'""")
+    sql("""clean files for table dest2""")
     checkAnswer(
       sql("""select c1,c2,c3,c5 from dest2 order by c2"""),
       Seq(Row("a", 1, "MGM", "Disco"),
@@ -125,33 +120,31 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
         Row("i", 39, "ii", "iii"),
         Row("j", 40, "jj", "jjj"))
     )
-    sql("""drop table dest2""").show()
+    sql("""drop table dest2""")
   }
 
 
   test("test IUD Horizontal Compaction Delete") {
-    sql("""drop database if exists iud4 cascade""").show()
+    sql("""drop database if exists iud4 cascade""")
     sql("""create database iud4""")
-    sql("""use iud4""").show()
+    sql("""use iud4""")
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
-    sql("""select * from dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""")
+    sql("""select * from dest2""")
     sql(
       """create table source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""").show()
-    sql("""select * from source2""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""")
+    sql("""select * from source2""")
     sql("""delete from dest2 where (c2 < 3) or (c2 > 10 and c2 < 13) or (c2 > 20 and c2 < 23) or (c2 > 30 and c2 < 33)""").show()
-    sql("""select * from dest2 order by 2""").show()
+    sql("""select * from dest2 order by 2""")
     sql("""delete from dest2 where (c2 > 3 and c2 < 5) or (c2 > 13 and c2 < 15) or (c2 > 23 and c2 < 25) or (c2 > 33 and c2 < 35)""").show()
-    sql("""select * from dest2 order by 2""").show()
+    sql("""select * from dest2 order by 2""")
     sql("""delete from dest2 where (c2 > 5 and c2 < 8) or (c2 > 15 and c2 < 18 ) or (c2 > 25 and c2 < 28) or (c2 > 35 and c2 < 38)""").show()
-    sql("""clean files for table dest2""").show()
+    sql("""clean files for table dest2""")
     checkAnswer(
       sql("""select c1,c2,c3,c5 from dest2 order by c2"""),
       Seq(Row("c", 3, "cc", "ccc"),
@@ -175,32 +168,30 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
         Row("i", 39, "ii", "iii"),
         Row("j", 40, "jj", "jjj"))
     )
-    sql("""drop table dest2""").show()
+    sql("""drop table dest2""")
   }
 
   test("test IUD Horizontal Compaction Multiple Update Vertical Compaction and Clean") {
-    sql("""drop database if exists iud4 cascade""").show()
+    sql("""drop database if exists iud4 cascade""")
     sql("""create database iud4""")
-    sql("""use iud4""").show()
+    sql("""use iud4""")
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""")
     sql(
       """create table source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""")
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and s.c22 < 3 or (s.c22 > 10 and s.c22 < 13) or (s.c22 > 20 and s.c22 < 23) or (s.c22 > 30 and s.c22 < 33))""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c11,s.c66 from source2 s where d.c1 = s.c11 and s.c22 < 3 or (s.c22 > 10 and s.c22 < 13) or (s.c22 > 20 and s.c22 < 23) or (s.c22 > 30 and s.c22 < 33))""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and (s.c22 > 3 and s.c22 < 5) or (s.c22 > 13 and s.c22 < 15) or (s.c22 > 23 and s.c22 < 25) or (s.c22 > 33 and s.c22 < 35))""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c11,s.c66 from source2 s where d.c1 = s.c11 and (s.c22 > 3 and s.c22 < 5) or (s.c22 > 13 and s.c22 < 15) or (s.c22 > 23 and s.c22 < 25) or (s.c22 > 33 and s.c22 < 35))""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and (s.c22 > 5 and c22 < 8) or (s.c22 > 15 and s.c22 < 18 ) or (s.c22 > 25 and c22 < 28) or (s.c22 > 35 and c22 < 38))""").show()
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c11,s.c66 from source2 s where d.c1 = s.c11 and (s.c22 > 5 and c22 < 8) or (s.c22 > 15 and s.c22 < 18 ) or (s.c22 > 25 and c22 < 28) or (s.c22 > 35 and c22 < 38))""").show()
-    sql("""alter table dest2 compact 'major'""").show()
-    sql("""clean files for table dest2""").show()
+    sql("""alter table dest2 compact 'major'""")
+    sql("""clean files for table dest2""")
     checkAnswer(
       sql("""select c1,c2,c3,c5 from dest2 order by c2"""),
       Seq(Row("a", 1, "a", "10"),
@@ -244,29 +235,27 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
         Row("i", 39, "ii", "iii"),
         Row("j", 40, "jj", "jjj"))
     )
-    sql("""drop table dest2""").show()
+    sql("""drop table dest2""")
   }
 
   test("test IUD Horizontal Compaction Update Delete and Clean") {
-    sql("""drop database if exists iud4 cascade""").show()
+    sql("""drop database if exists iud4 cascade""")
     sql("""create database iud4""")
-    sql("""use iud4""").show()
+    sql("""use iud4""")
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""")
     sql(
       """create table source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source3.csv' INTO table source2""")
     sql("""update dest2 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from source2 s where d.c1 = s.c11 and s.c22 < 3 or (s.c22 > 10 and s.c22 < 13) or (s.c22 > 20 and s.c22 < 23) or (s.c22 > 30 and s.c22 < 33))""").show()
     sql("""delete from dest2 where (c2 < 2) or (c2 > 10 and c2 < 13) or (c2 > 20 and c2 < 23) or (c2 > 30 and c2 < 33)""").show()
     sql("""delete from dest2 where (c2 > 3 and c2 < 5) or (c2 > 13 and c2 < 15) or (c2 > 23 and c2 < 25) or (c2 > 33 and c2 < 35)""").show()
     sql("""delete from dest2 where (c2 > 5 and c2 < 8) or (c2 > 15 and c2 < 18 ) or (c2 > 25 and c2 < 28) or (c2 > 35 and c2 < 38)""").show()
-    sql("""clean files for table dest2""").show()
+    sql("""clean files for table dest2""")
     checkAnswer(
       sql("""select c1,c2,c3,c5 from dest2 order by c2"""),
       Seq(Row("b", 2, "RGK", "Music"),
@@ -291,17 +280,16 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
         Row("i", 39, "ii", "iii"),
         Row("j", 40, "jj", "jjj"))
     )
-    sql("""drop table dest2""").show()
+    sql("""drop table dest2""")
   }
 
   test("test IUD Horizontal Compaction Check Column Cardinality") {
-    sql("""drop database if exists iud4 cascade""").show()
+    sql("""drop database if exists iud4 cascade""")
     sql("""create database iud4""")
-    sql("""use iud4""").show()
+    sql("""use iud4""")
     sql(
       """create table T_Carbn01(Active_status String,Item_type_cd INT,Qty_day_avg INT,Qty_total INT,Sell_price BIGINT,Sell_pricep DOUBLE,Discount_price DOUBLE,Profit DECIMAL(3,2),Item_code String,Item_name String,Outlet_name String,Update_time TIMESTAMP,Create_date String)STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/T_Hive1.csv' INTO table t_carbn01 options ('BAD_RECORDS_LOGGER_ENABLE' = 'FALSE', 'BAD_RECORDS_ACTION' = 'FORCE','DELIMITER'=',', 'QUOTECHAR'='\', 'FILEHEADER'='Active_status,Item_type_cd,Qty_day_avg,Qty_total,Sell_price,Sell_pricep,Discount_price,Profit,Item_code,Item_name,Outlet_name,Update_time,Create_date')""").show()
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/T_Hive1.csv' INTO table t_carbn01 options ('BAD_RECORDS_LOGGER_ENABLE' = 'FALSE', 'BAD_RECORDS_ACTION' = 'FORCE','DELIMITER'=',', 'QUOTECHAR'='\', 'FILEHEADER'='Active_status,Item_type_cd,Qty_day_avg,Qty_total,Sell_price,Sell_pricep,Discount_price,Profit,Item_code,Item_name,Outlet_name,Update_time,Create_date')""")
     sql("""update t_carbn01 set (item_code) = ('Orange') where item_type_cd = 14""").show()
     sql("""update t_carbn01 set (item_code) = ('Banana') where item_type_cd = 2""").show()
     sql("""delete from t_carbn01 where item_code in ('RE3423ee','Orange','Banana')""").show()
@@ -314,27 +302,24 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
         Row("SE3423ee"),
         Row("SE3423ee"))
     )
-    sql("""drop table t_carbn01""").show()
+    sql("""drop table t_carbn01""")
   }
 
 
   test("test IUD Horizontal Compaction Segment Delete Test Case") {
-    sql("""drop database if exists iud4 cascade""").show()
+    sql("""drop database if exists iud4 cascade""")
     sql("""create database iud4""")
-    sql("""use iud4""").show()
+    sql("""use iud4""")
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""")
     sql(
-      """delete from dest2 where (c2 < 3) or (c2 > 10 and c2 < 13) or (c2 > 20 and c2 < 23) or (c2 > 30 and c2 < 33)""")
-
-      .show()
-    sql("""DELETE SEGMENT 0 FROM TABLE dest2""").show()
-    sql("""clean files for table dest2""").show()
+      """delete from dest2 where (c2 < 3) or (c2 > 10 and c2 < 13) or (c2 > 20 and c2 < 23) or (c2 > 30 and c2 < 33)""").show()
+    sql("""DELETE SEGMENT 0 FROM TABLE dest2""")
+    sql("""clean files for table dest2""")
     sql(
       """update dest2 set (c5) = ('8RAM size') where (c2 > 3 and c2 < 5) or (c2 > 13 and c2 < 15) or (c2 > 23 and c2 < 25) or (c2 > 33 and c2 < 35)""")
       .show()
@@ -342,27 +327,26 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
       sql("""select count(*) from dest2"""),
       Seq(Row(24))
     )
-    sql("""drop table dest2""").show()
+    sql("""drop table dest2""")
   }
 
   test("test case full table delete") {
-    sql("""drop database if exists iud4 cascade""").show()
+    sql("""drop database if exists iud4 cascade""")
     sql("""create database iud4""")
-    sql("""use iud4""").show()
+    sql("""use iud4""")
     sql(
       """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-      .show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""").show()
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""").show()
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp2.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp3.csv' INTO table dest2""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp4.csv' INTO table dest2""")
     sql("""delete from dest2 where c2 < 41""").show()
-    sql("""alter table dest2 compact 'major'""").show()
+    sql("""alter table dest2 compact 'major'""")
     checkAnswer(
       sql("""select count(*) from dest2"""),
       Seq(Row(0))
     )
-    sql("""drop table dest2""").show()
+    sql("""drop table dest2""")
   }
 
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
@@ -29,7 +29,7 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop database if exists iud cascade")
     sql("create database iud")
     sql("use iud")
-    sql("""create table iud.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud.dest (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest""")
     sql("""create table iud.source2 (c11 string,c22 int,c33 string,c55 string, c66 int) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/source2.csv' INTO table iud.source2""")
@@ -46,7 +46,7 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("test update operation with 0 rows updation.") {
     sql("""drop table iud.zerorows""").show
-    sql("""create table iud.zerorows (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""create table iud.zerorows (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.zerorows""")
     sql("""update zerorows d  set (d.c2) = (d.c2 + 1) where d.c1 = 'a'""").show()
     sql("""update zerorows d  set (d.c2) = (d.c2 + 1) where d.c1 = 'xxx'""").show()
@@ -62,7 +62,7 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("update carbon table[select from source table with where and exist]") {
       sql("""drop table iud.dest11""").show
-      sql("""create table iud.dest11 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+      sql("""create table iud.dest11 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest11""")
       sql("""update iud.dest11 d set (d.c3, d.c5 ) = (select s.c33,s.c55 from iud.source2 s where d.c1 = s.c11) where 1 = 1""").show()
       checkAnswer(
@@ -73,8 +73,8 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
    }
 
    test("update carbon table[using destination table columns with where and exist]") {
-    sql("""drop table iud.dest22""").show
-    sql("""create table iud.dest22 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""drop table iud.dest22""")
+    sql("""create table iud.dest22 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest22""")
     checkAnswer(
       sql("""select c2 from iud.dest22 where c1='a'"""),
@@ -85,24 +85,24 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
       sql("""select c2 from iud.dest22 where c1='a'"""),
       Seq(Row(2))
     )
-    sql("""drop table iud.dest22""").show
+    sql("""drop table iud.dest22""")
    }
 
    test("update carbon table without alias in set columns") {
-      sql("""drop table iud.dest33""").show
-      sql("""create table iud.dest33 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+      sql("""drop table iud.dest33""")
+      sql("""create table iud.dest33 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest33""")
       sql("""update iud.dest33 d set (c3,c5 ) = (select s.c33 ,s.c55  from iud.source2 s where d.c1 = s.c11) where d.c1 = 'a'""").show()
       checkAnswer(
         sql("""select c3,c5 from iud.dest33 where c1='a'"""),
         Seq(Row("MGM","Disco"))
       )
-      sql("""drop table iud.dest33""").show
+      sql("""drop table iud.dest33""")
   }
 
   test("update carbon table without alias in set columns with mulitple loads") {
-    sql("""drop table iud.dest33""").show
-    sql("""create table iud.dest33 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""drop table iud.dest33""")
+    sql("""create table iud.dest33 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest33""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest33""")
     sql("""update iud.dest33 d set (c3,c5 ) = (select s.c33 ,s.c55  from iud.source2 s where d.c1 = s.c11) where d.c1 = 'a'""").show()
@@ -110,151 +110,151 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
       sql("""select c3,c5 from iud.dest33 where c1='a'"""),
       Seq(Row("MGM","Disco"),Row("MGM","Disco"))
     )
-    sql("""drop table iud.dest33""").show
+    sql("""drop table iud.dest33""")
   }
 
    test("update carbon table without alias in set three columns") {
-     sql("""drop table iud.dest44""").show
-     sql("""create table iud.dest44 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest44""")
+     sql("""create table iud.dest44 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest44""")
      sql("""update iud.dest44 d set (c1,c3,c5 ) = (select s.c11, s.c33 ,s.c55  from iud.source2 s where d.c1 = s.c11) where d.c1 = 'a'""").show()
      checkAnswer(
        sql("""select c1,c3,c5 from iud.dest44 where c1='a'"""),
        Seq(Row("a","MGM","Disco"))
      )
-     sql("""drop table iud.dest44""").show
+     sql("""drop table iud.dest44""")
    }
 
    test("update carbon table[single column select from source with where and exist]") {
-      sql("""drop table iud.dest55""").show
-      sql("""create table iud.dest55 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+      sql("""drop table iud.dest55""")
+      sql("""create table iud.dest55 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
       sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest55""")
      sql("""update iud.dest55 d set (c3)  = (select s.c33 from iud.source2 s where d.c1 = s.c11) where 1 = 1""").show()
       checkAnswer(
         sql("""select c1,c3 from iud.dest55 """),
         Seq(Row("a","MGM"),Row("b","RGK"),Row("c","cc"),Row("d","dd"),Row("e","ee"))
       )
-      sql("""drop table iud.dest55""").show
+      sql("""drop table iud.dest55""")
    }
 
   test("update carbon table[single column SELECT from source with where and exist]") {
-    sql("""drop table iud.dest55""").show
-    sql("""create table iud.dest55 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""drop table iud.dest55""")
+    sql("""create table iud.dest55 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest55""")
     sql("""update iud.dest55 d set (c3)  = (SELECT s.c33 from iud.source2 s where d.c1 = s.c11) where 1 = 1""").show()
     checkAnswer(
       sql("""select c1,c3 from iud.dest55 """),
       Seq(Row("a","MGM"),Row("b","RGK"),Row("c","cc"),Row("d","dd"),Row("e","ee"))
     )
-    sql("""drop table iud.dest55""").show
+    sql("""drop table iud.dest55""")
   }
 
    test("update carbon table[using destination table columns without where clause]") {
-     sql("""drop table iud.dest66""").show
-     sql("""create table iud.dest66 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest66""")
+     sql("""create table iud.dest66 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest66""")
      sql("""update iud.dest66 d set (c2, c5 ) = (c2 + 1, concat(c5 , "z"))""").show()
      checkAnswer(
        sql("""select c2,c5 from iud.dest66 """),
        Seq(Row(2,"aaaz"),Row(3,"bbbz"),Row(4,"cccz"),Row(5,"dddz"),Row(6,"eeez"))
      )
-     sql("""drop table iud.dest66""").show
+     sql("""drop table iud.dest66""")
    }
 
    test("update carbon table[using destination table columns with where clause]") {
-       sql("""drop table iud.dest77""").show
-       sql("""create table iud.dest77 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+       sql("""drop table iud.dest77""")
+       sql("""create table iud.dest77 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
        sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest77""")
        sql("""update iud.dest77 d set (c2, c5 ) = (c2 + 1, concat(c5 , "z")) where d.c3 = 'dd'""").show()
        checkAnswer(
          sql("""select c2,c5 from iud.dest77 where c3 = 'dd'"""),
          Seq(Row(5,"dddz"))
        )
-       sql("""drop table iud.dest77""").show
+       sql("""drop table iud.dest77""")
    }
 
    test("update carbon table[using destination table( no alias) columns without where clause]") {
-     sql("""drop table iud.dest88""").show
-     sql("""create table iud.dest88 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest88""")
+     sql("""create table iud.dest88 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest88""")
      sql("""update iud.dest88  set (c2, c5 ) = (c2 + 1, concat(c5 , "y" ))""").show()
      checkAnswer(
        sql("""select c2,c5 from iud.dest88 """),
        Seq(Row(2,"aaay"),Row(3,"bbby"),Row(4,"cccy"),Row(5,"dddy"),Row(6,"eeey"))
      )
-     sql("""drop table iud.dest88""").show
+     sql("""drop table iud.dest88""")
    }
 
    test("update carbon table[using destination table columns with hard coded value ]") {
-     sql("""drop table iud.dest99""").show
-     sql("""create table iud.dest99 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest99""")
+     sql("""create table iud.dest99 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest99""")
      sql("""update iud.dest99 d set (c2, c5 ) = (c2 + 1, "xyx")""").show()
      checkAnswer(
        sql("""select c2,c5 from iud.dest99 """),
        Seq(Row(2,"xyx"),Row(3,"xyx"),Row(4,"xyx"),Row(5,"xyx"),Row(6,"xyx"))
      )
-     sql("""drop table iud.dest99""").show
+     sql("""drop table iud.dest99""")
    }
 
    test("update carbon tableusing destination table columns with hard coded value and where condition]") {
-     sql("""drop table iud.dest110""").show
-     sql("""create table iud.dest110 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest110""")
+     sql("""create table iud.dest110 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest110""")
      sql("""update iud.dest110 d set (c2, c5 ) = (c2 + 1, "xyx") where d.c1 = 'e'""").show()
      checkAnswer(
        sql("""select c2,c5 from iud.dest110 where c1 = 'e' """),
        Seq(Row(6,"xyx"))
      )
-     sql("""drop table iud.dest110""").show
+     sql("""drop table iud.dest110""")
    }
 
    test("update carbon table[using source  table columns with where and exist and no destination table condition]") {
-     sql("""drop table iud.dest120""").show
-     sql("""create table iud.dest120 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest120""")
+     sql("""create table iud.dest120 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest120""")
      sql("""update iud.dest120 d  set (c3, c5 ) = (select s.c33 ,s.c55  from iud.source2 s where d.c1 = s.c11)""").show()
      checkAnswer(
        sql("""select c3,c5 from iud.dest120 """),
        Seq(Row("MGM","Disco"),Row("RGK","Music"),Row("cc","ccc"),Row("dd","ddd"),Row("ee","eee"))
      )
-     sql("""drop table iud.dest120""").show
+     sql("""drop table iud.dest120""")
    }
 
    test("update carbon table[using destination table where and exist]") {
-     sql("""drop table iud.dest130""").show
-     sql("""create table iud.dest130 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest130""")
+     sql("""create table iud.dest130 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest130""")
      sql("""update iud.dest130 dd  set (c2, c5 ) = (c2 + 1, "xyx")  where dd.c1 = 'a'""").show()
      checkAnswer(
        sql("""select c2,c5 from iud.dest130 where c1 = 'a' """),
        Seq(Row(2,"xyx"))
      )
-     sql("""drop table iud.dest130""").show
+     sql("""drop table iud.dest130""")
    }
 
    test("update carbon table[using destination table (concat) where and exist]") {
-     sql("""drop table iud.dest140""").show
-     sql("""create table iud.dest140 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest140""")
+     sql("""create table iud.dest140 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest140""")
      sql("""update iud.dest140 d set (c2, c5 ) = (c2 + 1, concat(c5 , "z"))  where d.c1 = 'a'""").show()
      checkAnswer(
        sql("""select c2,c5 from iud.dest140 where c1 = 'a'"""),
        Seq(Row(2,"aaaz"))
      )
-     sql("""drop table iud.dest140""").show
+     sql("""drop table iud.dest140""")
    }
 
    test("update carbon table[using destination table (concat) with  where") {
-     sql("""drop table iud.dest150""").show
-     sql("""create table iud.dest150 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+     sql("""drop table iud.dest150""")
+     sql("""create table iud.dest150 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest150""")
      sql("""update iud.dest150 d set (c5) = (concat(c5 , "z"))  where d.c1 = 'b'""").show()
      checkAnswer(
        sql("""select c5 from iud.dest150 where c1 = 'b' """),
        Seq(Row("bbbz"))
      )
-     sql("""drop table iud.dest150""").show
+     sql("""drop table iud.dest150""")
    }
 
   test("update table with data for datatype mismatch with column ") {
@@ -266,45 +266,32 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
    test("update carbon table-error[more columns in source table not allowed") {
-     try {
+     val exception = intercept[Exception] {
        sql("""update iud.dest d set (c2, c5 ) = (c2 + 1, concat(c5 , "z"), "abc")""").show()
-       assert(false)
-     } catch {
-       case ex: Exception =>
-         assertResult("Number of source and destination columns are not matching")(ex.getMessage)
      }
+     assertResult("Number of source and destination columns are not matching")(exception.getMessage)
    }
+
    test("update carbon table-error[no set columns") {
-     try {
+     intercept[Exception] {
        sql("""update iud.dest d set () = ()""").show()
-       assert(false)
-     } catch {
-       case ex: org.apache.spark.sql.AnalysisException =>
-         assert(true)
      }
    }
+
    test("update carbon table-error[no set columns with updated column") {
-     try {
+     intercept[Exception] {
        sql("""update iud.dest d set  = (c1+1)""").show()
-       assert(false)
-     } catch {
-       case ex: org.apache.spark.sql.AnalysisException =>
-         assert(true)
      }
    }
    test("update carbon table-error[one set column with two updated column") {
-     try {
+     intercept[Exception] {
        sql("""update iud.dest  set c2 = (c2 + 1, concat(c5 , "z") )""").show()
-       assert(false)
-     } catch {
-       case ex: org.apache.spark.sql.AnalysisException =>
-         assert(true)
      }
    }
 
  test("""update carbon [special characters  in value- test parsing logic ]""") {
-    sql("""drop table iud.dest160""").show
-    sql("""create table iud.dest160 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""drop table iud.dest160""")
+    sql("""create table iud.dest160 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest160""")
     sql("""update iud.dest160 set(c1) = ("ab\')$*)(&^)")""").show()
     sql("""update iud.dest160 set(c1) =  ('abd$asjdh$adasj$l;sdf$*)$*)(&^')""").show()
@@ -316,70 +303,58 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql("""update iud.dest160 d set (c3,c5)      =     (select s.c33,'a\\a\\' from iud.source2 s where d.c1 = s.c11 and d.c2 = s.c22) where  d.c2 between 1 and 3""").show()
     sql("""update iud.dest160 d set (c3,c5) =(select s.c33,'a\'a\\' from iud.source2 s where d.c1 = s.c11 and d.c2 = s.c22) where  d.c2 between 1 and 3""").show()
     sql("""update iud.dest160 d set (c3,c5)=(select s.c33,'\\a\'a\"' from iud.source2 s where d.c1 = s.c11 and d.c2 = s.c22) where  d.c2 between 1 and 3""").show()
-    sql("""drop table iud.dest160""").show
+    sql("""drop table iud.dest160""")
   }
 
   test("""update carbon [sub query, between and existing in outer condition.(Customer query ) ]""") {
-    sql("""drop table iud.dest170""").show
-    sql("""create table iud.dest170 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""drop table iud.dest170""")
+    sql("""create table iud.dest170 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest170""")
     sql("""update iud.dest170 d set (c3)=(select s.c33 from iud.source2 s where d.c1 = s.c11 and d.c2 = s.c22) where  d.c2 between 1 and 3""").show()
     checkAnswer(
       sql("""select c3 from  iud.dest170 as d where d.c2 between 1 and 3"""),
       Seq(Row("MGM"), Row("RGK"), Row("cc"))
     )
-    sql("""drop table iud.dest170""").show
+    sql("""drop table iud.dest170""")
   }
 
   test("""update carbon [self join select query ]""") {
-    sql("""drop table iud.dest171""").show
-    sql("""create table iud.dest171 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""drop table iud.dest171""")
+    sql("""create table iud.dest171 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest171""")
     sql("""update iud.dest171 d set (c3)=(select concat(s.c3 , "z") from iud.dest171 s where d.c2 = s.c2)""").show
-    sql("""drop table iud.dest172""").show
-    sql("""create table iud.dest172 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""").show()
+    sql("""drop table iud.dest172""")
+    sql("""create table iud.dest172 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.dest172""")
     sql("""update iud.dest172 d set (c3)=( concat(c3 , "z"))""").show
     checkAnswer(
       sql("""select c3 from  iud.dest171"""),
       sql("""select c3 from  iud.dest172""")
     )
-    sql("""drop table iud.dest171""").show
-    sql("""drop table iud.dest172""").show
+    sql("""drop table iud.dest171""")
+    sql("""drop table iud.dest172""")
   }
 
   test("update carbon table-error[closing bracket missed") {
-    try {
+    intercept[Exception] {
       sql("""update iud.dest d set (c2) = (194""").show()
-      assert(false)
-    } catch {
-      case ex: Exception =>
-        assert(true)
     }
   }
 
   test("update carbon table-error[starting bracket missed") {
-    try {
+    intercept[Exception] {
       sql("""update iud.dest d set (c2) = 194)""").show()
-      assert(false)
-    } catch {
-      case ex: Exception =>
-        assert(true)
     }
   }
 
   test("update carbon table-error[missing starting and closing bracket") {
-    try {
+    intercept[Exception] {
       sql("""update iud.dest d set (c2) = 194""").show()
-      assert(false)
-    } catch {
-      case ex: Exception =>
-        assert(true)
     }
   }
 
   test("test create table with column name as tupleID"){
-    try {
+    intercept[Exception] {
       sql("CREATE table carbontable (empno int, tupleID String, " +
           "designation String, doj Timestamp, workgroupcategory int, " +
           "workgroupcategoryname String, deptno int, deptname String, projectcode int, " +
@@ -387,8 +362,6 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
           "utilization int,salary int) STORED BY 'org.apache.carbondata.format' " +
           "TBLPROPERTIES('DICTIONARY_INCLUDE'='empno,workgroupcategory,deptno,projectcode'," +
           "'DICTIONARY_EXCLUDE'='empname')")
-    }catch  {
-      case ex: Exception => assert(true)
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
@@ -148,7 +148,7 @@ class AutoHighCardinalityIdentifyTestCase extends QueryTest with BeforeAndAfterA
     val oldTable = relation("highcard").tableMeta.carbonTable
     sql(s"LOAD DATA LOCAL INPATH '$filePath' into table highcard")
     val newTable = relation("highcard").tableMeta.carbonTable
-    sql(s"select count(hc1) from highcard").show
+    sql(s"select count(hc1) from highcard")
 
     // check dictionary file
     checkDictFile(newTable)
@@ -160,7 +160,7 @@ class AutoHighCardinalityIdentifyTestCase extends QueryTest with BeforeAndAfterA
     val oldTable = relation("colgrp_highcard").tableMeta.carbonTable
     sql(s"LOAD DATA LOCAL INPATH '$filePath' into table colgrp_highcard")
     val newTable = relation("colgrp_highcard").tableMeta.carbonTable
-    sql(s"select hc1 from colgrp_highcard").show
+    sql(s"select hc1 from colgrp_highcard")
 
     // check dictionary file
     val tableIdentifier = new CarbonTableIdentifier(newTable.getDatabaseName,

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
@@ -120,7 +120,7 @@ class CarbonDataSourceSuite extends QueryTest with BeforeAndAfterAll {
       .mode(SaveMode.Overwrite)
       .save()
     sql(s"select city, sum(m1) from testBigData " +
-        s"where country='country12' group by city order by city").show()
+        s"where country='country12' group by city order by city")
     checkAnswer(
       sql(s"select city, sum(m1) from testBigData " +
           s"where country='country12' group by city order by city"),

--- a/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
+++ b/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
@@ -78,8 +78,6 @@ public class BlockIndexStoreTest extends TestCase {
 
   @Test public void testLoadAndGetTaskIdToSegmentsMapForSingleSegment()
       throws IOException {
-    String canonicalPath =
-        new File(this.getClass().getResource("/").getPath() + "/../../").getCanonicalPath();
     File file = getPartFile();
     TableBlockInfo info =
         new TableBlockInfo(file.getAbsolutePath(), 0, "0", new String[] { "loclhost" },

--- a/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
@@ -120,9 +120,7 @@ public class StoreCreator {
    * Create store without any restructure
    */
   public static void createCarbonStore() {
-
     try {
-
       String factFilePath = new File("../hadoop/src/test/resources/data.csv").getCanonicalPath();
       File storeDir = new File(absoluteTableIdentifier.getStorePath());
       CarbonUtil.deleteFoldersAndFiles(storeDir);
@@ -133,7 +131,6 @@ public class StoreCreator {
       writeDictionary(factFilePath, table);
       CarbonDataLoadSchema schema = new CarbonDataLoadSchema(table);
       CarbonLoadModel loadModel = new CarbonLoadModel();
-      String partitionId = "0";
       loadModel.setCarbonDataLoadSchema(schema);
       loadModel.setDatabaseName(absoluteTableIdentifier.getCarbonTableIdentifier().getDatabaseName());
       loadModel.setTableName(absoluteTableIdentifier.getCarbonTableIdentifier().getTableName());
@@ -173,7 +170,6 @@ public class StoreCreator {
     } catch (Exception e) {
       e.printStackTrace();
     }
-
   }
 
   private static CarbonTable createTable() throws IOException {
@@ -378,8 +374,6 @@ public class StoreCreator {
     CarbonProperties.getInstance().addProperty("is.compressed.keyblock", "false");
     CarbonProperties.getInstance().addProperty("carbon.leaf.node.size", "120000");
 
-    String fileNamePrefix = "";
-
     String graphPath =
         outPutLoc + File.separator + loadModel.getDatabaseName() + File.separator + tableName
             + File.separator + 0 + File.separator + 1 + File.separator + tableName + ".ktr";
@@ -417,11 +411,6 @@ public class StoreCreator {
     info.setDatabaseName(databaseName);
     info.setTableName(tableName);
 
-//    DataGraphExecuter graphExecuter = new DataGraphExecuter(dataProcessTaskStatus);
-//    graphExecuter
-//        .executeGraph(graphPath, info, loadModel.getSchema());
-    //    LoadMetadataDetails[] loadDetails =
-    //        CarbonUtil.readLoadMetadata(loadModel.schema.getCarbonTable().getMetaDataFilepath());
     writeLoadMetadata(loadModel.getCarbonDataLoadSchema(), loadModel.getTableName(), loadModel.getTableName(),
         new ArrayList<LoadMetadataDetails>());
 
@@ -444,7 +433,6 @@ public class StoreCreator {
           break;
         }
       }
-      //      Files.copy(factFile.toPath(), file.toPath(), REPLACE_EXISTING);
       factFile.renameTo(new File(segLocation + "/" + factFile.getName()));
       CarbonUtil.deleteFoldersAndFiles(folder);
     }


### PR DESCRIPTION
When decompress 'gz' and 'bz2' file through LOAD DATA command, exception occurs:
java.lang.NullPointerException
	at org.apache.hadoop.io.compress.bzip2.Bzip2Factory.isNativeBzip2Loaded(Bzip2Factory.java:54)

This is due to the fact that the decompress codec should be configured while building.
I modified the code to add configuration before building codec object and tested with my real data.
