### PR TITLE
[CARBONDATA-1022] Fixed relative store path issue while update and delete

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -461,9 +461,18 @@ public final class FileFactory {
       case LOCAL:
       default:
         if (filePath != null && !filePath.isEmpty()) {
-          Path pathWithoutSchemeAndAuthority =
-              Path.getPathWithoutSchemeAndAuthority(new Path(filePath));
-          return pathWithoutSchemeAndAuthority.toString();
+          // If the store path is relative then convert to absolute path.
+          if (filePath.startsWith("./")) {
+            try {
+              return new File(filePath).getCanonicalPath();
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          } else {
+            Path pathWithoutSchemeAndAuthority =
+                Path.getPathWithoutSchemeAndAuthority(new Path(filePath));
+            return pathWithoutSchemeAndAuthority.toString();
+          }
         } else {
           return filePath;
         }


### PR DESCRIPTION
When user provides relative local path as store path then there is an issue in path formation for update/delete feature. This PR fixes it.