### PR TITLE
[CARBONDATA-1005] Fixed dataloading less number of rows than actual rows when data size is multiples of page size.

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
@@ -31,7 +31,7 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
 
   def buildTestData() = {
     import sqlContext.implicits._
-    df = sqlContext.sparkContext.parallelize(1 to 1000)
+    df = sqlContext.sparkContext.parallelize(1 to 32000)
       .map(x => ("a", "b", x))
       .toDF("c1", "c2", "c3")
 
@@ -62,22 +62,7 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
     buildTestData
   }
 
-  test("test loading data if the data count is multiple of page size"){
-    import sqlContext.implicits._
-    val df1 = sqlContext.sparkContext.parallelize(1 to 64000)
-      .map(x => ("a", "b", x))
-      .toDF("c1", "c2", "c3")
-    sql("drop table if exists carbon_load_match")
-    df1.write
-      .format("carbondata")
-      .option("tableName", "carbon_load_match")
-      .option("tempCSV", "false")
-      .mode(SaveMode.Overwrite)
-      .save()
-    checkAnswer(
-      sql("SELECT count(*) FROM carbon_load_match"),Seq(Row(64000)))
-    sql("drop table if exists carbon_load_match")
-  }
+
 
   test("test load dataframe with saving compressed csv files") {
     // save dataframe to carbon file
@@ -89,7 +74,7 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
       .mode(SaveMode.Overwrite)
       .save()
     checkAnswer(
-      sql("select count(*) from carbon1 where c3 > 500"), Row(500)
+      sql("select count(*) from carbon1 where c3 > 500"), Row(31500)
     )
   }
 
@@ -103,7 +88,7 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
       .mode(SaveMode.Overwrite)
       .save()
     checkAnswer(
-      sql("select count(*) from carbon2 where c3 > 500"), Row(500)
+      sql("select count(*) from carbon2 where c3 > 500"), Row(31500)
     )
   }
 
@@ -116,7 +101,7 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
       .mode(SaveMode.Overwrite)
       .save()
     checkAnswer(
-      sql("select count(*) from carbon3 where c3 > 500"), Row(500)
+      sql("select count(*) from carbon3 where c3 > 500"), Row(31500)
     )
   }
 
@@ -129,6 +114,11 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
       .save()
     checkAnswer(
       sql("SELECT decimal FROM carbon4"),Seq(Row(BigDecimal.valueOf(10000.00)),Row(BigDecimal.valueOf(1234.44))))
+  }
+
+  test("test loading data if the data count is multiple of page size"){
+    checkAnswer(
+      sql("SELECT count(*) FROM carbon2"),Seq(Row(32000)))
   }
 
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/RowConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/RowConverterImpl.java
@@ -178,7 +178,10 @@ public class RowConverterImpl implements RowConverter {
           client.shutDown();
         }
       }
