### PR TITLE
[CARBONDATA-1011] Fixed cast exception for new column with date datatype

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.scan.collector.impl;
 
 import java.util.List;
 
+import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
@@ -164,7 +165,11 @@ public class RestructureBasedVectorResultCollector extends DictionaryBasedVector
   private void fillDirectDictionaryData(CarbonColumnVector vector,
       ColumnVectorInfo columnVectorInfo, Object defaultValue) {
     if (null != defaultValue) {
-      vector.putLongs(columnVectorInfo.vectorOffset, columnVectorInfo.size, (long) defaultValue);
+      if (columnVectorInfo.directDictionaryGenerator.getReturnType().equals(DataType.INT)) {
+        vector.putInts(columnVectorInfo.vectorOffset, columnVectorInfo.size, (int) defaultValue);
+      } else {
+        vector.putLongs(columnVectorInfo.vectorOffset, columnVectorInfo.size, (long) defaultValue);
+      }
     } else {
       vector.putNulls(columnVectorInfo.vectorOffset, columnVectorInfo.size);
     }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.carbondata.restructure.vectorreader
 
 import java.math.{BigDecimal, RoundingMode}
-import java.sql.Timestamp
+import java.sql.{Date, Timestamp}
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
@@ -307,6 +307,28 @@ class AddColumnTestCases extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select * from alter_decimal_filter where n3 = 1.22"),
       Row("xx", 1, new BigDecimal(1.2200).setScale(4, RoundingMode.HALF_UP)))
     sql("DROP TABLE IF EXISTS alter_decimal_filter")
+  }
+
+  test("test add column with date") {
+    sql("DROP TABLE IF EXISTS carbon_table")
+    sql("CREATE TABLE carbon_table(intField int,stringField string,charField string,timestampField timestamp, decimalField decimal(6,2)) STORED BY 'carbondata'")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data1.csv' INTO TABLE carbon_table options('FILEHEADER'='intField,stringField,charField,timestampField,decimalField')")
+    sql(
+      "Alter table carbon_table add columns(newField date) TBLPROPERTIES" +
+      "('DEFAULT.VALUE.newField'='2017-01-01')")
+    checkAnswer(sql("select distinct(newField) from carbon_table"), Row(Date.valueOf("2017-01-01")))
+    sql("DROP TABLE IF EXISTS carbon_table")
+  }
+
+  test("test add column with timestamp") {
+    sql("DROP TABLE IF EXISTS carbon_table")
+    sql("CREATE TABLE carbon_table(intField int,stringField string,charField string,timestampField timestamp, decimalField decimal(6,2)) STORED BY 'carbondata'")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data1.csv' INTO TABLE carbon_table options('FILEHEADER'='intField,stringField,charField,timestampField,decimalField')")
+    sql(
+      "Alter table carbon_table add columns(newField timestamp) TBLPROPERTIES" +
+      "('DEFAULT.VALUE.newField'='01-01-2017 00:00:00.0')")
+    checkAnswer(sql("select distinct(newField) from carbon_table"), Row(Timestamp.valueOf("2017-01-01 00:00:00.0")))
+    sql("DROP TABLE IF EXISTS carbon_table")
   }
 
   override def afterAll {


### PR DESCRIPTION
Analysis: The date column being added had default value as Integer and it was being cast to long which caused the exception.

Solution: Add a condition to check the data type and cast appropriately.