### PR TITLE
[CARBONDATA-1004] Fixed broadcast filter join

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -75,4 +75,5 @@ case class CarbonDatasourceHadoopRelation(
     ", " + "Table name :" + carbonTable.getFactTableName + ", Schema :" + tableSchema + " ]"
   }
 
+  override def sizeInBytes: Long = carbonRelation.sizeInBytes
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -30,10 +30,13 @@ import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
 class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
 
+  var threshold: Int = _
+
   override def beforeAll {
 
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+    threshold = sqlContext.getConf("spark.sql.autoBroadcastJoinThreshold").toInt
     sqlContext.setConf("spark.sql.autoBroadcastJoinThreshold", "-1")
     sql("DROP TABLE IF EXISTS t3")
     sql("DROP TABLE IF EXISTS t4")
@@ -212,5 +215,6 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS t6")
     sql("DROP TABLE IF EXISTS t7")
     sql("DROP TABLE IF EXISTS t8")
+    sqlContext.setConf("spark.sql.autoBroadcastJoinThreshold", threshold.toString)
   }
 }


### PR DESCRIPTION
Broad cast filter join is not happening in current spark 2.1 with carbon because it hasn't override the `sizeInBytes` function in relation.