-      executorService.shutdownNow();
+      if (executorService != null) {
+        executorService.shutdownNow();
+        executorService = null;
+      }
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
@@ -85,6 +85,7 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
         if (first) {
           first = false;
           localConverter = converters.get(0).createCopyForNewThread();
+          converters.add(localConverter);
         }
         return childIter.hasNext();
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -589,6 +589,9 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
   /** generate the NodeHolder from the input rows */
   private NodeHolder processDataRows(List<Object[]> dataRows)
       throws CarbonDataWriterException {
+    if (dataRows.size() == 0) {
+      return new NodeHolder();
+    }
     // to store index of the measure columns which are null
     BitSet[] nullValueIndexBitSet = getMeasureNullValueIndexBitSet(measureCount);
     // statistics for one blocklet/page
@@ -859,12 +862,10 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
   public void finish() throws CarbonDataWriterException {
     // still some data is present in stores if entryCount is more
     // than 0
-    if (this.entryCount > 0) {
-      producerExecutorServiceTaskList.add(producerExecutorService
-          .submit(new Producer(blockletDataHolder, dataRows, ++writerTaskSequenceCounter, true)));
-      blockletProcessingCount.incrementAndGet();
-      processedDataCount += entryCount;
-    }
+    producerExecutorServiceTaskList.add(producerExecutorService
+        .submit(new Producer(blockletDataHolder, dataRows, ++writerTaskSequenceCounter, true)));
+    blockletProcessingCount.incrementAndGet();
+    processedDataCount += entryCount;
     closeWriterExecutionService(producerExecutorService);
     processWriteTaskSubmitList(producerExecutorServiceTaskList);
     processingComplete = true;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v1/CarbonFactDataWriterImplV1.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v1/CarbonFactDataWriterImplV1.java
@@ -198,6 +198,9 @@ public class CarbonFactDataWriterImplV1 extends AbstractFactDataWriter<int[]> {
   }
 
   @Override public void writeBlockletData(NodeHolder holder) throws CarbonDataWriterException {
+    if (holder.getEntryCount() == 0) {
+      return;
+    }
     int indexBlockSize = 0;
     for (int i = 0; i < holder.getKeyBlockIndexLength().length; i++) {
       indexBlockSize += holder.getKeyBlockIndexLength()[i] + CarbonCommonConstants.INT_SIZE_IN_BYTE;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v2/CarbonFactDataWriterImplV2.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v2/CarbonFactDataWriterImplV2.java
@@ -65,6 +65,9 @@ public class CarbonFactDataWriterImplV2 extends CarbonFactDataWriterImplV1 {
    * @throws CarbonDataWriterException any problem in writing operation
    */
   @Override public void writeBlockletData(NodeHolder holder) throws CarbonDataWriterException {
+    if (holder.getEntryCount() == 0) {
+      return;
+    }
     // size to calculate the size of the blocklet
     int size = 0;
     // get the blocklet info object

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -324,7 +324,9 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
           isAdded = true;
           dataWriterHolder.addNodeHolder(holder);
         }
-        LOGGER.info("Number of Pages for blocklet is: " + dataWriterHolder.getSize());
+
+        LOGGER.info("Number of Pages for blocklet is: " + dataWriterHolder.getNumberOfPagesAdded()
+            + " :Rows Added: " + dataWriterHolder.getTotalRows());
         // write the data
         writeDataToFile(fileChannel);
       }
@@ -334,16 +336,12 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
     } else {
       //for last blocklet check if the last page will exceed the blocklet size then write
       // existing pages and then last page
-      if (dataWriterHolder.getSize() + holder.getHolderSize() >= blockletSize
-          && dataWriterHolder.getNodeHolder().size() > 0) {
-        LOGGER.info("Number of Pages for blocklet is: " + dataWriterHolder.getSize());
-        writeDataToFile(fileChannel);
+      if (holder.getEntryCount() > 0) {
         dataWriterHolder.addNodeHolder(holder);
-        LOGGER.info("Number of Pages for blocklet is: " + "1");
-        writeDataToFile(fileChannel);
-      } else {
-        dataWriterHolder.addNodeHolder(holder);
-        LOGGER.info("Number of Pages for blocklet is: " + dataWriterHolder.getSize());
+      }
+      if (dataWriterHolder.getNumberOfPagesAdded() > 0) {
+        LOGGER.info("Number of Pages for blocklet is: " + dataWriterHolder.getNumberOfPagesAdded()
+            + " :Rows Added: " + dataWriterHolder.getTotalRows());
         writeDataToFile(fileChannel);
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/DataWriterHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/DataWriterHolder.java
@@ -48,6 +48,14 @@ public class DataWriterHolder {
     return nodeHolder.size();
   }
 
+  public int getTotalRows() {
+    int rows = 0;
+    for (NodeHolder nh : nodeHolder) {
+      rows += nh.getEntryCount();
+    }
+    return rows;
+  }
+
   public List<NodeHolder> getNodeHolder() {
     return nodeHolder;
   }


### PR DESCRIPTION
Data load does not load all rows when data size is multiples of page size. 
The page size of data load is 32000 , so if my data size is multiples 32000 like 64000 then it cannot load all data

It is because in finish step it does not take care the pages which are already existed in memory.